### PR TITLE
Fix deprecations in github action

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -2,24 +2,24 @@
 
 name: Build OpenTaiko
 
-on: 
+on:
   push:
     branches:
       - main
-  
+
 jobs:
   build:
     runs-on: windows-latest
-    
+
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
       contents: write
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-        
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -29,49 +29,49 @@ jobs:
         shell: cmd
         run: |
           dir
-          
+
       - name: Get commit subject for version checking
         id: get-latest-commit
         run: |
           $latestCommitMessage = git log -1 --pretty=format:%s
-          echo "::set-output name=latest_commit_message::$latestCommitMessage"
-          
+          echo "latest_commit_message=$latestCommitMessage" >> $GITHUB_OUTPUT
+
       - name: Extract version from commit message
         id: extract-version
         run: |
           if ('${{ steps.get-latest-commit.outputs.latest_commit_message }}' -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
             $version = $matches['version']
             Write-Host "Extracted version is: $version"
-            echo "::set-output name=version::$version"
+            echo "version=$version" >> $GITHUB_OUTPUT
           } else {
             Write-Host "No valid version found in the latest commit message. Skipping bump."
-            echo "::set-output name=version::"
+            echo "version=" >> $GITHUB_OUTPUT
           }
-          
+
       - name: Bump OpenTaiko version if necessary
         if: steps.extract-version.outputs.version != ''
         run: |
           $newVersion = "${{ steps.extract-version.outputs.version }}"
           Write-Host "Updating version in OpenTaiko.csproj to $newVersion"
           (Get-Content OpenTaiko/OpenTaiko.csproj) -replace '<Version>.*<\/Version>', "<Version>$newVersion</Version>" | Set-Content OpenTaiko/OpenTaiko.csproj
-          
+
       - name: Get version
         uses: kzrnm/get-net-sdk-project-versions-action@v2
         id: get-version
         with:
           proj-path: OpenTaiko/OpenTaiko.csproj
-          
+
       - name: Get current date
         id: get-date
         run: |
           $date = Get-Date -Format "yyyy-MM-dd"
-          echo "::set-output name=date::$date"
+          echo "date=$date" >> $GITHUB_OUTPUT
 
       - name: Get changelogs from commit description
         id: get-commit-message
         run: |
           $message = git log -1 --pretty=%b
-          echo "::set-output name=message::$message"
+          echo "message=$message" >> GITHUB_OUTPUT
 
       - name: Update CHANGELOG.md
         run: |
@@ -111,13 +111,13 @@ jobs:
           git add CHANGELOG.md
           git commit -m "Update changelog for version ${{steps.get-version.outputs.version}}"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
-      
+
 
       - name: Build for Windows x64
         shell: cmd
         run: |
           build-win-x64.bat
-          
+
       - name: Create Archive (Win x64)
         shell: cmd
         run: |
@@ -125,12 +125,12 @@ jobs:
           7z a ../../../../../OpenTaiko.Win.x64.zip publish/ -xr!publish/Songs/ -xr!publish/FFmpeg/ -xr!publish/System/ -xr!publish/Libs/
           7z u ../../../../../OpenTaiko.Win.x64.zip "publish/Libs/win-x64/*" "publish/FFmpeg/win-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*"
           cd ..\..\..\..\..\
-                
+
       - name: Build for Linux x64
         shell: cmd
         run: |
           build-linux-x64.bat
-          
+
       - name: Create Archive (Linux x64)
         shell: cmd
         run: |
@@ -142,14 +142,14 @@ jobs:
       - name: Check if tag exists
         uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
-        with: 
+        with:
           tag: "${{steps.get-version.outputs.version}}"
 
       - name: Create Release
         if: steps.check-tag.outputs.exists == 'false'
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "${{steps.get-version.outputs.version}}"
           release_name: OpenTaiko v${{steps.get-version.outputs.version}}
@@ -158,7 +158,7 @@ jobs:
             Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
           draft: false
           prerelease: false
-     
+
       - name: Upload All Builds
         uses: xresloader/upload-to-github-release@v1.4.2
         with:

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -160,7 +160,7 @@ jobs:
           prerelease: false
 
       - name: Upload All Builds
-        uses: xresloader/upload-to-github-release@v1.4.2
+        uses: xresloader/upload-to-github-release@v1.6.0
         with:
           file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
           overwrite: true


### PR DESCRIPTION
# Context
Currently we have some warnings for deprecated node version actions or the set-output command.
See [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and [latest run](https://github.com/0auBSQ/OpenTaiko/actions/runs/11535914988).