### PR TITLE
Fix Random() being assigned a fixed seed

### DIFF
--- a/OpenTaiko/src/Common/TJAPlayer3.cs
+++ b/OpenTaiko/src/Common/TJAPlayer3.cs
@@ -2933,7 +2933,7 @@ for (int i = 0; i < 3; i++) {
 			#endregion
 			#region [ Random の初期化 ]
 			//---------------------
-			Random = new Random( (int) Timer.SystemTime );
+			Random = new Random();
 			//---------------------
 			#endregion
 			#region [ Stages initialisation ]


### PR DESCRIPTION
This issue would cause randomized features like the Random Song button to always return the same results on every startup