### PR TITLE
Fix AI Gauge position & Dan Gauge Clear rect

### DIFF
--- a/TJAPlayer3/Helpers/HGaugeMethods.cs
+++ b/TJAPlayer3/Helpers/HGaugeMethods.cs
@@ -523,6 +523,11 @@ namespace TJAPlayer3
                 gauge_x = TJAPlayer3.Skin.Game_Gauge_4P[0] + (TJAPlayer3.Skin.Game_UIMove_4P[0] * player);
                 gauge_y = TJAPlayer3.Skin.Game_Gauge_4P[1] + (TJAPlayer3.Skin.Game_UIMove_4P[1] * player);
             }
+            else if (TJAPlayer3.ConfigIni.bAIBattleMode)
+            {
+                gauge_x = TJAPlayer3.Skin.Game_Gauge_X_AI;
+                gauge_y = TJAPlayer3.Skin.Game_Gauge_Y_AI;
+            }
             else
             {
                 gauge_x = TJAPlayer3.Skin.Game_Gauge_X[player];

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
@@ -290,7 +290,7 @@ namespace TJAPlayer3
                                 if (TJAPlayer3.DTX.Dan_C[i] != null && TJAPlayer3.DTX.Dan_C[i].GetExamType() == Exam.Type.Gauge && db現在のゲージ値[0] >= TJAPlayer3.DTX.Dan_C[i].GetValue(false))
                                 {
                                     TJAPlayer3.Tx.Gauge_Dan[3].Opacity = 255;
-                                    TJAPlayer3.Tx.Gauge_Dan[3]?.t2D描画(TJAPlayer3.app.Device, x + (TJAPlayer3.DTX.Dan_C[i].GetValue(false) / 2 * nWidth), y, new Rectangle(0, 0, nRectX[0] - (TJAPlayer3.DTX.Dan_C[i].GetValue(false) / 2 * nWidth), TJAPlayer3.Skin.Game_Gauge_Rect[3]));
+                                    TJAPlayer3.Tx.Gauge_Dan[3]?.t2D描画(TJAPlayer3.app.Device, x + (TJAPlayer3.DTX.Dan_C[i].GetValue(false) / 2 * nWidth), y, new Rectangle(TJAPlayer3.DTX.Dan_C[i].GetValue(false) / 2 * nWidth, 0, nRectX[0] - (TJAPlayer3.DTX.Dan_C[i].GetValue(false) / 2 * nWidth), TJAPlayer3.Skin.Game_Gauge_Rect[3]));
 
                                     int Opacity = 0;
                                     if (this.ctGaugeFlash.n現在の値 <= 365) Opacity = 0;


### PR DESCRIPTION
- Fix AI Gauge using `Game_Gauge_X`/`Game_Gauge_Y` instead of `Game_Gauge_X_AI`/`Game_Gauge_Y_AI`
- Fix Dan Gauge clear gauge using incorrect Rect X starting position