### PR TITLE
Unlockable Conditions in Singular Form

### DIFF
--- a/OpenTaiko/Lang/de/lang.json
+++ b/OpenTaiko/Lang/de/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Processing {0} score...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Verarbeite {0} Ergebnisse...\n<c.#0bb000>{1} von {2} importiert</c> (<c.#f0ad4e>{3} übersprungen</c> / <c.#b00000>{4} fehlgeschlagen</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Dan/Turm ausblenden",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "Neues Lied!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} Münze (Gesamt: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} Münzen (Gesamt: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "Alle großen Noten werden zu <c.#c800ff>Swap</c>-Noten",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> Noten werden sichtbar",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Automatische <c.#ffff00>Rolls</c> mit 1 Schläge",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatische <c.#ffff00>Rolls</c> mit {0} Schlägen",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Geteilte</c> <c.#0088ff>Spuren</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "Artikel gekauft!",
 		"UNLOCK_COIN_MORE": "Nicht genug Münzen!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {0} requires a value.",
-		"UNLOCK_CONDITION_ERROR": "Die folgende Bedingung: {0} erfordert {1} Werte.",
-		"UNLOCK_CONDITION_ERROR2": "Die folgende Bedingung: {0} erfordert ({1} * n) Werte und n Referenzen.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {1} requires a value.",
+		"UNLOCK_CONDITION_ERROR": "Die folgende Bedingung: {1} erfordert {0} Werte.",
+		"UNLOCK_CONDITION_ERROR2": "Die folgende Bedingung: {1} erfordert ({0} * n) Werte und n Referenzen.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,47 +507,47 @@
 		"UNLOCK_CONDITION_AIWIN": "Gewinne {0} KI-Kämpfe, um diesen Artikel freizuschalten! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "Play once to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Spiele {0} Lieder, um diesen Artikel freizuschalten! ({1}/{0})", // tp
 		// The quantifier above has been changed from "songs" to "times", please change as soon as possible.
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} a song to unlock this item! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} songs to unlock this item! ({2}/{0})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} Lieder auf {2} Schwierigkeitsgrad, um diesen Artikel freizuschalten! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{1} a song on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{1} {0} Lieder auf {2} Schwierigkeitsgrad, um diesen Artikel freizuschalten! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} Lieder mit einem Sterne-Rating von {2}, um diesen Artikel freizuschalten! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "Erreiche die folgenden Leistungen, um diesen Artikel freizuschalten: ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} a song with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} songs with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {0} {1} auf {2} Schwierigkeitsgrad.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} Lieder im {2}-Ordner. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} Charts erstellt von {2}. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {1} a song within the {2} folder. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {1} {0} Lieder im {2}-Ordner. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} a chart made by {2}. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {0} Charts erstellt von {2}. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Spiele",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Spiele",

--- a/OpenTaiko/Lang/de/lang.json
+++ b/OpenTaiko/Lang/de/lang.json
@@ -486,37 +486,48 @@
 		"UNLOCK_COIN_BOUGHT": "Artikel gekauft!",
 		"UNLOCK_COIN_MORE": "Nicht genug Münzen!",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {0} requires a value.",
 		"UNLOCK_CONDITION_ERROR": "Die folgende Bedingung: {0} erfordert {1} Werte.",
 		"UNLOCK_CONDITION_ERROR2": "Die folgende Bedingung: {0} erfordert ({1} * n) Werte und n Referenzen.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "Earn a coin to unlock this item! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "Verdiene insgesamt {0} Münzen, um diesen Artikel freizuschalten! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "Play an AI battle match to unlock this item! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "Spiele {0} KI-Kämpfe, um diesen Artikel freizuschalten! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "Win an AI battle match to unlock this item! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "Gewinne {0} KI-Kämpfe, um diesen Artikel freizuschalten! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Spiele {0} Lieder, um diesen Artikel freizuschalten! ({1}/{0})", // tp
+		// The quantifier above has been changed from "songs" to "times", please change as soon as possible.
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} Lieder auf {2} Schwierigkeitsgrad, um diesen Artikel freizuschalten! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} Lieder mit einem Sterne-Rating von {2}, um diesen Artikel freizuschalten! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "Erreiche die folgenden Leistungen, um diesen Artikel freizuschalten: ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -526,11 +537,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} Lieder im {2}-Ordner. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} Charts erstellt von {2}. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Spiele",

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "English",
-	"Version":  "0.6.0.0",
+	"Version":  "0.6.0.16",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Processing {0} score...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Processing {0} scores...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Hide Dan/Tower",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "New Song!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} Coin (Total: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} Coins (Total: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "All big notes become <c.#c800ff>Swap</c> notes",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> notes become visible",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Automatic <c.#ffff00>Rolls</c> at {0} hit/s",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatic <c.#ffff00>Rolls</c> at {0} hits/s",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "Item bought!",
 		"UNLOCK_COIN_MORE": "Not enough coins!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {0} requires a value.",
-		"UNLOCK_CONDITION_ERROR": "The following condition: {0} requires {1} values.",
-		"UNLOCK_CONDITION_ERROR2": "The following condition: {0} requires ({1} * n) values and n references.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {1} requires a value.",
+		"UNLOCK_CONDITION_ERROR": "The following condition: {1} requires {0} values.",
+		"UNLOCK_CONDITION_ERROR2": "The following condition: {1} requires ({0} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,46 +507,46 @@
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI battle matches to unlock this item! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "Play once to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Play {0} times to unlock this item! ({1}/{0})", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} a song to unlock this item! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} songs to unlock this item! ({2}/{1})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} songs on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{1} a song on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{1} {0} songs on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} songs with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} a song with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} songs with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {0} {1} on {2} difficulty.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} songs within the {2} folder. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} charts made by {2}. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {1} a song within the {2} folder. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {1} {0} songs within the {2} folder. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} a chart made by {2}. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {0} charts made by {2}. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Play",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Play",

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -486,37 +486,47 @@
 		"UNLOCK_COIN_BOUGHT": "Item bought!",
 		"UNLOCK_COIN_MORE": "Not enough coins!",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {0} requires a value.",
 		"UNLOCK_CONDITION_ERROR": "The following condition: {0} requires {1} values.",
 		"UNLOCK_CONDITION_ERROR2": "The following condition: {0} requires ({1} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "Earn a coin to unlock this item! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "Earn a total of {0} coins to unlock this item! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "Play an AI battle match to unlock this item! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "Play {0} AI battle matches to unlock this item! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "Win an AI battle match to unlock this item! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI battle matches to unlock this item! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Play {0} times to unlock this item! ({1}/{0})", // tp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} songs on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} songs with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -526,11 +536,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} songs within the {2} folder. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} charts made by {2}. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Play",

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "English",
-	"Version":  "0.6.0.16",
+	"Version":  "0.6.0.17",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/es/lang.json
+++ b/OpenTaiko/Lang/es/lang.json
@@ -487,37 +487,47 @@
 		"UNLOCK_COIN_BOUGHT": "¡Item comprado!",
 		"UNLOCK_COIN_MORE": "¡Monedas insuficientes!",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "Esta condición: {0} requires a value.",
 		"UNLOCK_CONDITION_ERROR": "Esta condición: {0} requires {1} values.",
 		"UNLOCK_CONDITION_ERROR2": "Esta condición: {0} requires ({1} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "Earn a coin to unlock this item! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "Earn a total of {0} coins to unlock this item! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "Play an AI battle match to unlock this item! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "Play {0} AI battle matches to unlock this item! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "Win an AI battle match to unlock this item! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI battle matches to unlock this item! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY": "Play {0} songs to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY": "Play {0} times to unlock this item! ({1}/{0})", // tp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} songs on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} songs with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -527,11 +537,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} songs within the {2} folder. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} charts made by {2}. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Play",

--- a/OpenTaiko/Lang/es/lang.json
+++ b/OpenTaiko/Lang/es/lang.json
@@ -62,6 +62,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Processing {0} score...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Processing {0} scores...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Ocultar Dans/Torres",
@@ -410,6 +411,7 @@
 		"MODAL_TITLE_SONG": "¡Canción conseguida!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} Moneda (Total: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} Monedas (Total: {1})",
 
 		// Online Lounge
@@ -474,6 +476,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "All big notes become <c.#c800ff>Swap</c> notes",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> notes become visible",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Automatic <c.#ffff00>Rolls</c> at 1 hit/s",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatic <c.#ffff00>Rolls</c> at {0} hits/s",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
 		// {0}: Coin multiplier
@@ -487,9 +490,9 @@
 		"UNLOCK_COIN_BOUGHT": "¡Item comprado!",
 		"UNLOCK_COIN_MORE": "¡Monedas insuficientes!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "Esta condición: {0} requires a value.",
