### PR TITLE
feat: make menu keys for all players and 1P drum keys for 1P work for difficulty menu and gameplay option menu

### DIFF
--- a/OpenTaiko/src/Stages/05.DaniSelect/CStage段位選択.cs
+++ b/OpenTaiko/src/Stages/05.DaniSelect/CStage段位選択.cs
@@ -250,7 +250,7 @@ class CStage段位選択 : CStage {
 			this.段位挑戦選択画面.Draw();
 		}
 
-		if (段位挑戦選択画面.bOption) actPlayOption.On進行描画(0);
+		this.actPlayOption.On進行描画(1, [this.段位挑戦選択画面.bOption]);
 
 		if (ct待機.CurrentValue >= 3000) {
 			if (段位リスト.currentBar.nodeType == CSongListNode.ENodeType.RANDOM) {

--- a/OpenTaiko/src/Stages/05.SongSelect/CActPlayOption.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActPlayOption.cs
@@ -138,37 +138,12 @@ internal class CActPlayOption : CActivity {
 
 
 
-	public int On進行描画(int player) {
+	public int On進行描画(int nPlayers, ReadOnlySpan<bool> bOptions) {
 		if (this.IsDeActivated)
 			return 0;
 
-		if (ctOpen.CurrentValue == 0)
-			Init(player);
-
-		ctOpen.Tick();
-		ctClose.Tick();
-
-		if (!ctOpen.IsTicked) ctOpen.Start(0, 50, 6, OpenTaiko.Timer);
-
 		var act難易度 = OpenTaiko.stageSongSelect.actDifficultySelectionScreen;
 		var danAct = OpenTaiko.stage段位選択.段位挑戦選択画面;
-
-		#region [ Open & Close ]
-
-		float oy1 = ctOpen.CurrentValue * 18;
-		float oy2 = (ctOpen.CurrentValue - 30) * 4;
-		float oy3 = ctOpen.CurrentValue < 30 ? 410 - oy1 : -80 + oy2;
-
-		float cy1 = ctClose.CurrentValue * 3;
-		float cy2 = (ctClose.CurrentValue - 20) * 16;
-		float cy3 = ctClose.CurrentValue < 20 ? 0 - cy1 : 20 + cy2;
-
-		float y = oy3 + cy3;
-
-		#endregion
-
-
-
 
 		var _textures = new CTexture[]
 		{
@@ -186,124 +161,167 @@ internal class CActPlayOption : CActivity {
 			txFunMods[nFunMods],
 		};
 
-		var pos = player % 2;
-		var _shift = pos == 1 ? (OpenTaiko.Tx.Difficulty_Option.szTextureSize.Width / 2) : 0;
-		var _rect = new Rectangle(_shift, 0, OpenTaiko.Tx.Difficulty_Option.szTextureSize.Width / 2, OpenTaiko.Tx.Difficulty_Option.szTextureSize.Height);
+		// menu key input, for the lowest-index player who is modifying play options
+		bool leftMenu = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LeftChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.LeftArrow));
+		bool rightMenu = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RightChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.RightArrow));
+		bool centerMenu = (OpenTaiko.Pad.bPressedDGB(EPad.Decide) ||
+			(OpenTaiko.ConfigIni.bEnterIsNotUsedInKeyAssignments && OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)));
+		bool upMenu = (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.UpArrow));
+		bool downMenu = (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.DownArrow));
+		bool cancelMenu = (OpenTaiko.Pad.bPressedDGB(EPad.Cancel) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape));
 
