### PR TITLE
桁数に応じて座標を設定できるように変更

### DIFF
--- a/OpenTaiko/System/Open-World Memories/GameConfig.ini
+++ b/OpenTaiko/System/Open-World Memories/GameConfig.ini
@@ -140,8 +140,12 @@ Game_Effect_Rainbow_Y=-140,548
 ; == DONE
 Game_Balloon_Combo_X=253,253
 Game_Balloon_Combo_Y=-11,882
-Game_Balloon_Combo_Number_X=277,277
-Game_Balloon_Combo_Number_Y=54,946
+Game_Balloon_Combo_Number_1digit_X=277,277
+Game_Balloon_Combo_Number_1digit_Y=54,946
+Game_Balloon_Combo_Number_2digit_X=277,277
+Game_Balloon_Combo_Number_2digit_Y=54,946
+Game_Balloon_Combo_Number_3digit_X=277,277
+Game_Balloon_Combo_Number_3digit_Y=54,946
 Game_Balloon_Combo_Number_Ex_X=277,277
 Game_Balloon_Combo_Number_Ex_Y=54,946
 Game_Balloon_Combo_Number_Size=80,93

--- a/OpenTaiko/System/SimpleStyle (1080p)/GameConfig.ini
+++ b/OpenTaiko/System/SimpleStyle (1080p)/GameConfig.ini
@@ -252,10 +252,17 @@ Game_Balloon_Combo_X=380,380
 Game_Balloon_Combo_Y=-17,807
 
 
-Game_Balloon_Combo_Number_X=389,389
+Game_Balloon_Combo_Number_1digit_X=389,389
 
-Game_Balloon_Combo_Number_Y=81,905
+Game_Balloon_Combo_Number_1digit_Y=81,905
 
+Game_Balloon_Combo_Number_2digit_X=389,389
+
+Game_Balloon_Combo_Number_2digit_Y=81,905
+
+Game_Balloon_Combo_Number_3digit_X=389,389
+
+Game_Balloon_Combo_Number_3digit_Y=81,905
 
 Game_Balloon_Combo_Number_Ex_X=446,446
 

--- a/OpenTaiko/System/SimpleStyle/GameConfig.ini
+++ b/OpenTaiko/System/SimpleStyle/GameConfig.ini
@@ -246,10 +246,17 @@ Game_Balloon_Combo_X=253,253
 Game_Balloon_Combo_Y=-11,538
 
 
-Game_Balloon_Combo_Number_X=257,257
+Game_Balloon_Combo_Number_1digit_X=257,257
 
-Game_Balloon_Combo_Number_Y=54,603
+Game_Balloon_Combo_Number_1digit_Y=54,603
 
+Game_Balloon_Combo_Number_2digit_X=257,257
+
+Game_Balloon_Combo_Number_2digit_Y=54,603
+
+Game_Balloon_Combo_Number_3digit_X=257,257
+
+Game_Balloon_Combo_Number_3digit_Y=54,603
 
 Game_Balloon_Combo_Number_Ex_X=257,257
 

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -4571,17 +4571,45 @@ namespace OpenTaiko {
 										}
 										break;
 									}