-		"UNLOCK_CONDITION_ERROR": "Esta condición: {0} requires {1} values.",
-		"UNLOCK_CONDITION_ERROR2": "Esta condición: {0} requires ({1} * n) values and n references.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "Esta condición: {1} requires a value.",
+		"UNLOCK_CONDITION_ERROR": "Esta condición: {1} requires {0} values.",
+		"UNLOCK_CONDITION_ERROR2": "Esta condición: {1} requires ({0} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -505,46 +508,46 @@
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI battle matches to unlock this item! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "Play once to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Play {0} times to unlock this item! ({1}/{0})", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} a song to unlock this item! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} songs to unlock this item! ({2}/{1})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} songs on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{1} a song on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{1} {0} songs on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} songs with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} a song with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} songs with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {0} {1} on {2} difficulty.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} songs within the {2} folder. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} charts made by {2}. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {1} a song within the {2} folder. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {1} {0} songs within the {2} folder. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} a chart made by {2}. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {0} charts made by {2}. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Play",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Play",

--- a/OpenTaiko/Lang/fr/lang.json
+++ b/OpenTaiko/Lang/fr/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Processing {0} score...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Processing {0} scores...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Masquer Dan/Tour",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "New Song!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} Jeton (Total: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} Jetons (Total: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "All big notes become <c.#c800ff>Swap</c> notes",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> notes become visible",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Automatic <c.#ffff00>Rolls</c> at 1 hit/s",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatic <c.#ffff00>Rolls</c> at {0} hits/s",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "Article acheté!",
 		"UNLOCK_COIN_MORE": "Nombre de jetons insuffisant!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "La condition suivante: {0} requires a value.",
-		"UNLOCK_CONDITION_ERROR": "La condition suivante: {0} requires {1} values.",
-		"UNLOCK_CONDITION_ERROR2": "La condition suivante: {0} requires ({1} * n) values and n references.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "La condition suivante: {1} requires a value.",
+		"UNLOCK_CONDITION_ERROR": "La condition suivante: {1} requires {0} values.",
+		"UNLOCK_CONDITION_ERROR2": "La condition suivante: {1} requires ({0} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,46 +507,46 @@
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI battle matches to unlock this item! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "Play once to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Play {0} times to unlock this item! ({1}/{0})", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} a song to unlock this item! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} songs to unlock this item! ({2}/{1})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} songs on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{1} a song on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{1} {0} songs on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} songs with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} a song with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} songs with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {0} {1} on {2} difficulty.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} songs within the {2} folder. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} charts made by {2}. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {1} a song within the {2} folder. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {1} {0} songs within the {2} folder. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} a chart made by {2}. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {0} charts made by {2}. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Play",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Play",

--- a/OpenTaiko/Lang/fr/lang.json
+++ b/OpenTaiko/Lang/fr/lang.json
@@ -486,37 +486,47 @@
 		"UNLOCK_COIN_BOUGHT": "Article acheté!",
 		"UNLOCK_COIN_MORE": "Nombre de jetons insuffisant!",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "La condition suivante: {0} requires a value.",
 		"UNLOCK_CONDITION_ERROR": "La condition suivante: {0} requires {1} values.",
 		"UNLOCK_CONDITION_ERROR2": "La condition suivante: {0} requires ({1} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "Earn a coin to unlock this item! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "Earn a total of {0} coins to unlock this item! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "Play an AI battle match to unlock this item! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "Play {0} AI battle matches to unlock this item! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "Win an AI battle match to unlock this item! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI battle matches to unlock this item! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY": "Play {0} songs to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY": "Play {0} times to unlock this item! ({1}/{0})", // tp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} songs on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} songs with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "Get the following performances to unlock this item:  ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -526,11 +536,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} songs within the {2} folder. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} charts made by {2}. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Play",

--- a/OpenTaiko/Lang/ja/lang.json
+++ b/OpenTaiko/Lang/ja/lang.json
@@ -486,37 +486,47 @@
 		"UNLOCK_COIN_BOUGHT": "商品購入済み !",
 		"UNLOCK_COIN_MORE": "コインが足りません !",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "下記の条件 : {0} requires a value.",
 		"UNLOCK_CONDITION_ERROR": "下記の条件 : {0} requires {1} values.",
 		"UNLOCK_CONDITION_ERROR2": "下記の条件 : {0} requires ({1} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "コイン手に入れた ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "{0}コイン以上手に入れた ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "AI演奏バトルを1回プレイ ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "AI演奏バトルを{0}回プレイ ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "AI演奏バトルで1回勝利 ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "AI演奏バトルで{0}回勝利 ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_PLAY_ONCE": "1回プレイ ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "2回プレイ ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "{0}回プレイ ({1}/{0})", // tp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "1譜面を{0} ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{1}譜面を{0} ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{2}で1譜面を{0} ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{2}で{1}譜面を{0} ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{2}★の1譜面を{0} ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{2}★の{1}譜面を{0} ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "以下の条件をクリアしましょう！： ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "以下の条件をクリアしましょう！： ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -526,11 +536,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "※{2}ジャンルの1譜面を{0} ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "※{2}ジャンルの{1}譜面を{0} ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "※{2}さんの1譜面を{0} ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "※{2}さんの{1}譜面を{0} ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "プレイ",

--- a/OpenTaiko/Lang/ja/lang.json
+++ b/OpenTaiko/Lang/ja/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Processing {0} score...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Processing {0} scores...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "段・タワー譜面省略",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "楽曲取得！",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0}コイン (累計: {1})",
 		"MODAL_MESSAGE_COIN": "+{0}コイン (累計: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "All big notes become <c.#c800ff>Swap</c> notes",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> notes become visible",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Automatic <c.#ffff00>Rolls</c> at 1 hit/s",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatic <c.#ffff00>Rolls</c> at {0} hits/s",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "商品購入済み !",
 		"UNLOCK_COIN_MORE": "コインが足りません !",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "下記の条件 : {0} requires a value.",
-		"UNLOCK_CONDITION_ERROR": "下記の条件 : {0} requires {1} values.",
-		"UNLOCK_CONDITION_ERROR2": "下記の条件 : {0} requires ({1} * n) values and n references.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "下記の条件 : {1} requires a value.",
+		"UNLOCK_CONDITION_ERROR": "下記の条件 : {1} requires {0} values.",
+		"UNLOCK_CONDITION_ERROR2": "下記の条件 : {1} requires ({0} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,46 +507,46 @@
 		"UNLOCK_CONDITION_AIWIN": "AI演奏バトルで{0}回勝利 ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "1回プレイ ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "1回プレイ ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "2回プレイ ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "{0}回プレイ ({1}/{0})", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "1譜面を{0} ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{1}譜面を{0} ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "1譜面を{1} ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1}譜面を{1} ({2}/{0})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{2}で1譜面を{0} ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{2}で{1}譜面を{0} ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{2}で1譜面を{1} ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{2}で{0}譜面を{1} ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{2}★の1譜面を{0} ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{2}★の{1}譜面を{0} ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "以下の条件をクリアしましょう！： ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "以下の条件をクリアしましょう！： ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{2}★の1譜面を{1} ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{2}★の{0}譜面を{1} ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "以下の条件をクリアしましょう！： ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "以下の条件をクリアしましょう！： ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "※{1}{2}を{0}", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "※{2}ジャンルの1譜面を{0} ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "※{2}ジャンルの{1}譜面を{0} ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "※{2}さんの1譜面を{0} ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "※{2}さんの{1}譜面を{0} ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "※{2}ジャンルの1譜面を{1} ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "※{2}ジャンルの{0}譜面を{1} ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "※{2}さんの1譜面を{1} ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "※{2}さんの{0}譜面を{1} ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "プレイ",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "プレイ",

--- a/OpenTaiko/Lang/ja/lang.json
+++ b/OpenTaiko/Lang/ja/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "日本語 (Japanese)",
-	"Version":  "0.6.0.16",
+	"Version":  "0.6.0.17",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/ja/lang.json
+++ b/OpenTaiko/Lang/ja/lang.json
@@ -6,8 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-    "Language": "日本語 (Japanese)",
-	"Version":  "0.6.0.0",
+	"Language": "日本語 (Japanese)",
+	"Version":  "0.6.0.16",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Processing {0} score...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Processing {0} scores...\n<c.#0bb000>{1} of {2} imported</c> (<c.#f0ad4e>{3} skipped</c> / <c.#b00000>{4} failed</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "단위도장/타워모드 숨기기",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "신곡!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} Coin (Total: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} Coins (Total: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "모든 큰 노트는 <c.#c800ff>스왑</c> 노트로 변경됩니다.",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> 노트가 보이게 됩니다.",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": " 1 히트에서 자동으로 <c.#ffff00>연타가</c>됩니다.",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": " {0} 히트에서 자동으로 <c.#ffff00>연타가</c>됩니다.",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "아이템 구매 완료!",
 		"UNLOCK_COIN_MORE": "코인이 부족합니다!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "다음 조건입니다: {0}에 1 값이 필요합니다.",
