### PR TITLE
Saving & Loading Dan-i Dojo exam scores to ScoreIni (File only; No visuals)

### DIFF
--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -5005,6 +5005,15 @@ namespace TJAPlayer3
                 this.TITLE = subTitle.Substring(5);
                 //tbTitle.Text = strCommandParam;
             }
+            else if (strCommandName.Equals("TITLE" + CLangManager.fetchLang().ToUpper()))
+            {
+                var subTitle = "";
+                for (int i = 0; i < strArray.Length; i++)
+                {
+                    subTitle += strArray[i];
+                }
+                this.TITLE = subTitle.Substring(7);
+            }
             if (strCommandName.Equals("SUBTITLE"))
             {
                 if (strCommandParam.StartsWith("--"))
@@ -5028,6 +5037,15 @@ namespace TJAPlayer3
                     }
                     this.SUBTITLE = subTitle.Substring(10);
                 }
+            }
+            else if (strCommandName.Equals("SUBTITLE" + CLangManager.fetchLang().ToUpper()))
+            {
+                var subTitle = "";
+                for (int i = 0; i < strArray.Length; i++)
+                {
+                    subTitle += strArray[i];
+                }
+                this.SUBTITLE = subTitle.Substring(10);
             }
             else if (strCommandName.Equals("LEVEL"))
             {

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -1314,6 +1314,9 @@ namespace TJAPlayer3
         private string[] dlmtEnter = { "\n" };
         private string[] dlmtCOURSE = { "COURSE:" };
 
+        private readonly string langTITLE = "TITLE" + CLangManager.fetchLang().ToUpper();
+        private readonly string langSUBTITLE = "SUBTITLE" + CLangManager.fetchLang().ToUpper();
+
         private int nスクロール方向 = 0;
         //2015.09.18 kairera0467
         //バタフライスライドみたいなアレをやりたいがために実装。
@@ -5005,7 +5008,7 @@ namespace TJAPlayer3
                 this.TITLE = subTitle.Substring(5);
                 //tbTitle.Text = strCommandParam;
             }
-            else if (strCommandName.Equals("TITLE" + CLangManager.fetchLang().ToUpper()))
+            else if (strCommandName.Equals(langTITLE))
             {
                 var subTitle = "";
                 for (int i = 0; i < strArray.Length; i++)
@@ -5038,7 +5041,7 @@ namespace TJAPlayer3
                     this.SUBTITLE = subTitle.Substring(10);
                 }
             }
-            else if (strCommandName.Equals("SUBTITLE" + CLangManager.fetchLang().ToUpper()))
+            else if (strCommandName.Equals(langSUBTITLE))
             {
                 var subTitle = "";
                 for (int i = 0; i < strArray.Length; i++)

--- a/TJAPlayer3/Songs/CScoreIni.cs
+++ b/TJAPlayer3/Songs/CScoreIni.cs
@@ -1191,14 +1191,22 @@ namespace TJAPlayer3
 														if (item.StartsWith("ExamResult"))
 														{
 															int a = int.Parse(item.Substring(10, item.IndexOf('_') - 10));
-															int b = int.Parse(item.Substring(item.IndexOf('_')));
-
-															if (c演奏記録.nExamResult[a] == null)
+															int b = int.Parse(item.Substring(item.IndexOf('_') + 1));
+															try
+															{
+																c演奏記録.nExamResult[a][b] = int.Parse(para);
+															}
+															catch (ArgumentOutOfRangeException) // it's terrible but it works well lol
                                                             {
 																c演奏記録.nExamResult.Insert(a, new int[CExamInfo.cMaxExam]);
-                                                            }
+																for (int c = 0; c < c演奏記録.nExamResult[a].Length; c++)
+                                                                {
+																	c演奏記録.nExamResult[a][c] = -1;
+                                                                }
+																c演奏記録.nExamResult[a][b] = int.Parse(para);
+															}
 
-															c演奏記録.nExamResult[a][b] = int.Parse(para);
+															
 														}
 														#endregion
 													}
@@ -1344,6 +1352,7 @@ namespace TJAPlayer3
 				writer.WriteLine("ScoreRank2={0}", this.stセクション[i].nスコアランク[2]);
 				writer.WriteLine("ScoreRank3={0}", this.stセクション[i].nスコアランク[3]);
 				writer.WriteLine("ScoreRank4={0}", this.stセクション[i].nスコアランク[4]);
