### PR TITLE
Fix playback volume being ignored when the speed is not 1x

### DIFF
--- a/FDK19/コード/03.サウンド/CSound.cs
+++ b/FDK19/コード/03.サウンド/CSound.cs
@@ -696,7 +696,8 @@ namespace FDK
 	            if (this.bBASSサウンドである)
 	            {
 	                var db音量 = ((value.ToDouble() / 100.0) + 1.0).Clamp(0, 1);
-	                Bass.BASS_ChannelSetAttribute(this.hBassStream, BASSAttribute.BASS_ATTRIB_VOL, (float) db音量);
+	                Bass.BASS_ChannelSetAttribute(this._hBassStream, BASSAttribute.BASS_ATTRIB_VOL, (float) db音量);
+	                Bass.BASS_ChannelSetAttribute(this._hTempoStream, BASSAttribute.BASS_ATTRIB_VOL, (float) db音量);
 	            }
 	            else if (this.bDirectSoundである)
 	            {


### PR DESCRIPTION
等倍以外の速度だと音量の設定が反映されてなかったので`TempoStream`の方にも`BASS_ATTRIB_VOL`を適用することで直しました。