### PR TITLE
F5 to reload chart in training mode

### DIFF
--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -1019,7 +1019,14 @@ namespace TJAPlayer3
                                                         }
                                                         else
                                                         {
-                                                            // Called here
+                                                            String tja_path = this.r現在選択中のスコア.ファイル情報.ファイルの絶対パス;
+                                                            if (!File.Exists(tja_path)) {
+                                                                this.act曲リスト.ctBarFlash.t開始(0, 2700, TJAPlayer3.Skin.SongSelect_Box_Opening_Interval, TJAPlayer3.Timer);
+                                                                CSound管理.rc演奏用タイマ.t再開();
+                                                                TJAPlayer3.Timer.t再開();
+                                                                TJAPlayer3.stage演奏ドラム画面.t演奏中止();
+                                                                break;
+                                                            }
                                                             TJAPlayer3.Skin.sound決定音.t再生する();
                                                             this.act難易度選択画面.bIsDifficltSelect = true;
                                                             this.act難易度選択画面.t選択画面初期化();

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums特訓モード.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums特訓モード.cs
@@ -268,6 +268,34 @@ namespace TJAPlayer3
 				if (TJAPlayer3.Input管理.Keyboard.bキーが押された((int)SlimDXKeys.Key.A))
 					this.t現在の位置にジャンプポイントを設定する();
 
+
+
+				if (TJAPlayer3.Input管理.Keyboard.bキーが押された((int)SlimDXKeys.Key.F5) && (TJAPlayer3.ConfigIni.bTokkunMode == true) && (this.b特訓PAUSE))
+				{
+					string path_to_song = TJAPlayer3.DTX.strファイル名の絶対パス;
+					CScoreIni ini = new CScoreIni(path_to_song + ".score.ini" );
+					TJAPlayer3.DTX = new CDTX(path_to_song, false, 1.0, ini.stファイル.BGMAdjust, 0, 0, true, TJAPlayer3.stage選曲.n確定された曲の難易度[0]);
+					
+					int nWAVcount = 1;
+					int looptime = (TJAPlayer3.ConfigIni.b垂直帰線待ちを行う) ? 3 : 1;   // VSyncWait=ON時は1frame(1/60s)あたり3つ読むようにする
+					for (int i = 0; i < looptime && nWAVcount <= TJAPlayer3.DTX.listWAV.Count; i++)
+					{
+						if (TJAPlayer3.DTX.listWAV[nWAVcount].listこのWAVを使用するチャンネル番号の集合.Count > 0)   // #28674 2012.5.8 yyagi
+						{
+							TJAPlayer3.DTX.tWAVの読み込み(TJAPlayer3.DTX.listWAV[nWAVcount]);
+						}
+						nWAVcount++;
+					}
+
+					if (nWAVcount > TJAPlayer3.DTX.listWAV.Count)
+					{
+						if (TJAPlayer3.ConfigIni.bDynamicBassMixerManagement)
+						{
+							TJAPlayer3.DTX.PlanToAddMixerChannel();
+						}
+					}
+				}
+
 				if (this.bスクロール中)
 				{
 					CSound管理.rc演奏用タイマ.n現在時刻ms = easing.EaseOut(this.ctスクロールカウンター, (int)this.nスクロール前ms, (int)this.nスクロール後ms, Easing.CalcType.Circular);

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums特訓モード.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums特訓モード.cs
@@ -275,23 +275,33 @@ namespace TJAPlayer3
 					string path_to_song = TJAPlayer3.DTX.strファイル名の絶対パス;
 					CScoreIni ini = new CScoreIni(path_to_song + ".score.ini" );
 					TJAPlayer3.DTX = new CDTX(path_to_song, false, 1.0, ini.stファイル.BGMAdjust, 0, 0, true, TJAPlayer3.stage選曲.n確定された曲の難易度[0]);
-					
+
 					int nWAVcount = 1;
 					int looptime = (TJAPlayer3.ConfigIni.b垂直帰線待ちを行う) ? 3 : 1;   // VSyncWait=ON時は1frame(1/60s)あたり3つ読むようにする
-					for (int i = 0; i < looptime && nWAVcount <= TJAPlayer3.DTX.listWAV.Count; i++)
-					{
-						if (TJAPlayer3.DTX.listWAV[nWAVcount].listこのWAVを使用するチャンネル番号の集合.Count > 0)   // #28674 2012.5.8 yyagi
-						{
-							TJAPlayer3.DTX.tWAVの読み込み(TJAPlayer3.DTX.listWAV[nWAVcount]);
-						}
-						nWAVcount++;
-					}
 
-					if (nWAVcount > TJAPlayer3.DTX.listWAV.Count)
+					if (TJAPlayer3.DTX.listWAV.Count <= 0)
 					{
-						if (TJAPlayer3.ConfigIni.bDynamicBassMixerManagement)
+						CSound管理.rc演奏用タイマ.t再開();
+						TJAPlayer3.Timer.t再開();
+						TJAPlayer3.stage演奏ドラム画面.t演奏中止();
+					}
+					else
+					{
+						for (int i = 0; i < looptime && nWAVcount <= TJAPlayer3.DTX.listWAV.Count; i++)
 						{
-							TJAPlayer3.DTX.PlanToAddMixerChannel();
+							if (TJAPlayer3.DTX.listWAV[nWAVcount].listこのWAVを使用するチャンネル番号の集合.Count > 0)   // #28674 2012.5.8 yyagi
+							{
+								TJAPlayer3.DTX.tWAVの読み込み(TJAPlayer3.DTX.listWAV[nWAVcount]);
+							}
+							nWAVcount++;
+						}
+
+						if (nWAVcount > TJAPlayer3.DTX.listWAV.Count)
+						{
+							if (TJAPlayer3.ConfigIni.bDynamicBassMixerManagement)
+							{
+								TJAPlayer3.DTX.PlanToAddMixerChannel();
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Figured I might toss this out there, just in case you guys find it helpful. It's been useful to me, so I figured what the heck, might be useful to other people. If it's not inline with your objectives, roadmap, or just plain undesirable go ahead and decline without a second-thought.

Dunno if there's been a better way of chart editing...but for me it involves this loop - every time. looking at training mode, pasting to snack tja studio, looking+matching+changing, pasting back to .tja, exiting to music select, selecting song, fast-forwarding to the changed-measure...and then finally inspecting my change. 

So I've mapped F5 to reload the chart whilst in training mode. It's only active in training mode, and you have to be paused. It doesn't interfere with the F5 bga format in "regular mode". 

On F5, the changes happen immediately, keeping the same measure on screen.  Cuts out a lot of steps as I can simply keep my position (measure) in my text editor, and F5 in training mode without losing my place. And the file is all ready for play when I disable training-mode

Looked around quite hard to ensure things were cleaned up properly, and I wasn't causing memory leaks. This is the best I came up with.

The music select song-title/artist doesn't update, but that's always been like that.

Cheers