-		"UNLOCK_CONDITION_ERROR": "다음 조건입니다: {0}에 {1} 값이 필요합니다.",
-		"UNLOCK_CONDITION_ERROR2": "다음 조건입니다: {0} requires ({1} * n) values and n references.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "다음 조건입니다: {1}에 1 값이 필요합니다.",
+		"UNLOCK_CONDITION_ERROR": "다음 조건입니다: {1}에 {0} 값이 필요합니다.",
+		"UNLOCK_CONDITION_ERROR2": "다음 조건입니다: {1} requires ({0} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,46 +507,46 @@
 		"UNLOCK_CONDITION_AIWIN": "AI 배틀 모드에서 {0}번 승리하여 이 아이템을 잠금 해제하세요! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "이 아이템을 잠금 해제하려면 1회를 플레이하세요! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "이 아이템을 잠금 해제하려면 1회를 플레이하세요! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "이 아이템을 잠금 해제하려면 2회를 플레이하세요! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "이 아이템을 잠금 해제하려면 {0}회를 플레이하세요! ({1}/{0})", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "이 아이템을 잠금 해제하려면 1곡을 {0}하세요! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "이 아이템을 잠금 해제하려면 {1}곡을 {0}하세요! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "이 아이템을 잠금 해제하려면 1곡을 {1}하세요! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "이 아이템을 잠금 해제하려면 {0}곡을 {1}하세요! ({2}/{0})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "이 아이템을 잠금 해제하려면 1 곡에서 {2} 난이도로 {0}를 해야합니다! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "이 아이템을 잠금 해제하려면 {1} 곡에서 {2} 난이도로 {0}를 해야합니다! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "이 아이템을 잠금 해제하려면 1 곡에서 {2} 난이도로 {1}를 해야합니다! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "이 아이템을 잠금 해제하려면 {0} 곡에서 {2} 난이도로 {1}를 해야합니다! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "이 아이템을 잠금 해제하려면 1 곡에서 {2}성 난이도로 {0}를 해야합니다! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "이 아이템을 잠금 해제하려면 {1} 곡에서 {2}성 난이도로 {0}를 해야합니다! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "이 아이템의 잠금 해제하려면 다음과 같은 성과를 달성하세요:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "이 아이템의 잠금 해제하려면 다음과 같은 성과를 달성하세요:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "이 아이템을 잠금 해제하려면 1 곡에서 {2}성 난이도로 {1}를 해야합니다! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "이 아이템을 잠금 해제하려면 {0} 곡에서 {2}성 난이도로 {1}를 해야합니다! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "이 아이템의 잠금 해제하려면 다음과 같은 성과를 달성하세요:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "이 아이템의 잠금 해제하려면 다음과 같은 성과를 달성하세요:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {1} 곡을 {2}로 {0}하세요.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {2}에 있는 1 곡을 {0}하세요. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {2}에 있는 {1} 곡을 {0}하세요. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {2}이(가) 만든 1 곡을 {0}하세요. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {2}이(가) 만든 {1} 곡을 {0}하세요. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {2}에 있는 1 곡을 {0}하세요. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {2}에 있는 {0} 곡을 {1}하세요. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {2}이(가) 만든 1 곡을 {1}하세요. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {2}이(가) 만든 {0} 곡을 {1}하세요. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "플레이",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "플레이",

--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -6,8 +6,8 @@
 
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
-    "Language": "한국어 (Korean)",
-	"Version":  "0.6.0.0",
+	"Language": "한국어 (Korean)",
+	"Version":  "0.6.0.16",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "한국어 (Korean)",
-	"Version":  "0.6.0.16",
+	"Version":  "0.6.0.17",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -28,7 +28,7 @@
 		"SETTINGS_SYSTEM": "시스템 옵션",
 		"SETTINGS_SYSTEM_DESC": "전체 시스템 설정입니다.",
 		"SETTINGS_GAME": "게임 플레이 옵션",
-		"SETTINGS_GAME_DESC": "게임 플레이 설정입니다,.",
+		"SETTINGS_GAME_DESC": "게임 플레이 설정입니다.",
 		"SETTINGS_EXIT": "나가기",
 		"SETTINGS_EXIT_DESC": "저장하고 나가기.",
 
@@ -46,7 +46,7 @@
 		"SETTINGS_SYSTEM_LANGUAGE": "시스템 언어",
 		"SETTINGS_SYSTEM_LANGUAGE_DESC": "시스템, 게임 언어를 변경 할 수 있습니다.",
 		"SETTINGS_SYSTEM_PLAYERCOUNT": "플레이어 수",
-		"SETTINGS_SYSTEM_PLAYERCOUNT_DESC": "플레이어 수를 변경 할 수 있습니다 .",
+		"SETTINGS_SYSTEM_PLAYERCOUNT_DESC": "플레이어 수를 변경 할 수 있습니다.",
 		"SETTINGS_SYSTEM_RELOADSONG": "곡 다시 불러오기",
 		"SETTINGS_SYSTEM_RELOADSONG_DESC": "곡 파일을 다시 불러옵니다.",
 		"SETTINGS_SYSTEM_RELOADSONGCACHE": "곡 다시 불러오기 (Hard reload)",
@@ -68,7 +68,7 @@
 
 		// Settings - System - Graphics
 		"SETTINGS_SYSTEM_FULLSCREEN": "전체화면 모드",
-		"SETTINGS_SYSTEM_FULLSCREEN_DESC": "전체화면 모드, 창 모드로 변경 할 수 있습니다..",
+		"SETTINGS_SYSTEM_FULLSCREEN_DESC": "전체화면 모드, 창 모드로 변경 할 수 있습니다.",
 		"SETTINGS_SYSTEM_VSYNC": "VSync 모드",
 		"SETTINGS_SYSTEM_VSYNC_DESC": "VSync로 전환, 또는 해제 할 수 있습니다.\nVSync 모드로 전환하시면, 프레임이 60FPS로 고정됩니다, 하지만 인풋렉은 늘어납니다.",
 		"SETTINGS_SYSTEM_GRAPHICSAPI": "그래픽 API",
@@ -105,7 +105,7 @@
 		"SETTINGS_SYSTEM_SIMPLEMODE_DESC": "간단하게 거의 모든 이미지, 이펙트를 없앱니다.",
 
 		"SETTINGS_SYSTEM_SKIN": "현재 스킨",
-		"SETTINGS_SYSTEM_SKIN_DESC": "System 폴더에 있는 스킨들을 고르세요..",
+		"SETTINGS_SYSTEM_SKIN_DESC": "System 폴더에 있는 스킨들을 고르세요.",
 
 		// Settings - System - Audio
 		"SETTINGS_SYSTEM_SONGPLAYBACK": "곡 재생",
@@ -486,33 +486,47 @@
 		"UNLOCK_COIN_BOUGHT": "아이템 구매 완료!",
 		"UNLOCK_COIN_MORE": "코인이 부족합니다!",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "다음 조건입니다: {0}에 1 값이 필요합니다.",
 		"UNLOCK_CONDITION_ERROR": "다음 조건입니다: {0}에 {1} 값이 필요합니다.",
 		"UNLOCK_CONDITION_ERROR2": "다음 조건입니다: {0} requires ({1} * n) values and n references.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "코인을 획득하여 이 아이템을 잠금 해제하세요! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "총 {0} 코인을 획득하여 이 아이템을 잠금 해제하세요! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "이 아이템을 잠금 해제하려면 1번의 AI 배틀 모드를 플레이하세요! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "이 아이템을 잠금 해제하려면 {0}번의 AI 배틀 모드를 플레이하세요! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "AI 배틀 모드에서 1번 승리하여 이 아이템을 잠금 해제하세요! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "AI 배틀 모드에서 {0}번 승리하여 이 아이템을 잠금 해제하세요! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY": "이 아이템을 잠금 해제하려면 {0}곡을 플레이하세요! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_ONCE": "이 아이템을 잠금 해제하려면 1회를 플레이하세요! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "이 아이템을 잠금 해제하려면 2회를 플레이하세요! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY": "이 아이템을 잠금 해제하려면 {0}회를 플레이하세요! ({1}/{0})", // tp
+		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
+		// {1}: Total plays needed
+		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "이 아이템을 잠금 해제하려면 1곡을 {0}하세요! ({2}/{1})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "이 아이템을 잠금 해제하려면 {1}곡을 {0}하세요! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "이 아이템을 잠금 해제하려면 1 곡에서 {2} 난이도로 {0}를 해야합니다! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "이 아이템을 잠금 해제하려면 {1} 곡에서 {2} 난이도로 {0}를 해야합니다! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "이 아이템을 잠금 해제하려면 1 곡에서 {2}성 난이도로 {0}를 해야합니다! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "이 아이템을 잠금 해제하려면 {1} 곡에서 {2}성 난이도로 {0}를 해야합니다! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "이 아이템의 잠금 해제하려면 다음과 같은 성과를 달성하세요:  ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "이 아이템의 잠금 해제하려면 다음과 같은 성과를 달성하세요:  ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -522,11 +536,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {2}에 있는 1 곡을 {0}하세요. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {2}에 있는 {1} 곡을 {0}하세요. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {2}이(가) 만든 1 곡을 {0}하세요. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {2}이(가) 만든 {1} 곡을 {0}하세요. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "플레이",
@@ -550,7 +566,7 @@
 		"AI_NAME": "AI",
 		"AI_TITLE": "Deus-Ex-Machina",
 		// {0}: Section No.
