### PR TITLE
DE translation and missing translation keys

### DIFF
--- a/OpenTaiko/Lang/de/lang.json
+++ b/OpenTaiko/Lang/de/lang.json
@@ -6,7 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "Deutsch (German)",
+    "Language": "Deutsch (German)",
+	"Version": "0.6.0.0",
 	"Entries": {
 
 		// Common
@@ -195,6 +196,10 @@
 		"SETTINGS_TRAINING_SKIPCOUNT_DESC": "Die Anzahl der Takte, die beim Drücken von\nVorwärts-/Rückwärts-Takt übersprungen werden\nim Trainingsmodus.",
 		"SETTINGS_TRAINING_JUMPINTERVAL": "Zeitintervall für Takt-Sprung",
 		"SETTINGS_TRAINING_JUMPINTERVAL_DESC": "Die Zeit in Millisekunden, die erforderlich ist,\num wiederholt die linken/rechten blauen Tasten zu drücken,\num zu einem markierten Takt im Trainingsmodus zu springen.",
+
+		// Settings - Gameplay - Unlockables
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES": "Freischaltung der Lieder ignorieren",
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Macht alle Lieder verfügbar, unabhängig von SongUnlockables.db3.\nDies fügt keine Freischaltungen zu Saves.db3 hinzu.\nFreischalt-Benachrichtigungen erscheinen weiterhin in den Ergebnissen.\n\n<c.#f0ad4e>WARNUNG\nDas Aktivieren dieser Option macht jeden Speedrun ungültig.</c>",
 
 		// Settings - Broken/Unused/Might Deprecate/Might Update
 		// Translate these anyways, even if their future is uncertain.
@@ -465,11 +470,11 @@
 		"HEYA_DESCRIPTION_EFFECTS_BOMBFACTOR": "Bombenfaktor: {0}% der Noten werden in Minen umgewandelt im Minensucher-Modus",
 		// {0}: Percentage of fuse rolls
 		"HEYA_DESCRIPTION_EFFECTS_FUSEFACTOR": "Zündschnurfaktor: {0}% der Ballons werden in Zündschnur-Rollen umgewandelt im Minensucher-Modus",
-		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "All big notes become <c.#c800ff>Swap</c> notes",
-		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> notes become visible",
+		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "Alle großen Noten werden zu <c.#c800ff>Swap</c>-Noten",
+		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> Noten werden sichtbar",
 		// {0}: # of auto-rolls per second
-		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatic <c.#ffff00>Rolls</c> at {0} hits/s",
-		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatische <c.#ffff00>Rolls</c> mit {0} Schlägen",
+		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Geteilte</c> <c.#0088ff>Spuren</c>",
 		// {0}: Coin multiplier
 		"HEYA_DESCRIPTION_COIN_MULTIPLIER": "Münz-Multiplikator: x{0}",
 

--- a/OpenTaiko/Lang/es/lang.json
+++ b/OpenTaiko/Lang/es/lang.json
@@ -6,7 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "Español (Spanish)",
+    "Language": "Español (Spanish)",
+	"Version":  "0.6.0.0",
 	"Entries": {
 
 		// Common
@@ -196,6 +197,10 @@
 		"SETTINGS_TRAINING_SKIPCOUNT_DESC": "The number of measures to skip while\npressing Skip Forward/Back Measure in\nTraining Mode.",
 		"SETTINGS_TRAINING_JUMPINTERVAL": "Measure Jump Time Interval",
 		"SETTINGS_TRAINING_JUMPINTERVAL_DESC": "The amount of time in milliseconds needed to\nrepeatedly hit the Left/Right Blue keys in\norder to jump to a bookmarked measure in\nTraining Mode.",
+
+		// Settings - Gameplay - Unlockables
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES": "Ignore Song Unlockables",
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Make all songs available ignoring SongUnlockables.db3.\nThis does not add unlock entries to Saves.db3.\nUnlock notifications will still appear on results.\n\n<c.#f0ad4e>WARNING\nHaving this option ON invalidates any speedrun.</c>",
 
 		// Settings - Broken/Unused/Might Deprecate/Might Update
 		// Translate these anyways, even if their future is uncertain.

--- a/OpenTaiko/Lang/fr/lang.json
+++ b/OpenTaiko/Lang/fr/lang.json
@@ -6,7 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "Français (French)",
+    "Language": "Français (French)",
+	"Version":  "0.6.0.0",
 	"Entries": {
 
 		// Common
@@ -199,7 +200,6 @@
 		// Settings - Gameplay - Unlockables
 		"SETTINGS_GAME_IGNORESONGUNLOCKABLES": "Ignorer SongUnlockables.db3",
 		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Rend tout les sons accessibles.\nNe modifie pas directement Saves.db3.\nLes sons sont toujours débloqués normalement.\n\n<c.#f0ad4e>ATTENTION\nActiver cette option rend les speedruns invalides.</c>",
-
 
 		// Settings - Broken/Unused/Might Deprecate/Might Update
 		// Translate these anyways, even if their future is uncertain.

--- a/OpenTaiko/Lang/ja/lang.json
+++ b/OpenTaiko/Lang/ja/lang.json
@@ -6,7 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "日本語 (Japanese)",
+    "Language": "日本語 (Japanese)",
+	"Version":  "0.6.0.0",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -6,7 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "한국어 (WIP)",
+    "Language": "한국어 (WIP)",
+	"Version":  "0.6.0.0",
 	"Entries": {
 
 		// Common
@@ -195,6 +196,10 @@
 		"SETTINGS_TRAINING_SKIPCOUNT_DESC": "The number of measures to skip while\npressing Skip Forward/Back Measure in\nTraining Mode.",
 		"SETTINGS_TRAINING_JUMPINTERVAL": "Measure Jump Time Interval",
 		"SETTINGS_TRAINING_JUMPINTERVAL_DESC": "The amount of time in milliseconds needed to\nrepeatedly hit the Left/Right Blue keys in\norder to jump to a bookmarked measure in\nTraining Mode.",
+
+		// Settings - Gameplay - Unlockables
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES": "Ignore Song Unlockables",
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Make all songs available ignoring SongUnlockables.db3.\nThis does not add unlock entries to Saves.db3.\nUnlock notifications will still appear on results.\n\n<c.#f0ad4e>WARNING\nHaving this option ON invalidates any speedrun.</c>",
 
 		// Settings - Broken/Unused/Might Deprecate/Might Update
 		// Translate these anyways, even if their future is uncertain.

--- a/OpenTaiko/Lang/nl/lang.json
+++ b/OpenTaiko/Lang/nl/lang.json
@@ -6,7 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-  "Language": "Nederlands (Dutch)",
+    "Language": "Nederlands (Dutch)",
+	"Version":  "0.6.0.0",
 	"Entries": {
 
 		// Common
@@ -191,6 +192,10 @@
 		"SETTINGS_TRAINING_SKIPCOUNT_DESC": "De hoeveelheid maten om over te slaan\nwanneer Skip Voor/Terug wordt ingedrukt in\nTraining Modus.",
 		"SETTINGS_TRAINING_JUMPINTERVAL": "Maat Spring Tijdsinterval",
 		"SETTINGS_TRAINING_JUMPINTERVAL_DESC": "De wachttijd in milliseconden om\nmeerdere keren de linker/rechter Kat toetsen in te drukken zodat\nhet springt naar een gebookmarkde maat\nin de Training Modus.",
+
+		// Settings - Gameplay - Unlockables
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES": "Ignore Song Unlockables",
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Make all songs available ignoring SongUnlockables.db3.\nThis does not add unlock entries to Saves.db3.\nUnlock notifications will still appear on results.\n\n<c.#f0ad4e>WARNING\nHaving this option ON invalidates any speedrun.</c>",
 
 		// Settings - Broken/Unused/Might Deprecate/Might Update
 		// Translate these anyways, even if their future is uncertain.


### PR DESCRIPTION
# Context
See title, nothing more than that. Maybe one open question: What is the added value for the version in the translation files? Will it not be the same in all translation files or will the translation files be “versioned” with it?

@ExpedicHabbet thanks for the ping! And yeah, Mr. is fine, but you can also just say @Morphclue without any title. 