### PR TITLE
fix abnormal song completion animation after retrying during normal song completion animation

### DIFF
--- a/OpenTaiko/src/Stages/07.Game/CAct演奏PauseMenu.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏PauseMenu.cs
@@ -75,6 +75,7 @@ namespace TJAPlayer3 {
 
 				case (int)EOrder.Redoing:
 					if (TJAPlayer3.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan) {
+						TJAPlayer3.stage演奏ドラム画面.tResetGameplayFinishedStatus();
 						this.bやり直しを選択した = true;
 						CActSelectPopupMenu.b選択した = true;
 					} else {

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4433,6 +4433,14 @@ namespace TJAPlayer3 {
 			this.bPAUSE = false;
 		}
 
+		// Workaround for abnormal song completion animation after retrying during normal song completion animation
+		public void tResetGameplayFinishedStatus() {
+			for (int i = 0; i < 5; i++) {
+				ifp[i] = false;
+				isDeniedPlaying[i] = false;
+			}
+		}
+
 		public void t演奏やりなおし() {
 			_AIBattleState = 0;
 			_AIBattleStateBatch = new Queue<float>[] { new Queue<float>(), new Queue<float>() };


### PR DESCRIPTION
## Issue to Solve

After retrying during a normal song completion animation, an abnormal song completion animation is played immediately at the beginning of the song. The gameplay ends after the abnormal song completion animation completes.

The song will be played until the end and cannot be stopped, unless the player retries the second time during the abnormal song completion animation, which avoids the abnormality.

## About this Fix

This fix is kind of a workaround because the resetting of song completion status is now done twice, one immediate in `CAct演奏PauseMenu.tEnter押下Main()` (for `CStage演奏ドラム画面.Draw()` to detect `CStage演奏画面共通.ifp[]`) and one later in `stage演奏ドラム画面.t演奏やりなおし()`.

* add `CStage演奏画面共通.tResetGameplayFinishedStatus()` for directly resetting song completion status
* `CAct演奏PauseMenu.tEnter押下Main()`:
	* make song completion status reset as soon as the retry option is chosen

## Related Mechanics

* The abnormal animation is due to `CStage演奏画面共通 /* CStageGameplayScreenCommon */ .ifp[]` (***i**s **f**inished **p**laying* (?)) elements being all `true` when checked in `CStage演奏ドラム画面 /* CStageGameplayDrumScreen */.Draw()`.
    * After the gameplay is checked to be finished, `stage演奏ドラム画面.ePhaseID` is set to `CStage.EPhase.Game_EndStage` and then `stage演奏ドラム画面.actEnd.Start()` is called to start a timer for the song completion animation.
* Using the breakpoint test, the `ifp[]` is found to be only updated at the begin of the normal animation (into `true`) and after the abnormal animation is triggered (info `false`).
* The update-to-`true` in question is performed when `CStage演奏ドラム画面.t進行描画_チップ /* tPerformDrawing_chip */ (EInstrumentPad.DRUMS, i)` returns `true` and specifically when a `0xFF` chip (for finishing the gameplay) reaches the critical judgement timing.
* The retry is triggered by `CAct演奏PauseMenu.tEnter押下Main /* tEnterPressedMain */ ()` and then `stage演奏ドラム画面.t演奏やりなおし /* tGameplayRedo */ ()` is called by `CAct演奏PauseMenu.t進行描画sub()` after a 1.5-second timer is set and times out.
* `stage演奏ドラム画面.t演奏やりなおし()` does reset `ifp[]` to all-`false`, but it seems that the `true`-checking code is run before `t演奏やりなおし()` could reset `ifp[]` to all-`false`
