### PR TITLE
BugFix/610 Add null check to avoid crash

### DIFF
--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -326,8 +326,11 @@ namespace TJAPlayer3
 
 			tResetTitleTextureKey();
 
-
-            if (rCurrentlySelectedSong.list子リスト.Count != 1)
+			// INFO: This null check is added due to `list子リスト` might be null during rapid sorting
+			//		Despite what editor tell you here it is possible to be null
+            if (rCurrentlySelectedSong != null && 
+				rCurrentlySelectedSong.list子リスト != null && 
+				rCurrentlySelectedSong.list子リスト.Count != 1)
 			{
 				if (TJAPlayer3.ConfigIni.TJAP3FolderMode)
 				{


### PR DESCRIPTION
# Summary
- Fixes the scenario described in https://github.com/0auBSQ/OpenTaiko/issues/610
- Despite what the editor says, `list子リスト` is possible to be null there
- This is a pretty quick and dirty fix, but in OOP it's pretty hard to guarantee anything.