-		OpenTaiko.Tx.Difficulty_Option.t2D描画(_shift, y, _rect);
-		OpenTaiko.Tx.Difficulty_Option_Select.t2D描画(_shift + OpenTaiko.Skin.SongSelect_Option_Select_Offset[0] + NowCount * OpenTaiko.Skin.SongSelect_Option_Interval[0],
-			OpenTaiko.Skin.SongSelect_Option_Select_Offset[1] + y + NowCount * OpenTaiko.Skin.SongSelect_Option_Interval[1], _rect);
-
-		for (int i = 0; i < OptionType.Length; i++) {
-			OptionType[i].t2D描画(OpenTaiko.Skin.SongSelect_Option_OptionType_X[pos] + i * OpenTaiko.Skin.SongSelect_Option_Interval[0],
-				OpenTaiko.Skin.SongSelect_Option_OptionType_Y[pos] + y + i * OpenTaiko.Skin.SongSelect_Option_Interval[1]);
-		}
-
-		txModMults[0]?.t2D拡大率考慮描画(CTexture.RefPnt.Up, OpenTaiko.Skin.SongSelect_Option_ModMults1_X[pos], OpenTaiko.Skin.SongSelect_Option_ModMults1_Y[pos] + y);
-		txModMults[1]?.t2D拡大率考慮描画(CTexture.RefPnt.Up, OpenTaiko.Skin.SongSelect_Option_ModMults2_X[pos], OpenTaiko.Skin.SongSelect_Option_ModMults2_Y[pos] + y);
-
-		for (int i = 0; i < _textures.Length; i++) {
-			_textures[i]?.t2D拡大率考慮描画(CTexture.RefPnt.Up, OpenTaiko.Skin.SongSelect_Option_Value_X[pos] + i * OpenTaiko.Skin.SongSelect_Option_Interval[0],
-				OpenTaiko.Skin.SongSelect_Option_Value_Y[pos] + y + i * OpenTaiko.Skin.SongSelect_Option_Interval[1]);
-		}
-
-		if (ctClose.CurrentValue >= 50) {
-			Decision(player);
-			NowCount = 0;
-			ctOpen.Stop();
-			ctOpen.CurrentValue = 0;
-			ctClose.Stop();
-			ctClose.CurrentValue = 0;
-			bEnd = false;
-			act難易度.bOption[player] = false;
-			danAct.bOption = false;
-		}
-
-		#region [ Inputs ]
-
-		if (!ctClose.IsTicked) {
-			bool _leftDrum = false;
-
-			bool _rightDrum = false;
-
-			bool _centerDrum = false;
-
-			bool _cancel = false;
-
-			switch (player) {
-				case 0:
-					_rightDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RightChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.RightArrow));
-					_leftDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LeftChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.LeftArrow));
-					_centerDrum = (OpenTaiko.Pad.bPressedDGB(EPad.Decide) ||
-								   (OpenTaiko.ConfigIni.bEnterIsNotUsedInKeyAssignments && OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)));
-					_cancel = (OpenTaiko.Pad.bPressedDGB(EPad.Cancel) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape));
-					break;
-				case 1:
-					_rightDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue2P));
-					_leftDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue2P));
-					_centerDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed2P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed2P));
-					break;
-				case 2:
-					_rightDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue3P));
-					_leftDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue3P));
-					_centerDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed3P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed3P));
-					break;
-				case 3:
-					_rightDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue4P));
-					_leftDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue4P));
-					_centerDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed4P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed4P));
-					break;
-				case 4:
-					_rightDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue5P));
-					_leftDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue5P));
-					_centerDrum = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed5P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed5P));
-					break;
+		for (int player = 0; player < nPlayers; ++player) {
+			if (!bOptions[player]) {
+				continue;
 			}
 
+			if (ctOpen.CurrentValue == 0)
+				Init(player);
 
-			if (_leftDrum || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.LeftArrow)) {
-				OptionSelect(true);
-				tFetchMults(player);
-				OpenTaiko.Skin.soundChangeSFX.tPlay();
+			ctOpen.Tick();
+			ctClose.Tick();
+
+			if (!ctOpen.IsTicked)
+				ctOpen.Start(0, 50, 6, OpenTaiko.Timer);
+
+			#region [ Open & Close ]
+
+			float oy1 = ctOpen.CurrentValue * 18;
+			float oy2 = (ctOpen.CurrentValue - 30) * 4;
+			float oy3 = ctOpen.CurrentValue < 30 ? 410 - oy1 : -80 + oy2;
+
+			float cy1 = ctClose.CurrentValue * 3;
+			float cy2 = (ctClose.CurrentValue - 20) * 16;
+			float cy3 = ctClose.CurrentValue < 20 ? 0 - cy1 : 20 + cy2;
+
+			float y = oy3 + cy3;
+
+			#endregion
+
+			var pos = player % 2;
+			var _shift = pos == 1 ? (OpenTaiko.Tx.Difficulty_Option.szTextureSize.Width / 2) : 0;
+			var _rect = new Rectangle(_shift, 0, OpenTaiko.Tx.Difficulty_Option.szTextureSize.Width / 2, OpenTaiko.Tx.Difficulty_Option.szTextureSize.Height);
+
+			OpenTaiko.Tx.Difficulty_Option.t2D描画(_shift, y, _rect);
+			OpenTaiko.Tx.Difficulty_Option_Select.t2D描画(_shift + OpenTaiko.Skin.SongSelect_Option_Select_Offset[0] + NowCount * OpenTaiko.Skin.SongSelect_Option_Interval[0],
+				OpenTaiko.Skin.SongSelect_Option_Select_Offset[1] + y + NowCount * OpenTaiko.Skin.SongSelect_Option_Interval[1], _rect);
+
+			for (int i = 0; i < OptionType.Length; i++) {
+				OptionType[i].t2D描画(OpenTaiko.Skin.SongSelect_Option_OptionType_X[pos] + i * OpenTaiko.Skin.SongSelect_Option_Interval[0],
+					OpenTaiko.Skin.SongSelect_Option_OptionType_Y[pos] + y + i * OpenTaiko.Skin.SongSelect_Option_Interval[1]);
 			}
 
-			if (_rightDrum || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.RightArrow)) {
-				OptionSelect(false);
-				tFetchMults(player);
-				OpenTaiko.Skin.soundChangeSFX.tPlay();
+			txModMults[0]?.t2D拡大率考慮描画(CTexture.RefPnt.Up, OpenTaiko.Skin.SongSelect_Option_ModMults1_X[pos], OpenTaiko.Skin.SongSelect_Option_ModMults1_Y[pos] + y);
+			txModMults[1]?.t2D拡大率考慮描画(CTexture.RefPnt.Up, OpenTaiko.Skin.SongSelect_Option_ModMults2_X[pos], OpenTaiko.Skin.SongSelect_Option_ModMults2_Y[pos] + y);
+
+			for (int i = 0; i < _textures.Length; i++) {
+				_textures[i]?.t2D拡大率考慮描画(CTexture.RefPnt.Up, OpenTaiko.Skin.SongSelect_Option_Value_X[pos] + i * OpenTaiko.Skin.SongSelect_Option_Interval[0],
+					OpenTaiko.Skin.SongSelect_Option_Value_Y[pos] + y + i * OpenTaiko.Skin.SongSelect_Option_Interval[1]);
 			}
 
-			if (_centerDrum && ctOpen.CurrentValue >= ctOpen.EndValue) {
-				OpenTaiko.Skin.soundDecideSFX.tPlay();
-				if (NowCount < nOptionCount) {
-					NowCount++;
-				} else if (NowCount >= nOptionCount && !bEnd) {
+			if (ctClose.CurrentValue >= 50) {
+				Decision(player);
+				NowCount = 0;
+				ctOpen.Stop();
+				ctOpen.CurrentValue = 0;
+				ctClose.Stop();
+				ctClose.CurrentValue = 0;
+				bEnd = false;
+				act難易度.bOption[player] = false;
+				danAct.bOption = false;
+			}
+
+			#region [ Inputs ]
+
+			if (!ctClose.IsTicked) {
+				// per-player key input
+				bool _leftDrum = leftMenu;
+				bool _rightDrum = rightMenu;
+				bool _centerDrum = centerMenu;
+				bool _up = upMenu;
+				bool _down = downMenu;
+				bool _cancel = cancelMenu;
+
+				leftMenu = false;
+				rightMenu = false;
+				centerMenu = false;
+				upMenu = false;
+				downMenu = false;
+				cancelMenu = false;
+
+				switch (player) {
+					case 0:
+						_rightDrum = _rightDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue));
+						_leftDrum = _leftDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue));
+						_centerDrum = _centerDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed));
+						break;
+					case 1:
+						_rightDrum = _rightDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue2P));
+						_leftDrum = _leftDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue2P));
+						_centerDrum = _centerDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed2P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed2P));
+						break;
+					case 2:
+						_rightDrum = _rightDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue3P));
+						_leftDrum = _leftDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue3P));
+						_centerDrum = _centerDrum ||(OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed3P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed3P));
+						break;
+					case 3:
+						_rightDrum = _rightDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue4P));
+						_leftDrum = _leftDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue4P));
+						_centerDrum = _centerDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed4P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed4P));
+						break;
+					case 4:
+						_rightDrum = _rightDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue5P));
+						_leftDrum = _leftDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue5P));
+						_centerDrum = _centerDrum || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed5P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed5P));
+						break;
+				}
+
+
+				if (_leftDrum) {
+					OptionSelect(true);
+					tFetchMults(player);
+					OpenTaiko.Skin.soundChangeSFX.tPlay();
+				}
+
+				if (_rightDrum) {
+					OptionSelect(false);
+					tFetchMults(player);
+					OpenTaiko.Skin.soundChangeSFX.tPlay();
+				}
+
+				if (_centerDrum && ctOpen.CurrentValue >= ctOpen.EndValue) {
+					OpenTaiko.Skin.soundDecideSFX.tPlay();
+					if (NowCount < nOptionCount) {
+						NowCount++;
+					} else if (NowCount >= nOptionCount && !bEnd) {
+						bEnd = true;
+						ctClose.Start(0, 50, 6, OpenTaiko.Timer);
+					}
+				}
+
+				int cp1 = nOptionCount + 1;
+
+				if (_up) {
+					OpenTaiko.Skin.soundChangeSFX.tPlay();
+					NowCount = (NowCount + cp1 - 1) % cp1;
+				}
+
+				if (_down) {
+					OpenTaiko.Skin.soundChangeSFX.tPlay();
+					NowCount = (NowCount + 1) % cp1;
+				}
+
+				if (_cancel) {
+					OpenTaiko.Skin.soundDecideSFX.tPlay();
 					bEnd = true;
 					ctClose.Start(0, 50, 6, OpenTaiko.Timer);
 				}
 			}
 
