### PR TITLE
BugFix/654 Fix dan-i dojo sub folder exit crash

### DIFF
--- a/OpenTaiko/src/Stages/05.DaniSelect/CActSelect段位リスト.cs
+++ b/OpenTaiko/src/Stages/05.DaniSelect/CActSelect段位リスト.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using FDK;
 using Silk.NET.Maths;
 using static TJAPlayer3.CActSelect曲リスト;
@@ -381,8 +382,8 @@ namespace TJAPlayer3 {
 
 		private void tDrawDanSelectedLevel(float Anime, int modifier = 0) {
 			int scroll = TJAPlayer3.Skin.Resolution[0] * modifier;
-			int currentSong = n現在の選択行 + modifier;
-			bool over4 = false;
+			int currentSong = Math.Clamp(n現在の選択行 + modifier, 0, stバー情報.Length - 1);
+            bool over4 = false;
 
 			switch (stバー情報[currentSong].eノード種別) {
 				case CSongListNode.ENodeType.SCORE: {

--- a/OpenTaiko/src/Stages/05.DaniSelect/CStage段位選択.cs
+++ b/OpenTaiko/src/Stages/05.DaniSelect/CStage段位選択.cs
@@ -204,6 +204,7 @@ namespace TJAPlayer3 {
 
 					if (TJAPlayer3.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape) ||
 						TJAPlayer3.Pad.bPressed(EInstrumentPad.DRUMS, EPad.Cancel)) {
+                        this.段位リスト.n現在の選択行 = 0;
 						return returnTitle();
 					}
 				}


### PR DESCRIPTION
# Summary
- Issue: https://github.com/0auBSQ/OpenTaiko/issues/654
- Reset select song index back to 0 when exiting dan-i dojo
- Clamps the index range for extra security to prevent any future crashes