### PR TITLE
workflows: safer hyphen/dash-(-)-splitting for changelog generation

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -71,20 +71,25 @@ jobs:
         id: get-commit-message
         run: |
           $message = git log -1 --pretty=%b
-          echo "::set-output name=message::$message"
+          $messagePath = 'COMMIT_MSG'
+          echo $message >> $messagePath
+          echo "messagePath=$messagePath" >> $env:GITHUB_ENV
 
       - name: Update CHANGELOG.md
         run: |
           $version = '${{steps.get-version.outputs.version}}'
           $date = '${{steps.get-date.outputs.date}}'
-          $message = '${{steps.get-commit-message.outputs.message}}'
+          $messagePath = $env:messagePath
           $changelogPath = "CHANGELOG.md"
+
+          # Read commit description content
+          $message = Get-Content -Path $messagePath
 
           # Read CHANGELOG.md content
           $changelog = Get-Content -Path $changelogPath
 
           # Split the message into individual items, trim whitespace, and format
-          $messageArray = $message -split '-' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+          $messageArray = $message -split '(^|\r|\n)\s*-' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
 
           # Format each item to have a leading dash
           $message = ($messageArray | ForEach-Object { "- $_" }) -join "`n"


### PR DESCRIPTION
※ 0auBSQ/OpenTaiko#736 is a further alternative solution of this.

* use temporary file $messagePath (`COMMIT_MSG`) to properly handle multiple-line commit message
* use a stricter regex pattern to split changelog items

## Test Cases

IepIweidieng/OpenTaiko@64edc8e2dc41f1a155d8a9ae560949589f8f383a → IepIweidieng/OpenTaiko@238cacb112f954ff7cf79f1acd2c6e63b0746ede