+				// Dan Dojo exam results
 				for (int section = 0; section < stセクション[i].nExamResult.Count; ++section)
 				{
 					for (int part = 0; part < stセクション[i].nExamResult[section].Length; ++part)

--- a/TJAPlayer3/Songs/CScoreIni.cs
+++ b/TJAPlayer3/Songs/CScoreIni.cs
@@ -218,6 +218,7 @@ namespace TJAPlayer3
             public Dan_C[] Dan_C;
 			public int[] nクリア;		//0:未クリア 1:クリア 2:フルコンボ 3:ドンダフルコンボ
 			public int[] nスコアランク;  //0:未取得 1:白粋 2:銅粋 3:銀粋 4:金雅 5:桃雅 6:紫雅 7:虹極
+			public List<int[]> nExamResult; //
 
 			public C演奏記録()
 			{
@@ -294,6 +295,11 @@ namespace TJAPlayer3
 				this.nクリア = new int[5];
 				this.nスコアランク = new int[5];
                 Dan_C = new Dan_C[CExamInfo.cMaxExam];
+				this.nExamResult = new List<int[]> { };
+				//for (int i = 0; i < TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count; i++)
+    //            {
+				//	nExamResult.Add(new int[CExamInfo.cMaxExam]);
+    //            }
 			}
 
 			public bool bフルコンボじゃない
@@ -1179,6 +1185,23 @@ namespace TJAPlayer3
 													{
 														c演奏記録.nスコアランク[i] = int.Parse(para);
 													}
+													else
+                                                    {
+														#region [Dan-i Dojo Exam Results]
+														if (item.StartsWith("ExamResult"))
+														{
+															int a = int.Parse(item.Substring(10, item.IndexOf('_') - 10));
+															int b = int.Parse(item.Substring(item.IndexOf('_')));
+
+															if (c演奏記録.nExamResult[a] == null)
+                                                            {
+																c演奏記録.nExamResult.Insert(a, new int[CExamInfo.cMaxExam]);
+                                                            }
+
+															c演奏記録.nExamResult[a][b] = int.Parse(para);
+														}
+														#endregion
+													}
 												}
 											}
                                             //else if ( item.Equals( "HiScore5" ) )
@@ -1321,6 +1344,21 @@ namespace TJAPlayer3
 				writer.WriteLine("ScoreRank2={0}", this.stセクション[i].nスコアランク[2]);
 				writer.WriteLine("ScoreRank3={0}", this.stセクション[i].nスコアランク[3]);
 				writer.WriteLine("ScoreRank4={0}", this.stセクション[i].nスコアランク[4]);
+				for (int section = 0; section < stセクション[i].nExamResult.Count; ++section)
+				{
+					for (int part = 0; part < stセクション[i].nExamResult[section].Length; ++part)
+                    {
+						try
+                        {
+							if (stセクション[i].nExamResult[section][part] > -1)
+								writer.WriteLine("ExamResult{0}_{1}={2}", section, part, this.stセクション[i].nExamResult[section][part]);
+                        }
+						catch (NullReferenceException)
+                        {
+
+                        }
+                    }
+				}
 			}
 			writer.Close();
 		}

--- a/TJAPlayer3/Songs/Cスコア.cs
+++ b/TJAPlayer3/Songs/Cスコア.cs
@@ -103,6 +103,8 @@ namespace TJAPlayer3
 			public int nDanTick;
 			public Color cDanTickColor;
 
+			public List<int[]> nExamResult;
+
 			[Serializable]
 			[StructLayout( LayoutKind.Sequential )]
 			public struct STHISTORY
@@ -339,7 +341,12 @@ namespace TJAPlayer3
 				this.GPInfo[i].nClear = new int[5];
 				this.GPInfo[i].nScoreRank = new int[5];
 			}
-			
+
+			this.譜面情報.nExamResult = new List<int[]> { };
+			//for (int i = 0; i < TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count; i++)
+			//{
+			//	譜面情報.nExamResult.Add(new int[CExamInfo.cMaxExam]);
+			//}
 
 			this.譜面情報.nLife = 5;
 			this.譜面情報.nTotalFloor = 140;

--- a/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -57,10 +57,11 @@ namespace TJAPlayer3
                 for (int i = 1; i < CExamInfo.cMaxExam; i++)
                     ExamChange[i] = false;
 