-		"AI_SECTION": "섹션 {0}", // ~區
+		"AI_SECTION": "섹션 {0}",
 
 		// Mods
 		"MOD_NONE": "없음",

--- a/OpenTaiko/Lang/nl/lang.json
+++ b/OpenTaiko/Lang/nl/lang.json
@@ -42,7 +42,6 @@
 		"SETTINGS_KEYASSIGN_TRAINING": "Training Modus Toetsinstellingen",
 		"SETTINGS_KEYASSIGN_TRAINING_DESC": "Een tweede menu voor het instellen van toetsen\ntijdens de Training Modus.",
 
-
 		// Settings - System
 		"SETTINGS_SYSTEM_LANGUAGE": "Systeemtaal",
 		"SETTINGS_SYSTEM_LANGUAGE_DESC": "Verander de taal\nvan het spel en de menu's.",
@@ -76,6 +75,7 @@
 		"SETTINGS_SYSTEM_GRAPHICSAPI_DESC": "Grafische tekenmethode:\nSelecteer de opties OpenGL,\nDirectX11, Vulkan of Metal.\nOpenGL is langzaam, maar compatibel en stabiel.\nDirectX11 is snel en stabiel, maar\n werkt alleen op Windows.\nVulkan werkt het snelst op Linux.\nMetal werkt alleen op MacOS.\n\nHerstart het spel om te activeren.",
 		"SETTINGS_SYSTEM_TEXTUREASYNC": "ASync Texture laden",
 		"SETTINGS_SYSTEM_TEXTUREASYNC_DESC": "Bevriezen bij het starten verdwijnt.\nZet deze optie uit als sommige textures zwart worden.\nDeze optie activeert na het herstarten van OpenTaiko.",
+
 		"SETTINGS_SYSTEM_BGMOVIE": "Video's Afspelen",
 		"SETTINGS_SYSTEM_BGMOVIE_DESC": "Schakelt achtergrond video's aan/uit.\nAls dit is ingeschakeld en het lied geen video heeft,\ndan zal de achtergrond zwart worden.",
 		"SETTINGS_SYSTEM_BGMOVIEDISPLAY": "Video Afspeelmodus",
@@ -86,6 +86,7 @@
 		"SETTINGS_SYSTEM_BGMOVIEDISPLAY_BOTH": "Beide",
 		"SETTINGS_SYSTEM_LANEOPACITY": "Laan Achtergrond Doorzichtigheid",
 		"SETTINGS_SYSTEM_LANEOPACITY_DESC": "Verandert de doorzichtigheid van de achtergrond\nbij het spelen van video's.\n\n0 = volledig doorzichtig,\n255 = niet doorzichtig.",
+
 		"SETTINGS_SYSTEM_BGA": "BGA Weergeven",
 		"SETTINGS_SYSTEM_BGA_DESC": "Schakelt animaties in de achtergrond aan/uit.",
 		"SETTINGS_SYSTEM_DISPLAYCHARA": "Karakters Weergeven",
@@ -102,6 +103,7 @@
 		"SETTINGS_SYSTEM_DISPLAYPUCHI_DESC": "Laat PuchiChara foto's zien.",
 		"SETTINGS_SYSTEM_SIMPLEMODE": "Simpele Modus",
 		"SETTINGS_SYSTEM_SIMPLEMODE_DESC": "Versimpelt graphics door visuele effecten en\nopmaak te verbergen tijdens gameplay.",
+
 		"SETTINGS_SYSTEM_SKIN": "Huidige Skin",
 		"SETTINGS_SYSTEM_SKIN_DESC": "Kies een skin uit de systeemfolder om te gebruiken.",
 
@@ -120,10 +122,12 @@
 		"SETTINGS_SYSTEM_SONGPREVIEWVOL_DESC": "Past de volume aan voor het lied voorbeeld.\nU moet OpenTaiko herstarten na het verlaten van de\ninstellingen zodat deze configuratie opslaat.",
 		"SETTINGS_SYSTEM_VOLINCREMENT": "Toetsenbord Volume Wijziging",
 		"SETTINGS_SYSTEM_VOLINCREMENT_DESC": "Geeft aan hoeveel de volume wordt aangepast voor de\nvolume omhoog/omlaag knoppen.\nU kunt een waarde instellen tussen 1 en 20.",
+
 		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER": "Lied Afspeel Buffer",
 		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER_DESC": "De tijdsduur voordat een lied afspeelt in het spel.\nAls deze waarde laag staat, kunnen nummers te vroeg afspelen.",
 		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER": "Lied Voorbeeld Buffer",
 		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER_DESC": "De tijdsduur voordat een lied voorbeeld afspeelt.\nAls deze waarde erg laag staat kunnen\nliedjes tijdens het scrollen afspelen.\nU kunt een waarde kiezen tussen 0ms en 10000ms.",
+
 		"SETTINGS_SYSTEM_AUDIOPLAYBACK": "Geluid Afspeelmodus",
 		"SETTINGS_SYSTEM_AUDIOPLAYBACK_DESC": "ASIO:\n- Werkt alleen op apparaten die ASIO audio ondersteunen\n- Heeft de laagste inputvertraging\nWasapi:\n- Alleen compatibel met Windows\n- Heeft de op een na laagste inputvertraging\nBASS:\n- Op alle platforms ondersteund\nOpmerking: verlaat de instellingen\nom dit op te slaan.",
 		"SETTINGS_SYSTEM_ASIOPLAYBACK": "ASIO Afspeelapparaat",
@@ -482,38 +486,48 @@
 		"UNLOCK_COIN_BOUGHT": "Item gekocht!",
 		"UNLOCK_COIN_MORE": "Niet genoeg munten!",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {0} requires a value.",
 		"UNLOCK_CONDITION_ERROR": "De volgende conditie: {0} vereist {1} waardes.",
-
 		"UNLOCK_CONDITION_ERROR2": "De volgende conditie: {0} vereist ({1} * n) waardes en n referenties.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "Earn a coin to unlock this item! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "Verdien in totaal {0} munten om dit itme te ontgrendelen! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "Play an AI battle match to unlock this item! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "Speel {0} AI gevecht wedstrijden om dit item to ontgrendelen! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "Win an AI battle match to unlock this item! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI gevecht wedstrijden om dit item to ontgrendelen! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Speel {0} liedjes om dit item te ontgrendelen! ({1}/{0})", // tp
+		// The quantifier above has been changed from "songs" to "times", please change as soon as possible.
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} liedjes op {2} moeilijkheidsgraad om dit item te ontgrendelen! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} nummers met een ster waarde van {2} om dit item te ontgrendelen! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "Behaal de volgende prestaties om dit item te ontgrendelen:  ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -523,11 +537,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} liedjes binnen de {2} folder. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} nummers gemaakt door {2}. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Speel",

--- a/OpenTaiko/Lang/nl/lang.json
+++ b/OpenTaiko/Lang/nl/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Verwerken van {0} score...\n<c.#0bb000>{1} van {2} geïmporteerd</c> (<c.#f0ad4e>{3} overgeslagen</c> / <c.#b00000>{4} mislukt</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Verwerken van {0} scores...\n<c.#0bb000>{1} van {2} geïmporteerd</c> (<c.#f0ad4e>{3} overgeslagen</c> / <c.#b00000>{4} mislukt</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Dan/Toren Verbergen",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "Nieuw Lied!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} Munt (Totaal: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} Munten (Totaal: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "All big notes become <c.#c800ff>Swap</c> notes",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> notes become visible",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Automatic <c.#ffff00>Rolls</c> at 1 hit/s",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Automatic <c.#ffff00>Rolls</c> at {0} hits/s",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Split</c> <c.#0088ff>Lanes</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "Item gekocht!",
 		"UNLOCK_COIN_MORE": "Niet genoeg munten!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {0} requires a value.",