-								case "Game_Balloon_Combo_Number_X": {
+								case "Game_Balloon_Combo_Number_1digit_X": {
 										string[] strSplit = strParam.Split(',');
 										for (int i = 0; i < 2; i++) {
-											Game_Balloon_Combo_Number_X[i] = int.Parse(strSplit[i]);
+											Game_Balloon_Combo_Number_1digit_X[i] = int.Parse(strSplit[i]);
 										}
 										break;
 									}
-								case "Game_Balloon_Combo_Number_Y": {
+								case "Game_Balloon_Combo_Number_1digit_Y": {
 										string[] strSplit = strParam.Split(',');
 										for (int i = 0; i < 2; i++) {
-											Game_Balloon_Combo_Number_Y[i] = int.Parse(strSplit[i]);
+											Game_Balloon_Combo_Number_1digit_Y[i] = int.Parse(strSplit[i]);
+										}
+										break;
+									}
+								case "Game_Balloon_Combo_Number_2digit_X": {
+										string[] strSplit = strParam.Split(',');
+										for (int i = 0; i < 2; i++) {
+											Game_Balloon_Combo_Number_2digit_X[i] = int.Parse(strSplit[i]);
+										}
+										break;
+									}
+								case "Game_Balloon_Combo_Number_2digit_Y": {
+										string[] strSplit = strParam.Split(',');
+										for (int i = 0; i < 2; i++) {
+											Game_Balloon_Combo_Number_1digit_Y[i] = int.Parse(strSplit[i]);
+										}
+										break;
+									}
+								case "Game_Balloon_Combo_Number_3digit_X": {
+										string[] strSplit = strParam.Split(',');
+										for (int i = 0; i < 2; i++) {
+											Game_Balloon_Combo_Number_3digit_X[i] = int.Parse(strSplit[i]);
+										}
+										break;
+									}
+								case "Game_Balloon_Combo_Number_3digit_Y": {
+										string[] strSplit = strParam.Split(',');
+										for (int i = 0; i < 2; i++) {
+											Game_Balloon_Combo_Number_3digit_Y[i] = int.Parse(strSplit[i]);
 										}
 										break;
 									}
@@ -8603,8 +8631,12 @@ namespace OpenTaiko {
 		#region Balloon
 		public int[] Game_Balloon_Combo_X = new int[] { 253, 253 };
 		public int[] Game_Balloon_Combo_Y = new int[] { -11, 538 };
-		public int[] Game_Balloon_Combo_Number_X = new int[] { 257, 257 };
-		public int[] Game_Balloon_Combo_Number_Y = new int[] { 54, 603 };
+		public int[] Game_Balloon_Combo_Number_1digit_X = new int[] { 257, 257 };
+		public int[] Game_Balloon_Combo_Number_1digit_Y = new int[] { 54, 603 };
+		public int[] Game_Balloon_Combo_Number_2digit_X = new int[] { 257, 257 };
+		public int[] Game_Balloon_Combo_Number_2digit_Y = new int[] { 54, 603 };
+		public int[] Game_Balloon_Combo_Number_3digit_X = new int[] { 257, 257 };
+		public int[] Game_Balloon_Combo_Number_3digit_Y = new int[] { 54, 603 };
 		public int[] Game_Balloon_Combo_Number_Ex_X = new int[] { 257, 257 };
 		public int[] Game_Balloon_Combo_Number_Ex_Y = new int[] { 54, 603 };
 		public int[] Game_Balloon_Combo_Number_Size = new int[] { 53, 62 };

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplComboBalloon.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplComboBalloon.cs
@@ -97,12 +97,26 @@ namespace OpenTaiko {
 							int plate_width = OpenTaiko.Tx.Balloon_Combo[j].szTextureSize.Width / 3;
 							int plate_height = OpenTaiko.Tx.Balloon_Combo[j].szTextureSize.Height;
 							OpenTaiko.Tx.Balloon_Combo[j].t2D描画(OpenTaiko.Skin.Game_Balloon_Combo_X[i], OpenTaiko.Skin.Game_Balloon_Combo_Y[i], new RectangleF(NowDrawBalloon * plate_width, 0, plate_width, plate_height));
-							if (this.nCombo_渡[i] < 1000) //2016.08.23 kairera0467 仮実装。
+							if (this.nCombo_渡[i] < 10) //1-digit
 							{
-								this.t小文字表示(OpenTaiko.Skin.Game_Balloon_Combo_Number_X[i], OpenTaiko.Skin.Game_Balloon_Combo_Number_Y[i], this.nCombo_渡[i], j);
+								this.t小文字表示(OpenTaiko.Skin.Game_Balloon_Combo_Number_1digit_X[i], OpenTaiko.Skin.Game_Balloon_Combo_Number_1digit_Y[i], this.nCombo_渡[i], j);
 								OpenTaiko.Tx.Balloon_Number_Combo.t2D描画(OpenTaiko.Skin.Game_Balloon_Combo_Text_X[i] + 6 - NowDrawBalloon * 3, OpenTaiko.Skin.Game_Balloon_Combo_Text_Y[i],
 									new Rectangle(OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[0], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[1], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[2], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[3]));
-							} else {
+							}
+							else if (this.nCombo_渡[i] < 100) //2-digit
+							{
+								this.t小文字表示(OpenTaiko.Skin.Game_Balloon_Combo_Number_2digit_X[i], OpenTaiko.Skin.Game_Balloon_Combo_Number_2digit_Y[i], this.nCombo_渡[i], j);
+								OpenTaiko.Tx.Balloon_Number_Combo.t2D描画(OpenTaiko.Skin.Game_Balloon_Combo_Text_X[i] + 6 - NowDrawBalloon * 3, OpenTaiko.Skin.Game_Balloon_Combo_Text_Y[i],
+									new Rectangle(OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[0], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[1], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[2], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[3]));
+							}
+							else if (this.nCombo_渡[i] < 1000) //3-digit
+							{
+								this.t小文字表示(OpenTaiko.Skin.Game_Balloon_Combo_Number_3digit_X[i], OpenTaiko.Skin.Game_Balloon_Combo_Number_3digit_Y[i], this.nCombo_渡[i], j);
+								OpenTaiko.Tx.Balloon_Number_Combo.t2D描画(OpenTaiko.Skin.Game_Balloon_Combo_Text_X[i] + 6 - NowDrawBalloon * 3, OpenTaiko.Skin.Game_Balloon_Combo_Text_Y[i],
+									new Rectangle(OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[0], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[1], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[2], OpenTaiko.Skin.Game_Balloon_Combo_Text_Rect[3]));
+							}
+							else //more
+							{
 								this.t小文字表示(OpenTaiko.Skin.Game_Balloon_Combo_Number_Ex_X[i], OpenTaiko.Skin.Game_Balloon_Combo_Number_Ex_Y[i], this.nCombo_渡[i], j);
 								OpenTaiko.Tx.Balloon_Number_Combo.vcScaleRatio.X = 1.0f;
 								OpenTaiko.Tx.Balloon_Number_Combo.t2D描画(OpenTaiko.Skin.Game_Balloon_Combo_Text_Ex_X[i] + 6 - NowDrawBalloon * 3, OpenTaiko.Skin.Game_Balloon_Combo_Text_Ex_Y[i],


### PR DESCRIPTION
`Game_Balloon_Combo_Number_X`,`Game_Balloon_Combo_Number_Y`を削除し、新たに
- `Game_Balloon_Combo_Number_1digit_X`,`Game_Balloon_Combo_Number_1digit_Y` (一桁)
- `Game_Balloon_Combo_Number_2digit_X`,`Game_Balloon_Combo_Number_2digit_Y` (二桁)
- `Game_Balloon_Combo_Number_3digit_X`,`Game_Balloon_Combo_Number_3digit_Y` (三桁)
を追加しました

1000コンボ以上の`Game_Balloon_Combo_Number_Ex_X`,`Game_Balloon_Combo_Number_Ex_Y`は変更されていません