### PR TITLE
workflow: always update assets of latest release

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -225,12 +225,11 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload All Builds
-        if: steps.check-tag.outputs.exists == 'false' && env.version != ''
+      - name: Upload All Builds for the Latest Release
         uses: xresloader/upload-to-github-release@v1.6.0
         with:
           file: "OpenTaiko.Win.x64.zip;OpenTaiko.Linux.x64.zip"
           overwrite: true
-          tag_name: ${{ env.version }}
+          tag_name: ${{ env.versionLast }}
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now newly pushed commits update the assets, assuming they are flagged as "chore" or "hotfix".

The inconsistency that only version-bump–including pushes can have assets hotfixes is also fixed.

## Test Cases

https://github.com/IepIweidieng/OpenTaiko/commits/9abe5e6a170160b604386899a57a672c9a03b28f
https://github.com/IepIweidieng/OpenTaiko/actions/runs/11664239994/job/32474347894
https://github.com/IepIweidieng/OpenTaiko/releases/tag/0.6.0.16

![{01920568-CFDB-4792-93B7-759EC1B1FE8C}](https://github.com/user-attachments/assets/8f480d0c-2eef-4492-984e-cc0370bdef67)