-		"UNLOCK_CONDITION_ERROR": "De volgende conditie: {0} vereist {1} waardes.",
-		"UNLOCK_CONDITION_ERROR2": "De volgende conditie: {0} vereist ({1} * n) waardes en n referenties.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "The following condition: {1} requires a value.",
+		"UNLOCK_CONDITION_ERROR": "De volgende conditie: {1} vereist {0} waardes.",
+		"UNLOCK_CONDITION_ERROR2": "De volgende conditie: {1} vereist ({0} * n) waardes en n referenties.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,47 +507,47 @@
 		"UNLOCK_CONDITION_AIWIN": "Win {0} AI gevecht wedstrijden om dit item to ontgrendelen! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "Play once to unlock this item! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "Play once to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "Play twice to unlock this item! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Speel {0} liedjes om dit item te ontgrendelen! ({1}/{0})", // tp
 		// The quantifier above has been changed from "songs" to "times", please change as soon as possible.
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} a song to unlock this item! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} songs to unlock this item! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} a song to unlock this item! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} songs to unlock this item! ({2}/{0})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} a song on {2} difficulty to unlock this item! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} liedjes op {2} moeilijkheidsgraad om dit item te ontgrendelen! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{1} a song on {2} difficulty to unlock this item! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{1} {0} liedjes op {2} moeilijkheidsgraad om dit item te ontgrendelen! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} a song with a star rating of {2} to unlock this item! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} nummers met een ster waarde van {2} om dit item te ontgrendelen! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "Behaal de volgende prestaties om dit item te ontgrendelen:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} a song with a star rating of {2} to unlock this item! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} nummers met een ster waarde van {2} om dit item te ontgrendelen! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Get the following performance to unlock this item:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Behaal de volgende prestaties om dit item te ontgrendelen:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {0} {1} op {2} moeilijkheidsgraad.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} a song within the {2} folder. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} liedjes binnen de {2} folder. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} a chart made by {2}. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} nummers gemaakt door {2}. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {1} a song within the {2} folder. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {1} {0} liedjes binnen de {2} folder. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} a chart made by {2}. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {0} nummers gemaakt door {2}. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Speel",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Speel",

--- a/OpenTaiko/Lang/ru/lang.json
+++ b/OpenTaiko/Lang/ru/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "Обработка {0} результата...\n<c.#0bb000>{1} из {2} импортировано</c> (<c.#f0ad4e>{3} пропущено</c> / <c.#b00000>{4} неудачно</c>)\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "Обработка {0} результата/ов...\n<c.#0bb000>{1} из {2} импортировано</c> (<c.#f0ad4e>{3} пропущено</c> / <c.#b00000>{4} неудачно</c>)\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Спрятать Дан и Башни",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "Новая Песня!",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0} монет (Общие: {1})",
 		"MODAL_MESSAGE_COIN": "+{0} монет. (Общие: {1})",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "Все большие ноты становятся <c.#c800ff>Самоблокирующимися</c> нотами",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c> ноты становятся видимыми",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "Автоматически <c.#ffff00>дробит</c> со скоростью 1 удар/с",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Автоматически <c.#ffff00>дробит</c> со скоростью {0} удар./с",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Разделяет</c> <c.#0088ff>Трассы</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "Товар куплен!",
 		"UNLOCK_COIN_MORE": "Недостаточно монет!",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "Следующее условие: Для {0} требуется значение.",
-		"UNLOCK_CONDITION_ERROR": "Следующее условие: Для {0} требуется {1} значени..",
-		"UNLOCK_CONDITION_ERROR2": "Следующее условие: Для {0} требуется ({1} * n) значений и n ссылок.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "Следующее условие: Для {1} требуется значение.",
+		"UNLOCK_CONDITION_ERROR": "Следующее условие: Для {1} требуется {0} значени..",
+		"UNLOCK_CONDITION_ERROR2": "Следующее условие: Для {1} требуется ({0} * n) значений и n ссылок.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,46 +507,46 @@
 		"UNLOCK_CONDITION_AIWIN": "Побеждайте {0} бытв. ИИ, чтобы разблокировать этот товар! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "Играйте раз, чтобы разблокировать этот товар! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "Играйте раз, чтобы разблокировать этот товар! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "Играйте 2 раза, чтобы разблокировать этот товар! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Играйте {0} раз., чтобы разблокировать этот товар! ({1}/{0})", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} песню/е, чтобы разблокировать этот товар! ({2}/{1})", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} песн., чтобы разблокировать этот товар! ({2}/{1})", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} песню/е, чтобы разблокировать этот товар! ({2}/{0})", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} песн., чтобы разблокировать этот товар! ({2}/{0})", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} песню/е на {2} трудности, чтобы разблокировать этот товар! ({3}/{1})", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} песн. на {2} трудности, чтобы разблокировать этот товар! ({3}/{1})", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{1} песню/е на {2} трудности, чтобы разблокировать этот товар! ({3}/{0})", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "{1} {0} песн. на {2} трудности, чтобы разблокировать этот товар! ({3}/{0})", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} песню/е с {2} звезд., чтобы разблокировать этот товар! ({3}/{1})", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} песн. с {2} звезд., чтобы разблокировать этот товар! ({3}/{1})", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Получайте следующее представление, чтобы разблокировать этот товар:  ({0}/{1})", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "Получайте следующие представления, чтобы разблокировать этот товар:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} песню/е с рейтингом в {2} звезд., чтобы разблокировать этот товар! ({3}/{0})", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} песн. с рейтингом в {2} звезд., чтобы разблокировать этот товар! ({3}/{0})", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Получайте следующее представление, чтобы разблокировать этот товар:  ({1}/{0})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Получайте следующие представления, чтобы разблокировать этот товар:  ({1}/{0})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- {0} {1} на {2} трудности.", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} песню/е в папке {2}. ({3}/{1})", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} песн. в папке {2}. ({3}/{1})", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} партитуру/е сделано {2}. ({3}/{1})", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} партитур. сделано {2}. ({3}/{1})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {1} песню/е в папке {2}. ({3}/{0})", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {1} {0} песн. в папке {2}. ({3}/{0})", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} партитуру/е сделано {2}. ({3}/{0})", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {0} партитур. сделано {2}. ({3}/{0})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Играйте",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Играйте",

--- a/OpenTaiko/Lang/ru/lang.json
+++ b/OpenTaiko/Lang/ru/lang.json
@@ -486,38 +486,48 @@
 		"UNLOCK_COIN_BOUGHT": "Товар куплен!",
 		"UNLOCK_COIN_MORE": "Недостаточно монет!",
 
-		"UNLOCK_CONDITION_ERROR": "Следующее условие: Для {0} требуется {1} значения.",
-		"UNLOCK_CONDITION_ERROR2": "Следующее условие: Для {0} требуется ({1} * n) значения и n ссылок.",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "Следующее условие: Для {0} требуется значение.",
+		"UNLOCK_CONDITION_ERROR": "Следующее условие: Для {0} требуется {1} значени..",
+		"UNLOCK_CONDITION_ERROR2": "Следующее условие: Для {0} требуется ({1} * n) значений и n ссылок.",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "Получайте монету, чтобы разблокировать этот товар! ({1}/{0})", // ce
 		"UNLOCK_CONDITION_EARN": "Получайте в общей сложности {0} монет., чтобы разблокировать этот товар! ({1}/{0})", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "Играйте бытву ИИ, чтобы разблокировать этот товар! ({1}/{0})", // ap
 		"UNLOCK_CONDITION_AIPLAY": "Играйте {0} бытв. ИИ, чтобы разблокировать этот товар! ({1}/{0})", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "Побеждайте бытву ИИ, чтобы разблокировать этот товар! ({1}/{0})", // aw
 		"UNLOCK_CONDITION_AIWIN": "Побеждайте {0} бытв. ИИ, чтобы разблокировать этот товар! ({1}/{0})", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_PLAY_ONCE": "Играйте раз, чтобы разблокировать этот товар! ({1}/{0})", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "Играйте 2 раза, чтобы разблокировать этот товар! ({1}/{0})", // tp
 		"UNLOCK_CONDITION_PLAY": "Играйте {0} раз., чтобы разблокировать этот товар! ({1}/{0})", // tp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} песню/е, чтобы разблокировать этот товар! ({2}/{1})", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} песн., чтобы разблокировать этот товар! ({2}/{1})", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "{0} песню/е на {2} трудности, чтобы разблокировать этот товар! ({3}/{1})", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "{0} {1} песн. на {2} трудности, чтобы разблокировать этот товар! ({3}/{1})", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} песню/е с {2} звезд., чтобы разблокировать этот товар! ({3}/{1})", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} песн. с {2} звезд., чтобы разблокировать этот товар! ({3}/{1})", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE": "Получайте следующее представления, чтобы разблокировать этот товар:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "Получайте следующее представление, чтобы разблокировать этот товар:  ({0}/{1})", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "Получайте следующие представления, чтобы разблокировать этот товар:  ({0}/{1})", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
@@ -526,11 +536,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- {0} песню/е в папке {2}. ({3}/{1})", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- {0} {1} песн. в папке {2}. ({3}/{1})", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} партитуру/е сделано {2}. ({3}/{1})", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {1} партитур. сделано {2}. ({3}/{1})", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Играйте",

--- a/OpenTaiko/Lang/ru/lang.json
+++ b/OpenTaiko/Lang/ru/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "Русский (Russian)",
-	"Version":  "0.6.0.0",
+	"Version":  "0.6.0.16",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/ru/lang.json
+++ b/OpenTaiko/Lang/ru/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "Русский (Russian)",
-	"Version":  "0.6.0.16",
+	"Version":  "0.6.0.17",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -61,6 +61,7 @@
 		// {3}: # of score.ini files skipped
 		// {4}: # of score.ini files that failed to import due to an error
 		// {5}: Name of the current score.ini file being processed.
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2_SINGULAR": "正在处理 {0} 份成绩……\n<c.#0bb000>{1} ／ {2} 已处理</c>（<c.#f0ad4e>{3} 跳过</c> ／ <c.#b00000>{4} 失败</c>）\n\n{5}",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "正在处理 {0} 份成绩……\n<c.#0bb000>{1} ／ {2} 已处理</c>（<c.#f0ad4e>{3} 跳过</c> ／ <c.#b00000>{4} 失败</c>）\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "隐藏段位/塔",
@@ -409,6 +410,7 @@
 		"MODAL_TITLE_SONG": "获得新歌曲！",
 		// {0}: Newly obtained coins
 		// {1}: New total coin count