-                for (int j = 1; j < CExamInfo.cMaxExam; j++)  //段位条件のループ(魂ゲージを除く) 縦(y)
+                for (int j = 0; j < CExamInfo.cMaxExam; j++)
                 {
                     if (TJAPlayer3.stage選曲.r確定された曲.DanSongs[0].Dan_C[j] != null)
                     {
+                        Challenge[j] = TJAPlayer3.stage選曲.r確定された曲.DanSongs[NowShowingNumber].Dan_C[j];
                         if (TJAPlayer3.stage選曲.r確定された曲.DanSongs[TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count - 1].Dan_C[j] != null
                             && TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count > 1) // Individual exams, not counted if dan is only a single song
                         {
@@ -73,7 +74,6 @@ namespace TJAPlayer3
                                 TJAPlayer3.stage選曲.r確定された曲.DanSongs[NowShowingNumber].Dan_C[j].Amount = 0;
                             }
 
-                            Challenge[j] = TJAPlayer3.stage選曲.r確定された曲.DanSongs[NowShowingNumber].Dan_C[j];
                             ExamChange[j] = true;
                         }
                     }

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -337,6 +337,43 @@ namespace TJAPlayer3
 							ini[0].stセクション[0].nクリア[0] = Math.Max(ini[0].stセクション[0].nクリア[0], clearValue);
 							ini[0].stセクション[0].nハイスコア[0] = Math.Max(ini[0].stセクション[0].nハイスコア[0], (int)TJAPlayer3.stage演奏ドラム画面.actScore.Get(E楽器パート.DRUMS, 0)); ;
 
+                            #region [ Update Dan Dojo individual conditions ]
+                            for (int i = 0; i < TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count; i++)
+                            {
+								if (ini[0].stセクション[0].nExamResult.Count < TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count)
+								{
+									ini[0].stセクション[0].nExamResult.Add(new int[CExamInfo.cMaxExam]);
+									for (int h = 0; h < ini[0].stセクション[0].nExamResult.Last().Length; h++)
+                                    {
+										ini[0].stセクション[0].nExamResult.Last()[h] = -1;
+                                    }
+								}
+
+								for (int j = 0; j < TJAPlayer3.stage選曲.r確定された曲.DanSongs[i].Dan_C.Length; j++)
+                                {
+									if (TJAPlayer3.stage選曲.r確定された曲.DanSongs[i].Dan_C[j] != null && TJAPlayer3.stage選曲.r確定された曲.DanSongs[i].Dan_C[j].GetEnable())
+                                    {
+										int amount = TJAPlayer3.stage選曲.r確定された曲.DanSongs[i].Dan_C[j].GetAmount();
+										int current = ini[0].stセクション[0].nExamResult[i][j];
+
+										if (ini[0].stセクション[0].nExamResult[i][j] == -1)
+                                        {
+											ini[0].stセクション[0].nExamResult[i][j] = amount;
+                                        }
+										else if (TJAPlayer3.stage選曲.r確定された曲.DanSongs[i].Dan_C[j].GetExamRange() == Exam.Range.More)
+                                        {
+											ini[0].stセクション[0].nExamResult[i][j] = (amount > current) ? amount : current;
+										}
+										else if (TJAPlayer3.stage選曲.r確定された曲.DanSongs[i].Dan_C[j].GetExamRange() == Exam.Range.Less)
+										{
+											ini[0].stセクション[0].nExamResult[i][j] = (amount < current) ? amount : current;
+										}
+
+									}
+								}
+                            }
+							#endregion
+
 							if (TJAPlayer3.ConfigIni.bScoreIniを出力する)
 								ini[0].t書き出し(str[0]);
 						}

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -337,7 +337,7 @@ namespace TJAPlayer3
 							ini[0].stセクション[0].nクリア[0] = Math.Max(ini[0].stセクション[0].nクリア[0], clearValue);
 							ini[0].stセクション[0].nハイスコア[0] = Math.Max(ini[0].stセクション[0].nハイスコア[0], (int)TJAPlayer3.stage演奏ドラム画面.actScore.Get(E楽器パート.DRUMS, 0)); ;
 
-                            #region [ Update Dan Dojo individual conditions ]
+                            #region [ Update Dan Dojo exam results ]
                             for (int i = 0; i < TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count; i++)
                             {
 								if (ini[0].stセクション[0].nExamResult.Count < TJAPlayer3.stage選曲.r確定された曲.DanSongs.Count)


### PR DESCRIPTION
Dan Dojo exam scores are now saved & loaded in `*.score#P.ini`, both global & individual.
Format goes by `ExamResult#_#=`, first `#` value representing the song number (all Global exams will only use first song), second `#` value representing `EXAM#`. Starts from 0.

ExamResult will only update when a better result is compared with the last result. Respectively, smaller numbers will be applied in Less conditions, and larger numbers will be applied in More conditions. If the result is the same or worse, the exam score will not change.

_This addition does not include visual changes to show players their exam scores._