### PR TITLE
BugFix/597 Remove empty line for last lyric of a song

### DIFF
--- a/OpenTaiko/src/Songs/VTTParser.cs
+++ b/OpenTaiko/src/Songs/VTTParser.cs
@@ -400,7 +400,11 @@ namespace TJAPlayer3
                     }
                 }
             }
-            if (lyricData.Count > 0) { lrclist.Add(CreateLyric(lyricData, order)); }
+            // Add last lyric to list
+            if (lyricData.Count > 0) { 
+                lyricData.RemoveAll(empty => String.IsNullOrEmpty(empty.Text));
+                lrclist.Add(CreateLyric(lyricData, order));
+            }
             lrclist.Add(CreateLyric(new List<LyricData>() { new LyricData() { timestamp = endTime + offset } }, order));
             return lrclist;
 


### PR DESCRIPTION
# Summary
- Remove any empty lines for the last lyric of a song  

## Before:  
![image](https://github.com/0auBSQ/OpenTaiko/assets/18529901/19e2c420-bd9a-43a0-a05e-aeeba219a71a)
## After:  
![image](https://github.com/0auBSQ/OpenTaiko/assets/18529901/827e7591-6c15-46e5-94bc-7c1a6a98d1d9)