+		"MODAL_MESSAGE_COIN_SINGULAR": "+{0}金币（总计：{1}）",
 		"MODAL_MESSAGE_COIN": "+{0}金币（总计：{1}）",
 
 		// Online Lounge
@@ -473,6 +475,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_ALLSWAP": "所有大音符变成<c.#c800ff>交换</c>音符",
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "<c.#c4ffe2>ADLib</c>音符变为可视",
 		// {0}: # of auto-rolls per second
+		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL_SINGULAR": "自动以 1 打／秒<c.#ffff00>连打</c>",
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "自动以 {0} 打／秒<c.#ffff00>连打</c>",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>分开</c><c.#0088ff>跑道</c>",
 		// {0}: Coin multiplier
@@ -486,9 +489,9 @@
 		"UNLOCK_COIN_BOUGHT": "购买成功！",
 		"UNLOCK_COIN_MORE": "金币不足！",
 
-		"UNLOCK_CONDITION_ERROR_SINGULAR": "需求条件：{0}需要 1 个值。",
-		"UNLOCK_CONDITION_ERROR": "需求条件：{0}需要 {1} 个值。",
-		"UNLOCK_CONDITION_ERROR2": "需求条件：{0}需要（{1} × n）个值和 n 项参考。",
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "需求条件：{1}需要 1 个值。",
+		"UNLOCK_CONDITION_ERROR": "需求条件：{1}需要 {0} 个值。",
+		"UNLOCK_CONDITION_ERROR2": "需求条件：{1}需要（{0} × n）个值和 n 项参考。",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
@@ -504,46 +507,46 @@
 		"UNLOCK_CONDITION_AIWIN": "获胜 {0} 次 AI 对战以解锁该物品！（{1}／{0}）", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
-		"UNLOCK_CONDITION_PLAY_ONCE": "游玩 1 次以解锁该物品！（{1}／{0}）", // tp
+		"UNLOCK_CONDITION_PLAY_SINGULAR": "游玩 1 次以解锁该物品！（{1}／{0}）", // tp
 		"UNLOCK_CONDITION_PLAY_TWICE": "游玩 2 次以解锁该物品！（{1}／{0}）", // tp
 		"UNLOCK_CONDITION_PLAY": "游玩 {0} 次以解锁该物品！（{1}／{0}）", // tp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: Total plays needed
+		// {0}: Total plays needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Current progress
-		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} 1 首歌曲以解锁该物品！（{2}／{1}）", // sd
-		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} 首歌曲以解锁该物品！（{2}／{1}）", // sd
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{1} 1 首歌曲以解锁该物品！（{2}／{0}）", // sd
+		"UNLOCK_CONDITION_PLAYDISTINCT": "{1} {0} 首歌曲以解锁该物品！（{2}／{0}）", // sd
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "在{2}难度下{0} 1 首歌曲以解锁该物品！（{3}／{1}）", // dp
-		"UNLOCK_CONDITION_PLAYDIFF": "在{2}难度下{0} {1} 首歌曲以解锁该物品！（{3}／{1}）", // dp
-		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
-		// {1}: # of songs needed
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "在{2}难度下{1} 1 首歌曲以解锁该物品！（{3}／{0}）", // dp
+		"UNLOCK_CONDITION_PLAYDIFF": "在{2}难度下{1} {0} 首歌曲以解锁该物品！（{3}／{0}）", // dp
+		// {0}: # of songs needed
+		// {1}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} 1 首 {2} ★歌曲以解锁该物品！（{3}／{1}）", // lp
-		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} 首 {2} ★歌曲以解锁该物品！（{3}／{1}）", // lp
-		// {0}: Current progress
-		// {1}: Total # of challenges
-		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "获得以下表现以解锁该物品：　（{0}／{1}）", // sp, sg, sc
-		"UNLOCK_CONDITION_CHALLENGE": "获得以下表现以解锁该物品：　（{0}／{1}）", // sp, sg, sc
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{1} 1 首 {2} ★歌曲以解锁该物品！（{3}／{0}）", // lp
+		"UNLOCK_CONDITION_PLAYLEVEL": "{1} {0} 首 {2} ★歌曲以解锁该物品！（{3}／{0}）", // lp
+		// {0}: Total # of challenges
+		// {1}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "获得以下表现以解锁该物品：　（{1}／{0}）", // sp, sg, sc
+		"UNLOCK_CONDITION_CHALLENGE": "获得以下表现以解锁该物品：　（{1}／{0}）", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
 		// {2}: Difficulty type
 		"UNLOCK_CONDITION_CHALLENGE_PLAYDIFF": "- 在{2}难度下{0} {1} 。", // sp
-		// {0}: Clear type
-		// {1}: # of songs needed
+		// {0}: # of songs needed
+		// {1}: Clear type
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- 在文件夹 {2} 下{0} 1 首歌曲。（{3}／{1}）", // sg
-		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- 在文件夹 {2} 下{0} {1} 首歌曲。（{3}／{1}）", // sg
-		// {0}: Clear type
-		// {1} # of songs needed
-		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
-		// {3} Current progress
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} {2} 制作的 1 张谱面。（{3}／{1}）", // sc
-		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {2} 制作的 {1} 张谱面。（{3}／{1}）", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- 在文件夹 {2} 下{1} 1 首歌曲。（{3}／{0}）", // sg
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- 在文件夹 {2} 下{1} {0} 首歌曲。（{3}／{0}）", // sg
+		// {0}: # of songs needed
+		// {1}: Clear type
+		// {2}: Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
+		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {1} {2} 制作的 1 张谱面。（{3}／{0}）", // sc
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {1} {2} 制作的 {0} 张谱面。（{3}／{0}）", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "游玩",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "游玩",

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "中文 (Chinese)",
-	"Version":  "0.6.0.0",
+	"Version":  "0.6.0.16",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -7,7 +7,7 @@
   // "Language" should include the name of your language in its native text, as well as its English variant in parentheses.
   // i.e. "日本語 (Japanese)"
 	"Language": "中文 (Chinese)",
