### PR TITLE
Revert "Fix #561 (Add real-time FPS display to window bar)"

### DIFF
--- a/OpenTaiko/src/Common/TJAPlayer3.cs
+++ b/OpenTaiko/src/Common/TJAPlayer3.cs
@@ -768,7 +768,6 @@ namespace TJAPlayer3
             Timer?.Update();
             SoundManager.PlayTimer?.Update();
             FPS?.Update();
-			ShowWindowTitleWithSoundType();
 
 			if (BeatScaling != null)
 			{
@@ -2345,7 +2344,7 @@ for (int i = 0; i < 3; i++) {
 						{
 							if (r現在のステージ.eStageID != CStage.EStage.Game)
 							{
-								RefreshSkin();
+								RefleshSkin();
 								r現在のステージ.DeActivate();
 								if (!ConfigIni.PreAssetsLoading) 
 								{
@@ -3143,7 +3142,7 @@ for (int i = 0; i < 3; i++) {
 				delay = "(" + SoundManager.GetSoundDelay() + "ms)";
 			}
             AssemblyName asmApp = Assembly.GetExecutingAssembly().GetName();
-            base.Text = asmApp.Name + " Ver." + VERSION + " (" + SoundManager.GetCurrentSoundDeviceType() + delay + ") (" + ((FPS != null) ? FPS.NowFPS : "??") + " FPS)";
+            base.Text = asmApp.Name + " Ver." + VERSION + " (" + SoundManager.GetCurrentSoundDeviceType() + delay + ")";
 		}
 
 		private void t終了処理()
@@ -3591,7 +3590,7 @@ for (int i = 0; i < 3; i++) {
 			WindowSize = new Silk.NET.Maths.Vector2D<int>(nWidth, nHeight);
 		}
 
-		public void RefreshSkin()
+		public void RefleshSkin()
         {
             Trace.TraceInformation("スキン変更:" + TJAPlayer3.Skin.GetCurrentSkinSubfolderFullName(false));
 

--- a/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
@@ -1034,7 +1034,7 @@ namespace TJAPlayer3
 			#region [ Skin変更 ]
 			if ( TJAPlayer3.Skin.GetCurrentSkinSubfolderFullName( true ) != this.skinSubFolder_org )
 			{
-                TJAPlayer3.app.RefreshSkin();
+                TJAPlayer3.app.RefleshSkin();
             }
 			#endregion
 

--- a/OpenTaiko/src/Stages/10.ChangeSkin/CStageChangeSkin.cs
+++ b/OpenTaiko/src/Stages/10.ChangeSkin/CStageChangeSkin.cs
@@ -79,7 +79,7 @@ namespace TJAPlayer3
 				}
 
                 //スキン変更処理
-                TJAPlayer3.app.RefreshSkin();
+                TJAPlayer3.app.RefleshSkin();
 
                 return 1;
 			}


### PR DESCRIPTION
This current implementation will lag the Taskbar on Windows, with the amount of lag corresponding to FPS. (more FPS = worse Taskbar performance).

It would probably help if the window title is updated after a fixed amount of time instead, as it looks like it's being updated every frame.