### PR TITLE
workflows: use commit message body minus empty lines as-is for changelog generation

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -71,23 +71,25 @@ jobs:
         id: get-commit-message
         run: |
           $message = git log -1 --pretty=%b
-          echo "::set-output name=message::$message"
+          $messagePath = 'COMMIT_MSG'
+          echo $message >> $messagePath
+          echo "messagePath=$messagePath" >> $env:GITHUB_ENV
 
       - name: Update CHANGELOG.md
         run: |
           $version = '${{steps.get-version.outputs.version}}'
           $date = '${{steps.get-date.outputs.date}}'
-          $message = '${{steps.get-commit-message.outputs.message}}'
+          $messagePath = $env:messagePath
           $changelogPath = "CHANGELOG.md"
+
+          # Read commit description content
+          $messageLines = Get-Content -Path $messagePath
 
           # Read CHANGELOG.md content
           $changelog = Get-Content -Path $changelogPath
 
-          # Split the message into individual items, trim whitespace, and format
-          $messageArray = $message -split '-' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
-
-          # Format each item to have a leading dash
-          $message = ($messageArray | ForEach-Object { "- $_" }) -join "`n"
+          # Remove empty lines from the message
+          $message = ($messageLines | Where-Object { $_ -ne "" }) -join "`n"
 
           # Check if the version already exists
           if ($changelog -match "## \[$version\]") {


### PR DESCRIPTION
Alternative solution for 0auBSQ/OpenTaiko#735.

## Test Cases

https://github.com/IepIweidieng/OpenTaiko/commit/992208fd8bbf28b6ef214d8896ec6d5e51d14e0e → https://github.com/IepIweidieng/OpenTaiko/commit/d92fd54264845bbc4729107a2d64bb9c08cfef4b