-	"Version":  "0.6.0.16",
+	"Version":  "0.6.0.17",
 	"Entries": {
 
 		// Common

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -486,37 +486,47 @@
 		"UNLOCK_COIN_BOUGHT": "购买成功！",
 		"UNLOCK_COIN_MORE": "金币不足！",
 
+		"UNLOCK_CONDITION_ERROR_SINGULAR": "需求条件：{0}需要 1 个值。",
 		"UNLOCK_CONDITION_ERROR": "需求条件：{0}需要 {1} 个值。",
 		"UNLOCK_CONDITION_ERROR2": "需求条件：{0}需要（{1} × n）个值和 n 项参考。",
 
 		// {0}: Coin earn requirement
 		// {1}: Current progress
+		"UNLOCK_CONDITION_EARN_SINGULAR": "获得金币以解锁该物品！（{1}／{0}）", // ce
 		"UNLOCK_CONDITION_EARN": "累计获得 {0} 金币以解锁该物品！（{1}／{0}）", // ce
 		// {0}: Total AI plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIPLAY_SINGULAR": "游玩 1 次 AI 对战以解锁该物品！（{1}／{0}）", // ap
 		"UNLOCK_CONDITION_AIPLAY": "游玩 {0} 次 AI 对战以解锁该物品！（{1}／{0}）", // ap
 		// {0}: Total AI wins needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_AIWIN_SINGULAR": "获胜 1 次 AI 对战以解锁该物品！（{1}／{0}）", // aw
 		"UNLOCK_CONDITION_AIWIN": "获胜 {0} 次 AI 对战以解锁该物品！（{1}／{0}）", // aw
 		// {0}: Total plays needed
 		// {1}: Current progress
+		"UNLOCK_CONDITION_PLAY_ONCE": "游玩 1 次以解锁该物品！（{1}／{0}）", // tp
+		"UNLOCK_CONDITION_PLAY_TWICE": "游玩 2 次以解锁该物品！（{1}／{0}）", // tp
 		"UNLOCK_CONDITION_PLAY": "游玩 {0} 次以解锁该物品！（{1}／{0}）", // tp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: Total plays needed
 		// {2}: Current progress
+		"UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR": "{0} 1 首歌曲以解锁该物品！（{2}／{1}）", // sd
 		"UNLOCK_CONDITION_PLAYDISTINCT": "{0} {1} 首歌曲以解锁该物品！（{2}／{1}）", // sd
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Difficulty type (i.e. Easy, Normal, Hard, Ex, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYDIFF_SINGULAR": "在{2}难度下{0} 1 首歌曲以解锁该物品！（{3}／{1}）", // dp
 		"UNLOCK_CONDITION_PLAYDIFF": "在{2}难度下{0} {1} 首歌曲以解锁该物品！（{3}／{1}）", // dp
 		// {0}: Clear type (i.e. Play, Clear, FC, Perfect, etc.)
 		// {1}: # of songs needed
 		// {2}: Star rating (i.e. 8*, 9*, 10*, etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_PLAYLEVEL_SINGULAR": "{0} 1 首 {2} ★歌曲以解锁该物品！（{3}／{1}）", // lp
 		"UNLOCK_CONDITION_PLAYLEVEL": "{0} {1} 首 {2} ★歌曲以解锁该物品！（{3}／{1}）", // lp
 		// {0}: Current progress
 		// {1}: Total # of challenges
+		"UNLOCK_CONDITION_CHALLENGE_SINGULAR": "获得以下表现以解锁该物品：　（{0}／{1}）", // sp, sg, sc
 		"UNLOCK_CONDITION_CHALLENGE": "获得以下表现以解锁该物品：　（{0}／{1}）", // sp, sg, sc
 		// {0}: Clear type
 		// {1}: Song name
@@ -526,11 +536,13 @@
 		// {1}: # of songs needed
 		// {2}: Genre name (i.e. "OpenTaiko Chapter II", "Dashy's Secrets", "Touhou Arrangements", etc.)
 		// {3}: Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR": "- 在文件夹 {2} 下{0} 1 首歌曲。（{3}／{1}）", // sg
 		"UNLOCK_CONDITION_CHALLENGE_PLAYGENRE": "- 在文件夹 {2} 下{0} {1} 首歌曲。（{3}／{1}）", // sg
 		// {0}: Clear type
 		// {1} # of songs needed
 		// {2} Charter name (i.e. Komi, bol, Dashy, Colin, etc.)
 		// {3} Current progress
+		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR": "- {0} {2} 制作的 1 张谱面。（{3}／{1}）", // sc
 		"UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER": "- {0} {2} 制作的 {1} 张谱面。（{3}／{1}）", // sc
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "游玩",

--- a/OpenTaiko/src/Databases/DBUnlockables.cs
+++ b/OpenTaiko/src/Databases/DBUnlockables.cs
@@ -130,52 +130,38 @@ class DBUnlockables {
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.Medals }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "ce":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.TotalEarnedMedals }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "ap":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.AIBattleModePlaycount }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "aw":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.AIBattleModeWins }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "tp":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.TotalPlaycount }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "sd":
 					if (this.Values.Length == 2)
 						return tConditionMet(new int[] { tGetCountChartsPassingCondition(player) }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "dp":
 				case "lp":
 					if (this.Values.Length == 3)
 						return tConditionMet(new int[] { tGetCountChartsPassingCondition(player) }, screen);
 					else
-						if (this.RequiredArgCount == 1)
-							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount.ToString(), this.Condition));
 				case "sp":
 				case "sg":
 				case "sc":
@@ -183,7 +169,7 @@ class DBUnlockables {
 						&& this.Reference.Length == this.Values.Length / this.RequiredArgCount)
 						return tConditionMet(new int[] { tGetCountChartsPassingCondition(player) }, screen);
 					else
-						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR2", this.Condition, this.RequiredArgCount.ToString()));
+						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR2", this.RequiredArgCount.ToString(), this.Condition));
 				case "ig":
 					return (false, "");
 			}
@@ -299,9 +285,7 @@ class DBUnlockables {
 				RequiredArgCount = RequiredArgs[Condition];
 
 			if (this.Values.Length < this.RequiredArgCount)
-				if (this.RequiredArgCount == 1)
-					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount);
-				return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount);
+				return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.RequiredArgCount, this.Condition);
 
 			// Only the player loaded as 1P can check unlockables in real time
 			var SaveData = OpenTaiko.SaveFileInstances[OpenTaiko.SaveFile].data;
@@ -323,24 +307,13 @@ class DBUnlockables {
 							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_COST", this.Values[0]);
 						return (CLangManager.LangInstance.GetString("UNLOCK_CONDITION_INVALID"));
 					}
-				case "ce": {
-						if (this.Values[0] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_EARN_SINGULAR", this.Values[0], SaveData.TotalEarnedMedals);
-						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_EARN", this.Values[0], SaveData.TotalEarnedMedals);
-					}
-				case "ap": {
-						if (this.Values[0] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIPLAY_SINGULAR", this.Values[0], SaveData.AIBattleModePlaycount);
-						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIPLAY", this.Values[0], SaveData.AIBattleModePlaycount);
-					}
-				case "aw": {
-						if (this.Values[0] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIWIN_SINGULAR", this.Values[0], SaveData.AIBattleModeWins);
-						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIWIN", this.Values[0], SaveData.AIBattleModeWins);
-					}
+				case "ce":
+					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_EARN", this.Values[0], SaveData.TotalEarnedMedals);
+				case "ap":
+					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIPLAY", this.Values[0], SaveData.AIBattleModePlaycount);
+				case "aw":
+					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIWIN", this.Values[0], SaveData.AIBattleModeWins);
 				case "tp": {
-						if (this.Values[0] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY_ONCE", this.Values[0], SaveData.TotalPlaycount);
 						if (this.Values[0] == 2)
 							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY_TWICE", this.Values[0], SaveData.TotalPlaycount);
 						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY", this.Values[0], SaveData.TotalPlaycount);
@@ -361,9 +334,7 @@ class DBUnlockables {
 						var _count = _values[_aimedStatus];
 						var statusString = GetRequiredClearStatus(_aimedStatus);
 
-						if (this.Values[0] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR", statusString, this.Values[0], _count);
-						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDISTINCT", statusString, this.Values[0], _count);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDISTINCT", this.Values[0], statusString, _count);
 					}
 				case "dp": {
 						var _aimedDifficulty = this.Values[0];
@@ -382,9 +353,7 @@ class DBUnlockables {
 
 						var diffString = (_aimedDifficulty == (int)Difficulty.Oni) ? CLangManager.LangInstance.GetString("DIFF_EXEXTRA") : CLangManager.LangInstance.GetDifficulty(_aimedDifficulty);
 						var statusString = GetRequiredClearStatus(_aimedStatus);
-						if (this.Values[2] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDIFF_SINGULAR", statusString, this.Values[2], diffString, _count);
-						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDIFF", statusString, this.Values[2], diffString, _count);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDIFF", this.Values[2], statusString, diffString, _count);
 					}
 				case "lp": {
 						var _aimedDifficulty = this.Values[0];
@@ -399,9 +368,7 @@ class DBUnlockables {
 						else _count = ChartStats.LevelPerfects.TryGetValue(_aimedDifficulty, out var value) ? value : 0;
 
 						var statusString = GetRequiredClearStatus(_aimedStatus);
-						if (this.Values[2] == 1)
-							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYLEVEL_SINGULAR", statusString, this.Values[2], _aimedDifficulty, _count);
-						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYLEVEL", statusString, this.Values[2], _aimedDifficulty, _count);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYLEVEL", this.Values[2], statusString, _aimedDifficulty, _count);
 					}
 				case "sp": {
 						List<string> _rows = new List<string>();
@@ -440,10 +407,7 @@ class DBUnlockables {
 						}
 
 						// Push front
-						if (_challengeCount == 1)
-							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_SINGULAR", _count, _challengeCount));
-						else
-							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
+						_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _challengeCount, _count));
 						return String.Join("\n", _rows);
 					}
 				case "sg": {
@@ -467,16 +431,10 @@ class DBUnlockables {
 
 
 							var statusString = GetRequiredClearStatus(_aimedStatus);
-							if (_songCount == 1)
-								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR", statusString, _songCount, _genreName, _satifsiedCount));
-							else
-								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYGENRE", statusString, _songCount, _genreName, _satifsiedCount));
+							_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYGENRE", _songCount, statusString, _genreName, _satifsiedCount));
 						}
 
-						if (_challengeCount == 1)
-							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_SINGULAR", _count, _challengeCount));
-						else
-							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
+						_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _challengeCount, _count));
 						return String.Join("\n", _rows);
 					}
 				case "sc": {
@@ -500,16 +458,10 @@ class DBUnlockables {
 
 
 							var statusString = GetRequiredClearStatus(_aimedStatus);
-							if (_songCount == 1)
-								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR", statusString, _songCount, _charterName, _satifsiedCount));
-							else
-								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER", statusString, _songCount, _charterName, _satifsiedCount));
+							_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER", _songCount, statusString, _charterName, _satifsiedCount));
 						}
 
-						if (_challengeCount == 1)
-							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_SINGULAR", _count, _challengeCount));
-						else
-							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
+						_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _challengeCount, _count));
 						return String.Join("\n", _rows);
 					}
 

