### PR TITLE
fix TJA newline after last note symbol and before `,` caused wrong note-symbols-per-measure calculation

### DIFF
--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1893,7 +1893,6 @@ internal class CTja : CActivity {
 	}
 
 	// Regexes
-	private static readonly Regex regexForPrefixingCommaStartingLinesWithZero = new Regex(@"^,", RegexOptions.Multiline | RegexOptions.Compiled);
 	private static readonly Regex regexForStrippingHeadingLines = new Regex(
 		@"^(?!(TITLE|LEVEL|BPM|WAVE|OFFSET|BALLOON|EXAM1|EXAM2|EXAM3|EXAM4|EXAM5|EXAM6|EXAM7|DANTICK|DANTICKCOLOR|RENREN22|RENREN23|RENREN32|RENREN33|RENREN42|RENREN43|BALLOONNOR|BALLOONEXP|BALLOONMAS|SONGVOL|SEVOL|SCOREINIT|SCOREDIFF|COURSE|STYLE|TOWERTYPE|GAME|LIFE|DEMOSTART|SIDE|SUBTITLE|SCOREMODE|GENRE|MAKER|SELECTBG|MOVIEOFFSET|BGIMAGE|BGMOVIE|HIDDENBRANCH|GAUGEINCR|LYRICFILE|#HBSCROLL|#BMSCROLL)).+\n",
 		RegexOptions.Multiline | RegexOptions.Compiled);
@@ -1912,10 +1911,6 @@ internal class CTja : CActivity {
 		nDifficulty = difficulty;
 		if (!String.IsNullOrEmpty(strInput)) //空なら通さない
 		{
-
-			//2017.01.31 DD カンマのみの行を0,に置き換え
-			strInput = regexForPrefixingCommaStartingLinesWithZero.Replace(strInput, "0,");
-
 			//2017.02.03 DD ヘッダ内にある命令以外の文字列を削除
 			var startIndex = strInput.IndexOf("#START");
 			if (startIndex < 0) {


### PR DESCRIPTION
The parser assumed that the measure-final `,` must come right before the last note symbol of a measure, and just replaced `,` lines with `0,`.

This is not true as TaikoJiro allows newlines between each note symbol and `,`, and a newline is required if a command is placed right before the `,`.

The original handling was also ignoring every indented `,` line while currently running completely fine, so the replacing is now unnecessary.

This PR simply stops replacing `,` lines with `0,`.

## Test Case

[measure_note_count.tja](https://github.com/user-attachments/files/17585958/measure_note_count.tja.txt)