-			int cp1 = nOptionCount + 1;
 
-			if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.UpArrow)) {
-				OpenTaiko.Skin.soundChangeSFX.tPlay();
-				NowCount = (NowCount + cp1 - 1) % cp1;
-			}
-
-			if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.DownArrow)) {
-				OpenTaiko.Skin.soundChangeSFX.tPlay();
-				NowCount = (NowCount + 1) % cp1;
-			}
-
-			if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape)) {
-				OpenTaiko.Skin.soundDecideSFX.tPlay();
-				bEnd = true;
-				ctClose.Start(0, 50, 6, OpenTaiko.Timer);
-			}
+			#endregion
 		}
-
-
-		#endregion
 
 		return 0;
 	}

--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelect難易度選択画面.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelect難易度選択画面.cs
@@ -157,43 +157,53 @@ internal class CActSelect難易度選択画面 : CActivity {
 
 		if (this.ctBarAnimeIn.IsEnded && exextraAnimation == 0) // Prevent player actions if animation is active
 		{
-			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
-				if (!bSelect[i] && !isOnOption()) {
-					bool right = false;
-					bool left = false;
-					bool decide = false;
+			// menu key input, for the lowest-index player who is still selecting the difficulty
+			bool rightMenu = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RightChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.RightArrow));
+			bool leftMenu = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LeftChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.LeftArrow));
+			bool decideMenu = (OpenTaiko.Pad.bPressedDGB(EPad.Decide) ||
+				(OpenTaiko.ConfigIni.bEnterIsNotUsedInKeyAssignments && OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)));
+			bool cancelMenu = (OpenTaiko.Pad.bPressedDGB(EPad.Cancel) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape));
 