--- a/OpenTaiko/src/Databases/DBUnlockables.cs
+++ b/OpenTaiko/src/Databases/DBUnlockables.cs
@@ -130,37 +130,51 @@ class DBUnlockables {
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.Medals }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "ce":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.TotalEarnedMedals }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "ap":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.AIBattleModePlaycount }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "aw":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.AIBattleModeWins }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "tp":
 					if (this.Values.Length == 1)
 						return tConditionMet(new int[] { (int)OpenTaiko.SaveFileInstances[player].data.TotalPlaycount }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "sd":
 					if (this.Values.Length == 2)
 						return tConditionMet(new int[] { tGetCountChartsPassingCondition(player) }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "dp":
 				case "lp":
 					if (this.Values.Length == 3)
 						return tConditionMet(new int[] { tGetCountChartsPassingCondition(player) }, screen);
 					else
+						if (this.RequiredArgCount == 1)
+							return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount.ToString()));
 						return (false, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount.ToString()));
 				case "sp":
 				case "sg":
@@ -285,6 +299,8 @@ class DBUnlockables {
 				RequiredArgCount = RequiredArgs[Condition];
 
 			if (this.Values.Length < this.RequiredArgCount)
+				if (this.RequiredArgCount == 1)
+					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR_SINGULAR", this.Condition, this.RequiredArgCount);
 				return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_ERROR", this.Condition, this.RequiredArgCount);
 
 			// Only the player loaded as 1P can check unlockables in real time
@@ -307,14 +323,28 @@ class DBUnlockables {
 							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_COST", this.Values[0]);
 						return (CLangManager.LangInstance.GetString("UNLOCK_CONDITION_INVALID"));
 					}
-				case "ce":
-					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_EARN", this.Values[0], SaveData.TotalEarnedMedals);
-				case "ap":
-					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIPLAY", this.Values[0], SaveData.AIBattleModePlaycount);
-				case "aw":
-					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIWIN", this.Values[0], SaveData.AIBattleModeWins);
-				case "tp":
-					return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY", this.Values[0], SaveData.TotalPlaycount);
+				case "ce": {
+						if (this.Values[0] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_EARN_SINGULAR", this.Values[0], SaveData.TotalEarnedMedals);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_EARN", this.Values[0], SaveData.TotalEarnedMedals);
+					}
+				case "ap": {
+						if (this.Values[0] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIPLAY_SINGULAR", this.Values[0], SaveData.AIBattleModePlaycount);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIPLAY", this.Values[0], SaveData.AIBattleModePlaycount);
+					}
+				case "aw": {
+						if (this.Values[0] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIWIN_SINGULAR", this.Values[0], SaveData.AIBattleModeWins);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_AIWIN", this.Values[0], SaveData.AIBattleModeWins);
+					}
+				case "tp": {
+						if (this.Values[0] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY_ONCE", this.Values[0], SaveData.TotalPlaycount);
+						if (this.Values[0] == 2)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY_TWICE", this.Values[0], SaveData.TotalPlaycount);
+						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAY", this.Values[0], SaveData.TotalPlaycount);
+					}
 				case "sd": {
 						var _aimedStatus = this.Values[1];
 
@@ -331,6 +361,8 @@ class DBUnlockables {
 						var _count = _values[_aimedStatus];
 						var statusString = GetRequiredClearStatus(_aimedStatus);
 
+						if (this.Values[0] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDISTINCT_SINGULAR", statusString, this.Values[0], _count);
 						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDISTINCT", statusString, this.Values[0], _count);
 					}
 				case "dp": {
@@ -350,6 +382,8 @@ class DBUnlockables {
 
 						var diffString = (_aimedDifficulty == (int)Difficulty.Oni) ? CLangManager.LangInstance.GetString("DIFF_EXEXTRA") : CLangManager.LangInstance.GetDifficulty(_aimedDifficulty);
 						var statusString = GetRequiredClearStatus(_aimedStatus);
+						if (this.Values[2] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDIFF_SINGULAR", statusString, this.Values[2], diffString, _count);
 						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYDIFF", statusString, this.Values[2], diffString, _count);
 					}
 				case "lp": {
@@ -365,6 +399,8 @@ class DBUnlockables {
 						else _count = ChartStats.LevelPerfects.TryGetValue(_aimedDifficulty, out var value) ? value : 0;
 
 						var statusString = GetRequiredClearStatus(_aimedStatus);
+						if (this.Values[2] == 1)
+							return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYLEVEL_SINGULAR", statusString, this.Values[2], _aimedDifficulty, _count);
 						return CLangManager.LangInstance.GetString("UNLOCK_CONDITION_PLAYLEVEL", statusString, this.Values[2], _aimedDifficulty, _count);
 					}
 				case "sp": {
@@ -404,7 +440,10 @@ class DBUnlockables {
 						}
 
 						// Push front
-						_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
+						if (_challengeCount == 1)
+							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_SINGULAR", _count, _challengeCount));
+						else
+							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
 						return String.Join("\n", _rows);
 					}
 				case "sg": {
@@ -428,10 +467,16 @@ class DBUnlockables {
 
 
 							var statusString = GetRequiredClearStatus(_aimedStatus);
-							_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYGENRE", statusString, _songCount, _genreName, _satifsiedCount));
+							if (_songCount == 1)
+								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYGENRE_SINGULAR", statusString, _songCount, _genreName, _satifsiedCount));
+							else
+								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYGENRE", statusString, _songCount, _genreName, _satifsiedCount));
 						}
 
-						_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
+						if (_challengeCount == 1)
+							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_SINGULAR", _count, _challengeCount));
+						else
+							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
 						return String.Join("\n", _rows);
 					}
 				case "sc": {
@@ -455,10 +500,16 @@ class DBUnlockables {
 
 
 							var statusString = GetRequiredClearStatus(_aimedStatus);
-							_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER", statusString, _songCount, _charterName, _satifsiedCount));
+							if (_songCount == 1)
+								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER_SINGULAR", statusString, _songCount, _charterName, _satifsiedCount));
+							else
+								_rows.Add(CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_PLAYCHARTER", statusString, _songCount, _charterName, _satifsiedCount));
 						}
 
-						_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
+						if (_challengeCount == 1)
+							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE_SINGULAR", _count, _challengeCount));
+						else
+							_rows.Insert(0, CLangManager.LangInstance.GetString("UNLOCK_CONDITION_CHALLENGE", _count, _challengeCount));
 						return String.Join("\n", _rows);
 					}
 

--- a/OpenTaiko/src/I18N/CLang.cs
+++ b/OpenTaiko/src/I18N/CLang.cs
@@ -62,6 +62,11 @@ internal class CLang {
 		return (Entries.TryGetValue(key, out string? value)) ? value : InvalidKey.SafeFormat(key);
 	}
 	public string GetString(string key, params object?[] values) {
+		if (Object.Equals(values[0], 1)) { // Only the first parameter is going to be judged either singular or plural.
+			if (Entries.TryGetValue(key + "_SINGULAR", out string? _value)) {
+				return _value.SafeFormat(values);
+			}
+		}
 		return (Entries.TryGetValue(key, out string? value)) ? value.SafeFormat(values) : InvalidKey.SafeFormat(key);
 	}
 

--- a/OpenTaiko/src/I18N/CLang.cs
+++ b/OpenTaiko/src/I18N/CLang.cs
@@ -62,12 +62,15 @@ internal class CLang {
 		return (Entries.TryGetValue(key, out string? value)) ? value : InvalidKey.SafeFormat(key);
 	}
 	public string GetString(string key, params object?[] values) {
-		if (Object.Equals(values[0], 1)) { // Only the first parameter is going to be judged either singular or plural.
-			if (Entries.TryGetValue(key + "_SINGULAR", out string? _value)) {
-				return _value.SafeFormat(values);
-			}
-		}
+		key += GetCountingSuffix(key, values[0]); // Only the parameter {0} is going to be judged.
 		return (Entries.TryGetValue(key, out string? value)) ? value.SafeFormat(values) : InvalidKey.SafeFormat(key);
+	}
+
+	private string GetCountingSuffix(string key, object? value) {
+		if (Object.Equals(value, 1) && (Entries.TryGetValue(key + "_SINGULAR", out _)) == true) {
+			return "_SINGULAR";
+		}
+		return "";
 	}
 
 	public string GetDifficulty(int diff) {


### PR DESCRIPTION
It needs to provide unlockable conditions in singular form for English. This could be also helpful to French, Spanish, Dutch, German, Russian and other European languages that take grammar important. Therefore Japanese, Chinese and Korean only moved a few as East Asian Languages.
It is very important to provide singular form, even if the users can comprehend before this. My software testing textbook couldn’t ignore emphasizing this in L12N module as well. Some might not tend to be used, like `UNLOCK_CONDITION_EARN_SINGULAR`, but it does not mean there is no one may use this.
In Russian, singular omits the quantity in default as it does not have articles like a/an and the (or _le_/_la_/_l’_, _les_, _un(e)_ and _des_ in French). There is no intention to solve casing problems in this PR.
Please @Morphclue provide your text after this PR is merged.