### PR TITLE
Correction of the native name of Korean language

### DIFF
--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -6,7 +6,7 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "한국인 (WIP)",
+  "Language": "한국어 (WIP)",
   "Entries": {
 
     // Common


### PR DESCRIPTION
The third syllable of the native name of Korean language miswritten into "인" (means "person"), its correct writing is "어" (means "language").
Hereby the correction is made.
It is suggested to specify a fallback Korean font, as Koreans may occasionally use _hanja_ (characters) with their unique standard too.