-					bool cancel = false;
+			// per-player key input
+			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
+				if (!bSelect[i] && !isOnOption() &&
+					!(OpenTaiko.ConfigIni.bAIBattleMode && i == 1)
+					) {
+					bool right = rightMenu;
+					bool left = leftMenu;
+					bool decide = decideMenu;
+					bool cancel = cancelMenu;
+
+					rightMenu = false;
+					leftMenu = false;
+					decideMenu = false;
+					cancelMenu = false;
 
 					switch (i) {
 						case 0:
-							right = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RightChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.RightArrow));
-							left = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LeftChange) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.LeftArrow));
-							decide = (OpenTaiko.Pad.bPressedDGB(EPad.Decide) ||
-									  (OpenTaiko.ConfigIni.bEnterIsNotUsedInKeyAssignments && OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)));
-							cancel = (OpenTaiko.Pad.bPressedDGB(EPad.Cancel) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape));
+							right = right || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue);
+							left = left || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LeftChange);
+							decide = decide || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed));
 							break;
 						case 1:
-							if (!OpenTaiko.ConfigIni.bAIBattleMode) {
-								right = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue2P));
-								left = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue2P));
-								decide = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed2P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed2P));
-							}
+							right = right || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue2P));
+							left = left || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue2P));
+							decide = decide || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed2P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed2P));
 							break;
 						case 2:
