### PR TITLE
fix: reset bar drumroll redness on retry or training-mode pause

### DIFF
--- a/OpenTaiko/src/Songs/TJA/CChip.cs
+++ b/OpenTaiko/src/Songs/TJA/CChip.cs
@@ -133,9 +133,17 @@ internal class CChip : IComparable<CChip>, ICloneable {
 
 
 	public bool b演奏終了後も再生が続くチップである; // #32248 2013.10.14 yyagi
-	public CCounter RollDelay; // 18.9.22 AioiLight Add 連打時に赤くなるやつのタイマー
-	public CCounter RollInputTime; // 18.9.22 AioiLight Add  連打入力後、RollDelayが作動するまでのタイマー
+	public CCounter? RollDelay; // 18.9.22 AioiLight Add 連打時に赤くなるやつのタイマー
+	public CCounter? RollInputTime; // 18.9.22 AioiLight Add  連打入力後、RollDelayが作動するまでのタイマー
 	public int RollEffectLevel; // 18.9.22 AioiLight Add 連打時に赤くなるやつの度合い
+
+	public void ResetRollEffect() {
+		this.RollInputTime?.Stop();
+		this.RollInputTime = null;
+		this.RollDelay?.Stop();
+		this.RollDelay = null;
+		this.RollEffectLevel = 0;
+	}
 
 	public CChip() {
 		this.nHorizontalChipDistance = 0;

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4370,6 +4370,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		OpenTaiko.borderColor = new Color4(1f, 0f, 0f, 0f);
 
 		foreach (var chip in OpenTaiko.TJA.listChip) {
+			chip.ResetRollEffect();
 			if (chip.obj == null) continue;
 			chip.obj.isVisible = false;
 			chip.obj.yScale = 1.0f;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -335,6 +335,7 @@ class CActImplTrainingMode : CActivity {
 		for (int i = 0; i < dTX.listChip.Count; i++) {
 			CChip pChip = dTX.listChip[i];
 			pChip.bHit = false;
+			pChip.ResetRollEffect();
 			if (dTX.listChip[i].nChannelNo != 0x50) {
 				pChip.bShow = true;
 				pChip.bVisible = true;


### PR DESCRIPTION
## Test Cases

Just play any chart with drumroll at the beginning.

## How

* add `CChip.ResetRollEffect()` for resetting bar drumroll redness and use in:
  * `CStage演奏画面共通.t演奏やりなおし()` [`CStageGameplayScreenCommon.tGameplayRedo()`]
  * `CActImplTrainingMode.tPausePlay()`