### PR TITLE
workflow: iterate for each pushed commit; fix deprecation; prevent extra empty lines, again

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -16,6 +16,10 @@ jobs:
       # added or changed files to the repository.
       contents: write
 
+    env:
+      messagePathPrefix: COMMIT_MSG_
+      versionsPath: COMMIT_VERSIONS
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -30,33 +34,21 @@ jobs:
         run: |
           dir
 
-      - name: Get commit subject for version checking
-        id: get-latest-commit
+      - name: Get each commit message for version checking
+        id: get-latest-commits
         run: |
-          $latestCommitMessage = git log -1 --pretty=format:%s
-          echo "latest_commit_message=$latestCommitMessage" >> $env:GITHUB_ENV
-
-      - name: Extract version from commit message
-        id: extract-version
-        run: |
-          $commitMessage = $env:latest_commit_message
-          if ($commitMessage -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
-            $version = $matches['version']
-            Write-Host "Extracted version is: $version"
-            echo "version=$version" >> $env:GITHUB_ENV
-          } else {
-            Write-Host "No valid version found in the latest commit message. Skipping bump."
-            echo "version=" >> $env:GITHUB_ENV
+          $messages = ConvertFrom-Json $env:messagesJson
+          $nMessages = $messages.Count
+          echo "nMessages=$nMessages" >> $env:GITHUB_ENV
+          for ($c = 0; $c -lt $nMessages; ++$c) {
+              New-Item -Path ($env:messagePathPrefix + $c) -Type file
+              $message = $messages | Select-Object -Index $c
+              echo $message > ($env:messagePathPrefix + $c)
           }
+        env:
+          messagesJson: ${{ toJSON(github.event.commits.*.message) }}
 
-      - name: Bump OpenTaiko version if necessary
-        if: env.version != ''
-        run: |
-          $newVersion = $env:version
-          Write-Host "Updating version in OpenTaiko.csproj to $newVersion"
-          (Get-Content OpenTaiko/OpenTaiko.csproj) -replace '<Version>.*<\/Version>', "<Version>$newVersion</Version>" | Set-Content OpenTaiko/OpenTaiko.csproj
-
-      - name: Get version
+      - name: Get project version
         uses: kzrnm/get-net-sdk-project-versions-action@v2
         id: get-version
         with:
@@ -66,49 +58,78 @@ jobs:
         run: |
           echo "projectVersion=${{ steps.get-version.outputs.version }}" >> $env:GITHUB_ENV
 
+      - name: Extract latest version info from each commit message
+        id: extract-versions
+        run: |
+          $hasVersion = $false
+          $version = $env:projectVersion
+          New-Item -Path $env:versionsPath -Type file
+          for ($c = 0; $c -lt $env:nMessages; ++$c) {
+              $commitSubject = Get-Content -Path ($env:messagePathPrefix + $c) | Select-Object -First 1
+              if ($commitSubject -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
+                  $hasVersion = $true
+                  $version = $matches['version']
+              }
+              if ($c -eq 0) {
+                  echo "versionFirst=$version" >> $env:GITHUB_ENV
+              }
+              echo $version >> $env:versionsPath
+          }
+
+          # check the latest version
+          if ($hasVersion) {
+              Write-Host "Extracted latest version is: $version"
+              echo "version=$version" >> $env:GITHUB_ENV
+          } else {
+              Write-Host "No valid version found in the latest commit messages. Skipping bump."
+              echo "version=" >> $env:GITHUB_ENV
+          }
+          echo "versionLast=$version" >> $env:GITHUB_ENV
+
+      - name: Bump OpenTaiko version if necessary
+        if: env.version != ''
+        run: |
+          $newVersion = $env:version
+          Write-Host "Updating version in OpenTaiko.csproj to $newVersion"
+          (Get-Content OpenTaiko/OpenTaiko.csproj) -replace '<Version>.*<\/Version>', "<Version>$newVersion</Version>" | Set-Content OpenTaiko/OpenTaiko.csproj
+
       - name: Get current date
         id: get-date
         run: |
           $date = Get-Date -Format "yyyy-MM-dd"
           echo "date=$date" >> $env:GITHUB_ENV
 
-      - name: Get changelogs from commit description
-        id: get-commit-message
-        run: |
-          $message = git log -1 --pretty=%b
-          $messagePath = 'COMMIT_MSG'
-          echo $message >> $messagePath
-          echo "messagePath=$messagePath" >> $env:GITHUB_ENV
-
       - name: Update CHANGELOG.md
         run: |
-          $version = $env:projectVersion
+          $versions = Get-Content -Path $env:versionsPath
           $date = $env:date
-          $messagePath = $env:messagePath
           $changelogPath = "CHANGELOG.md"
 
-          # Read commit description content
-          $messageLines = Get-Content -Path $messagePath
+          for ($c = 0; $c -lt $env:nMessages; ++$c) {
+              # (Re-)read CHANGELOG.md content as (re-)split lines
+              $changelog = Get-Content -Path $changelogPath
 
-          # Read CHANGELOG.md content
-          $changelog = Get-Content -Path $changelogPath
+              # Read the message as individual items
+              $commitBody = Get-Content -Path ($env:messagePathPrefix + $c) | Select-Object -Skip 1
 
-          # Remove empty lines from the message
-          $message = ($messageLines | Where-Object { $_ -ne "" }) -join "`n"
+              # Remove empty lines from the message
+              $message = ($commitBody | Where-Object { $_ -ne "" }) -join "`n"
 
-          # Check if the version already exists
-          if ($changelog -match "## \[$version\]") {
-              if ($message) {
-                  # Capture the existing content under the version heading
-                  $changelog = $changelog -replace "(## \[($version)\] .* \(Beta\))", "`$1`n`n$message"
+              # Check if the version already exists
+              $version = $versions | Select-Object -Index $c
+              if ($changelog -match "## \[$version\]") {
+                  if ($message) {
+                      # Capture the existing content under the version heading
+                      $changelog = $changelog -replace "(## \[($version)\] .* \(Beta\))", "`$1`n`n$message"
+                  }
+              } else {
+                  # Insert new version under '# Changelog'
+                  $changelog = $changelog -replace "(# Changelog)", "`$1`n`n## [$version] - $date (Beta)`n`n$message"
               }
-          } else {
-              # Insert new version under '# Changelog'
-              $changelog = $changelog -replace "(# Changelog)", "`$1`n`n## [$version] - $date (Beta)`n`n$message"
-          }
 
-          # Write updated content back to CHANGELOG.md
-          Set-Content -Path $changelogPath -Value $changelog
+              # Write updated content back to CHANGELOG.md
+              Set-Content -Path $changelogPath -Value $changelog
+          }
 
       - name: Commit CHANGELOG.md and OpenTaiko.csproj changes
         run: |
@@ -116,7 +137,11 @@ jobs:
           git config --global user.email "actions@github.com"
           git add OpenTaiko/OpenTaiko.csproj
           git add CHANGELOG.md
-          git commit -m "Update changelog for version $env:projectVersion"
+          if ($env:versionLast -eq $env:versionFirst) {
+              git commit -m "Update changelog for version $env:versionLast"
+          } else {
+              git commit -m "Update changelog for versions $env:versionFirst to $env:versionLast"
+          }
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
 
       - name: Build for Windows x64

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -1,5 +1,3 @@
-# Original script from totoa553/OpenTaiko and DragonRatTiger/OpenTaiko
-
 name: Build OpenTaiko
 
 on:
@@ -12,8 +10,6 @@ jobs:
     runs-on: windows-latest
 
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
       contents: write
 
     steps:
@@ -34,24 +30,25 @@ jobs:
         id: get-latest-commit
         run: |
           $latestCommitMessage = git log -1 --pretty=format:%s
-          echo "latest_commit_message=$latestCommitMessage" >> $GITHUB_ENV
+          echo "latest_commit_message=$latestCommitMessage" >> $env:GITHUB_ENV
 
       - name: Extract version from commit message
         id: extract-version
         run: |
-          if ('${{ steps.get-latest-commit.outputs.latest_commit_message }}' -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
+          $commitMessage = $env:latest_commit_message
+          if ($commitMessage -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
             $version = $matches['version']
             Write-Host "Extracted version is: $version"
-            echo "version=$version" >> $GITHUB_ENV
+            echo "version=$version" >> $env:GITHUB_ENV
           } else {
             Write-Host "No valid version found in the latest commit message. Skipping bump."
-            echo "version=" >> $GITHUB_ENV
+            echo "version=" >> $env:GITHUB_ENV
           }
 
       - name: Bump OpenTaiko version if necessary
-        if: steps.extract-version.outputs.version != ''
+        if: env.version != ''
         run: |
-          $newVersion = "${{ steps.extract-version.outputs.version }}"
+          $newVersion = $env:version
           Write-Host "Updating version in OpenTaiko.csproj to $newVersion"
           (Get-Content OpenTaiko/OpenTaiko.csproj) -replace '<Version>.*<\/Version>', "<Version>$newVersion</Version>" | Set-Content OpenTaiko/OpenTaiko.csproj
 
@@ -65,7 +62,7 @@ jobs:
         id: get-date
         run: |
           $date = Get-Date -Format "yyyy-MM-dd"
-          echo "date=$date" >> $GITHUB_ENV
+          echo "date=$date" >> $env:GITHUB_ENV
 
       - name: Get changelogs from commit description
         id: get-commit-message
@@ -77,8 +74,8 @@ jobs:
 
       - name: Update CHANGELOG.md
         run: |
-          $version = '${{steps.get-version.outputs.version}}'
-          $date = '${{steps.get-date.outputs.date}}'
+          $version = $env:version
+          $date = $env:date
           $messagePath = $env:messagePath
           $changelogPath = "CHANGELOG.md"
 
@@ -104,68 +101,3 @@ jobs:
 
           # Write updated content back to CHANGELOG.md
           Set-Content -Path $changelogPath -Value $changelog
-
-      - name: Commit CHANGELOG.md and OpenTaiko.csproj changes
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "actions@github.com"
-          git add OpenTaiko/OpenTaiko.csproj
-          git add CHANGELOG.md
-          git commit -m "Update changelog for version ${{steps.get-version.outputs.version}}"
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
-
-
-      - name: Build for Windows x64
-        shell: cmd
-        run: |
-          build-win-x64.bat
-
-      - name: Create Archive (Win x64)
-        shell: cmd
-        run: |
-          cd OpenTaiko\bin\Release\net8.0\win-x64\
-          7z a ../../../../../OpenTaiko.Win.x64.zip publish/ -xr!publish/Songs/ -xr!publish/FFmpeg/ -xr!publish/System/ -xr!publish/Libs/
-          7z u ../../../../../OpenTaiko.Win.x64.zip "publish/Libs/win-x64/*" "publish/FFmpeg/win-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*"
-          cd ..\..\..\..\..\
-
-      - name: Build for Linux x64
-        shell: cmd
-        run: |
-          build-linux-x64.bat
-
-      - name: Create Archive (Linux x64)
-        shell: cmd
-        run: |
-          cd OpenTaiko\bin\Release\net8.0\linux-x64\
-          7z a ../../../../../OpenTaiko.Linux.x64.zip publish/ -xr!publish/Songs/ -xr!publish/FFmpeg/ -xr!publish/System/ -xr!publish/Libs/
-          7z u ../../../../../OpenTaiko.Linux.x64.zip "publish/Libs/linux-x64/*" "publish/FFmpeg/linux-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*"
-          cd ..\..\..\..\..\
-
-      - name: Check if tag exists
-        uses: mukunku/tag-exists-action@v1.6.0
-        id: check-tag
-        with:
-          tag: "${{steps.get-version.outputs.version}}"
-
-      - name: Create Release
-        if: steps.check-tag.outputs.exists == 'false'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: "${{steps.get-version.outputs.version}}"
-          release_name: OpenTaiko v${{steps.get-version.outputs.version}}
-          body: |
-            Note: The releases do not contain skins nor songs.
-            Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
-          draft: false
-          prerelease: false
-
-      - name: Upload All Builds
-        uses: xresloader/upload-to-github-release@v1.6.0
-        with:
-          file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
-          overwrite: true
-          tag_name: "${{steps.get-version.outputs.version}}"
-          draft: false
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -1,3 +1,5 @@
+# Original script from totoa553/OpenTaiko and DragonRatTiger/OpenTaiko
+
 name: Build OpenTaiko
 
 on:
@@ -10,6 +12,8 @@ jobs:
     runs-on: windows-latest
 
     permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
       contents: write
 
     steps:
@@ -101,3 +105,67 @@ jobs:
 
           # Write updated content back to CHANGELOG.md
           Set-Content -Path $changelogPath -Value $changelog
+
+      - name: Commit CHANGELOG.md and OpenTaiko.csproj changes
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+          git add OpenTaiko/OpenTaiko.csproj
+          git add CHANGELOG.md
+          git commit -m "Update changelog for version $env.version"
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
+
+      - name: Build for Windows x64
+        shell: cmd
+        run: |
+          build-win-x64.bat
+
+      - name: Create Archive (Win x64)
+        shell: cmd
+        run: |
+          cd OpenTaiko\bin\Release\net8.0\win-x64\
+          7z a ../../../../../OpenTaiko.Win.x64.zip publish/ -xr!publish/Songs/ -xr!publish/FFmpeg/ -xr!publish/System/ -xr!publish/Libs/
+          7z u ../../../../../OpenTaiko.Win.x64.zip "publish/Libs/win-x64/*" "publish/FFmpeg/win-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*"
+          cd ..\..\..\..\..\
+
+      - name: Build for Linux x64
+        shell: cmd
+        run: |
+          build-linux-x64.bat
+
+      - name: Create Archive (Linux x64)
+        shell: cmd
+        run: |
+          cd OpenTaiko\bin\Release\net8.0\linux-x64\
+          7z a ../../../../../OpenTaiko.Linux.x64.zip publish/ -xr!publish/Songs/ -xr!publish/FFmpeg/ -xr!publish/System/ -xr!publish/Libs/
+          7z u ../../../../../OpenTaiko.Linux.x64.zip "publish/Libs/linux-x64/*" "publish/FFmpeg/linux-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*"
+          cd ..\..\..\..\..\
+
+      - name: Check if tag exists
+        uses: mukunku/tag-exists-action@v1.6.0
+        id: check-tag
+        with:
+          tag: $env:version
+
+      - name: Create Release
+        if: steps.check-tag.outputs.exists == 'false'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: $env.version
+          release_name: OpenTaiko v$env.version
+          body: |
+            Note: The releases do not contain skins nor songs.
+            Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
+          draft: false
+          prerelease: false
+
+      - name: Upload All Builds
+        uses: xresloader/upload-to-github-release@v1.6.0
+        with:
+          file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
+          overwrite: true
+          tag_name: $env.version
+          draft: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -34,7 +34,7 @@ jobs:
         id: get-latest-commit
         run: |
           $latestCommitMessage = git log -1 --pretty=format:%s
-          echo "latest_commit_message=$latestCommitMessage" >> $GITHUB_OUTPUT
+          echo "latest_commit_message=$latestCommitMessage" >> $GITHUB_ENV
 
       - name: Extract version from commit message
         id: extract-version
@@ -42,10 +42,10 @@ jobs:
           if ('${{ steps.get-latest-commit.outputs.latest_commit_message }}' -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
             $version = $matches['version']
             Write-Host "Extracted version is: $version"
-            echo "version=$version" >> $GITHUB_OUTPUT
+            echo "version=$version" >> $GITHUB_ENV
           } else {
             Write-Host "No valid version found in the latest commit message. Skipping bump."
-            echo "version=" >> $GITHUB_OUTPUT
+            echo "version=" >> $GITHUB_ENV
           }
 
       - name: Bump OpenTaiko version if necessary
@@ -65,7 +65,7 @@ jobs:
         id: get-date
         run: |
           $date = Get-Date -Format "yyyy-MM-dd"
-          echo "date=$date" >> $GITHUB_OUTPUT
+          echo "date=$date" >> $GITHUB_ENV
 
       - name: Get changelogs from commit description
         id: get-commit-message

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -162,7 +162,7 @@ jobs:
           prerelease: false
 
       - name: Upload All Builds
-        uses: xresloader/upload-to-github-release@v1.4.2
+        uses: xresloader/upload-to-github-release@v1.6.0
         with:
           file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
           overwrite: true

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -112,7 +112,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git add OpenTaiko/OpenTaiko.csproj
           git add CHANGELOG.md
-          git commit -m "Update changelog for version $env.version"
+          git commit -m "Update changelog for version $env:version"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
 
       - name: Build for Windows x64
@@ -145,7 +145,7 @@ jobs:
         uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
         with:
-          tag: $env:version
+          tag: ${{ env.version }}
 
       - name: Create Release
         if: steps.check-tag.outputs.exists == 'false'
@@ -153,8 +153,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: $env.version
-          release_name: OpenTaiko v$env.version
+          tag_name: ${{ env.version }}
+          release_name: OpenTaiko v${{ env.version }}
           body: |
             Note: The releases do not contain skins nor songs.
             Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
@@ -166,6 +166,6 @@ jobs:
         with:
           file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
           overwrite: true
-          tag_name: $env.version
+          tag_name: ${{ env.version }}
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -209,7 +209,7 @@ jobs:
         uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
         with:
-          tag: ${{ env.projectVersion }}
+          tag: ${{ env.version }}
 
       - name: Create Release
         if: steps.check-tag.outputs.exists == 'false' && env.version != ''
@@ -217,8 +217,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.projectVersion }}
-          release_name: OpenTaiko v${{ env.projectVersion }}
+          tag_name: ${{ env.version }}
+          release_name: OpenTaiko v${{ env.version }}
           body: |
             Note: The releases do not contain skins nor songs.
             Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
@@ -226,10 +226,11 @@ jobs:
           prerelease: false
 
       - name: Upload All Builds
+        if: steps.check-tag.outputs.exists == 'false' && env.version != ''
         uses: xresloader/upload-to-github-release@v1.6.0
         with:
           file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
           overwrite: true
-          tag_name: ${{ env.projectVersion }}
+          tag_name: ${{ env.version }}
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -148,7 +148,7 @@ jobs:
           tag: ${{ env.version }}
 
       - name: Create Release
-        if: steps.check-tag.outputs.exists == 'false'
+        if: steps.check-tag.outputs.exists == 'false' && env.version != ''
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -105,9 +105,13 @@ jobs:
           $date = $env:date
           $changelogPath = "CHANGELOG.md"
 
-          for ($c = 0; $c -lt $env:nMessages; ++$c) {
+          :commit for ($c = 0; $c -lt $env:nMessages; ++$c) {
               # (Re-)read CHANGELOG.md content as (re-)split lines
               $changelog = Get-Content -Path $changelogPath
+              # Ensure list type for []-indexing
+              if ($changelog.Count -eq 1) {
+                  $changelog = , $changelog
+              }
 
               # Read the message as individual items
               $commitBody = Get-Content -Path ($env:messagePathPrefix + $c) | Select-Object -Skip 1
@@ -117,18 +121,49 @@ jobs:
 
               # Check if the version already exists
               $version = $versions | Select-Object -Index $c
-              if ($changelog -match "## \[$version\]") {
-                  if ($message) {
-                      # Capture the existing content under the version heading
-                      $changelog = $changelog -replace "(## \[($version)\] .* \(Beta\))", "`$1`n`n$message"
+              for ($i = 0; $i -lt $changelog.Count; ++$i) {
+                  if (-not ($changelog[$i] -match "## \[$version\]")) {
+                      continue
                   }
-              } else {
-                  # Insert new version under '# Changelog'
-                  $changelog = $changelog -replace "(# Changelog)", "`$1`n`n## [$version] - $date (Beta)`n`n$message"
+                  # Capture the existing content under the version heading
+                  if ($message) {
+                      # Append after the empty line (if exist) or the heading
+                      $di = ($changelog[$i + 1] -eq "")
+                      $changelog[$i + $di] += "`n$message"
+                  }
+
+                  # Write updated content back to CHANGELOG.md
+                  Set-Content -Path $changelogPath -Value $changelog
+
+                  continue commit
               }
 
-              # Write updated content back to CHANGELOG.md
-              Set-Content -Path $changelogPath -Value $changelog
+              # Insert new version under '# Changelog'
+              for ($i = 0; $i -lt $changelog.Count; ++$i) {
+                  if (-not ($changelog[$i] -match "# Changelog")) {
+                      continue
+                  }
+                  # Append after the title, create empty line space
+                  $changelog[$i] += "`n`n## [$version] - $date (Beta)`n`n"
+                  if ($message) {
+                      $changelog[$i] += "$message`n"
+                  }
+                  # Remove original empty line space
+                  while (++$i -lt $changelog.Count) {
+                      if ($changelog[$i] -ne "") {
+                          break
+                      }
+                      $changelog[$i] = $null
+                  }
+
+                  # Write updated content back to CHANGELOG.md
+                  Set-Content -Path $changelogPath -Value $changelog
+
+                  continue commit
+              }
+
+              # No '# Changelog', do nothing
+              break commit
           }
 
       - name: Commit CHANGELOG.md and OpenTaiko.csproj changes

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -2,24 +2,24 @@
 
 name: Build OpenTaiko
 
-on: 
+on:
   push:
     branches:
       - main
-  
+
 jobs:
   build:
     runs-on: windows-latest
-    
+
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
       contents: write
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-        
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -29,43 +29,43 @@ jobs:
         shell: cmd
         run: |
           dir
-          
+
       - name: Get commit subject for version checking
         id: get-latest-commit
         run: |
           $latestCommitMessage = git log -1 --pretty=format:%s
-          echo "::set-output name=latest_commit_message::$latestCommitMessage"
-          
+          echo "latest_commit_message=$latestCommitMessage" >> $GITHUB_OUTPUT
+
       - name: Extract version from commit message
         id: extract-version
         run: |
           if ('${{ steps.get-latest-commit.outputs.latest_commit_message }}' -match '^(?<version>[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s-\s') {
             $version = $matches['version']
             Write-Host "Extracted version is: $version"
-            echo "::set-output name=version::$version"
+            echo "version=$version" >> $GITHUB_OUTPUT
           } else {
             Write-Host "No valid version found in the latest commit message. Skipping bump."
-            echo "::set-output name=version::"
+            echo "version=" >> $GITHUB_OUTPUT
           }
-          
+
       - name: Bump OpenTaiko version if necessary
         if: steps.extract-version.outputs.version != ''
         run: |
           $newVersion = "${{ steps.extract-version.outputs.version }}"
           Write-Host "Updating version in OpenTaiko.csproj to $newVersion"
           (Get-Content OpenTaiko/OpenTaiko.csproj) -replace '<Version>.*<\/Version>', "<Version>$newVersion</Version>" | Set-Content OpenTaiko/OpenTaiko.csproj
-          
+
       - name: Get version
         uses: kzrnm/get-net-sdk-project-versions-action@v2
         id: get-version
         with:
           proj-path: OpenTaiko/OpenTaiko.csproj
-          
+
       - name: Get current date
         id: get-date
         run: |
           $date = Get-Date -Format "yyyy-MM-dd"
-          echo "::set-output name=date::$date"
+          echo "date=$date" >> $GITHUB_OUTPUT
 
       - name: Get changelogs from commit description
         id: get-commit-message
@@ -113,13 +113,13 @@ jobs:
           git add CHANGELOG.md
           git commit -m "Update changelog for version ${{steps.get-version.outputs.version}}"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
-      
+
 
       - name: Build for Windows x64
         shell: cmd
         run: |
           build-win-x64.bat
-          
+
       - name: Create Archive (Win x64)
         shell: cmd
         run: |
@@ -127,12 +127,12 @@ jobs:
           7z a ../../../../../OpenTaiko.Win.x64.zip publish/ -xr!publish/Songs/ -xr!publish/FFmpeg/ -xr!publish/System/ -xr!publish/Libs/
           7z u ../../../../../OpenTaiko.Win.x64.zip "publish/Libs/win-x64/*" "publish/FFmpeg/win-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*"
           cd ..\..\..\..\..\
-                
+
       - name: Build for Linux x64
         shell: cmd
         run: |
           build-linux-x64.bat
-          
+
       - name: Create Archive (Linux x64)
         shell: cmd
         run: |
@@ -144,14 +144,14 @@ jobs:
       - name: Check if tag exists
         uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
-        with: 
+        with:
           tag: "${{steps.get-version.outputs.version}}"
 
       - name: Create Release
         if: steps.check-tag.outputs.exists == 'false'
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "${{steps.get-version.outputs.version}}"
           release_name: OpenTaiko v${{steps.get-version.outputs.version}}
@@ -160,7 +160,7 @@ jobs:
             Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
           draft: false
           prerelease: false
-     
+
       - name: Upload All Builds
         uses: xresloader/upload-to-github-release@v1.4.2
         with:

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -62,6 +62,10 @@ jobs:
         with:
           proj-path: OpenTaiko/OpenTaiko.csproj
 
+      - name: Store projectVersion in environment
+        run: |
+          echo "projectVersion=${{ steps.get-version.outputs.version }}" >> $env:GITHUB_ENV
+
       - name: Get current date
         id: get-date
         run: |
@@ -78,7 +82,7 @@ jobs:
 
       - name: Update CHANGELOG.md
         run: |
-          $version = $env:version
+          $version = $env:projectVersion
           $date = $env:date
           $messagePath = $env:messagePath
           $changelogPath = "CHANGELOG.md"
@@ -112,7 +116,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git add OpenTaiko/OpenTaiko.csproj
           git add CHANGELOG.md
-          git commit -m "Update changelog for version $env:version"
+          git commit -m "Update changelog for version $env:projectVersion"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
 
       - name: Build for Windows x64
@@ -145,7 +149,7 @@ jobs:
         uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
         with:
-          tag: ${{ env.version }}
+          tag: ${{ env.projectVersion }}
 
       - name: Create Release
         if: steps.check-tag.outputs.exists == 'false' && env.version != ''
@@ -153,8 +157,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.version }}
-          release_name: OpenTaiko v${{ env.version }}
+          tag_name: ${{ env.projectVersion }}
+          release_name: OpenTaiko v${{ env.projectVersion }}
           body: |
             Note: The releases do not contain skins nor songs.
             Please download/update through the OpenTaiko Hub: https://github.com/OpenTaiko/OpenTaiko-Hub/releases
@@ -166,6 +170,6 @@ jobs:
         with:
           file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
           overwrite: true
-          tag_name: ${{ env.version }}
+          tag_name: ${{ env.projectVersion }}
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes the "old project version being treated as the version to release" regression of 0auBSQ/OpenTaiko#741.

## Test Cases

https://github.com/IepIweidieng/OpenTaiko/commits/b8692a780e479affa21eaef3ef7be78f328612e0
https://github.com/IepIweidieng/OpenTaiko/releases/tag/6.6.1.4