-							right = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue3P));
-							left = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue3P));
-							decide = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed3P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed3P));
+							right = right || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue3P));
+							left = left || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue3P));
+							decide = decide || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed3P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed3P));
 							break;
 						case 3:
-							right = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue4P));
-							left = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue4P));
-							decide = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed4P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed4P));
+							right = right || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue4P));
+							left = left || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue4P));
+							decide = decide || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed4P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed4P));
 							break;
 						case 4:
-							right = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue5P));
-							left = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue5P));
-							decide = (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed5P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed5P));
+							right = right || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RBlue5P));
+							left = left || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LBlue5P));
+							decide = decide || (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed5P) || OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed5P));
 							break;
 					}
 

--- a/OpenTaiko/src/Stages/05.SongSelect/CStage選曲.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStage選曲.cs
@@ -1123,11 +1123,7 @@ internal class CStage選曲 : CStage {
 				}
 			}
 
-			if (actDifficultySelectionScreen.bOption[0]) actPlayOption.On進行描画(0);
-			if (actDifficultySelectionScreen.bOption[1]) actPlayOption.On進行描画(1);
-			if (actDifficultySelectionScreen.bOption[2]) actPlayOption.On進行描画(2);
-			if (actDifficultySelectionScreen.bOption[3]) actPlayOption.On進行描画(3);
-			if (actDifficultySelectionScreen.bOption[4]) actPlayOption.On進行描画(4);
+			this.actPlayOption.On進行描画(5, this.actDifficultySelectionScreen.bOption);
 
 			if (actNewHeya.IsOpend) actNewHeya.Draw();
 


### PR DESCRIPTION
## Fixed

* Softlocked in difficulty selection when any non-P1 player has no key binds
    * Now menu keys control the lowerest-index operable player
* P1 could have only use menu keys but not drum keys, if the key binds differ
    * Now both work
* Up (<kbd>↑</kbd>) and Down (<kbd>↓</kbd>) arrow keys controlled multiple players at once in gameplay option
    * Now menu keys only control the lowerest-index operable player

## Method signature changes

* `CActPlayOption.On進行描画()` [`OnDraw`] now accepts count of players and process all players at once