### PR TITLE
add BOM to .tja in UTF-8 but without BOM

### DIFF
--- a/OpenTaiko/Songs/01 OpenTaiko Chapter I/014 - Startup Parade!/Startup Parade!.tja
+++ b/OpenTaiko/Songs/01 OpenTaiko Chapter I/014 - Startup Parade!/Startup Parade!.tja
@@ -1,4 +1,4 @@
-TITLE:Startup Parade!
+﻿TITLE:Startup Parade!
 SUBTITLE:--Ryuto Setsujin
 TITLEJA:Startup Parade!
 SUBTITLEJA:リュトセツジン


### PR DESCRIPTION
Discovered by @‌sango9233 on Japanese OpenTaiko Discord.

`.tja`(s) in UTF-8 without BOM:

* `01 OpenTaiko Chapter I/014 - Startup Parade!/Startup Parade!.tja`

Info: Non–UTF-8 `.tja`s (in Shift-JIS instead):

* `S1 Dan-i Dojo/99. 例段/ReiDan.tja`
* `E01 Rainy Memories/RM05 - 076 - Rainy Night II ~無信の森~/Rainy Night II.tja`
* `E01 Rainy Memories/RM03 - 024 - Rainy Night ~夢幻想~/Rainy Night ~夢幻想~.tja`
* `01 OpenTaiko Chapter I/030 - 闇/Yami.tja`