### PR TITLE
Fix parsing of roll heads and ends to improve TaikoJiro compatibility

### DIFF
--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -4898,216 +4898,7 @@ internal class CTja : CActivity {
 								}
 							}
 
-							var chip = new CChip();
-							chip.IsMissed = false;
-							chip.bHit = false;
-							chip.bVisible = true;
-							chip.bShow = true;
-							chip.bShowRoll = true;
-							chip.nChannelNo = 0x10 + nObjectNum;
-							//chip.n発声位置 = (this.n現在の小節数 * 384) + ((384 * n) / n文字数);
-							chip.n発声位置 = (int)((this.n現在の小節数 * 384.0) + ((384.0 * n) / n文字数));
-							chip.db発声位置 = this.dbNowTime;
-							chip.n発声時刻ms = (int)this.dbNowTime;
-							//chip.fBMSCROLLTime = (float)(( this.dbBarLength ) * (16.0f / this.n各小節の文字数[this.n現在の小節数]));
-							chip.fBMSCROLLTime = (float)this.dbNowBMScollTime;
-							chip.n整数値 = nObjectNum;
-							chip.n整数値_内部番号 = 1;
-							chip.IsEndedBranching = IsEndedBranching;
-							chip.fNow_Measure_m = this.fNow_Measure_m;
-							chip.fNow_Measure_s = this.fNow_Measure_s;
-							chip.dbBPM = this.dbNowBPM;
-							chip.dbSCROLL = this.dbNowScroll;
-							chip.dbSCROLL_Y = this.dbNowScrollY;
-							chip.nScrollDirection = this.nスクロール方向;
-							chip.eScrollMode = eScrollMode;
-
-							if (IsEndedBranching)
-								chip.nBranch = (ECourse)i;
-							else
-								chip.nBranch = n現在のコース;
-
-							chip.n分岐回数 = this.n内部番号BRANCH1to;
-							chip.nノーツ出現時刻ms = (int)(this.db出現時刻 * 1000.0);
-							chip.nノーツ移動開始時刻ms = (int)(this.db移動待機時刻 * 1000.0);
-							chip.nPlayerSide = this.nPlayerSide;
-							chip.bGOGOTIME = this.bGOGOTIME;
-
-							if (NotesManager.IsKusudama(chip)) {
-								if (IsEndedBranching) {
-								} else {
-									// Balloon in branches
-									chip.nChannelNo = 0x19;
-								}
-							}
-
-							if (NotesManager.IsGenericBalloon(chip)) {
-								//this.n現在のコースをswitchで分岐していたため風船の値がうまく割り当てられていない 2020.04.21 akasoko26
-
-								#region [Balloons]
-
-								switch (chip.nBranch) {
-									case ECourse.eNormal:
-										if (this.listBalloon_Normal.Count == 0) {
-											chip.nBalloon = 5;
-											break;
-										}
-
-										if (this.listBalloon_Normal.Count > this.listBalloon_Normal_数値管理) {
-											chip.nBalloon = this.listBalloon_Normal[this.listBalloon_Normal_数値管理];
-											this.listBalloon_Normal_数値管理++;
-											break;
-										}
-										break;
-									case ECourse.eExpert:
-										if (this.listBalloon_Expert.Count == 0) {
-											chip.nBalloon = 5;
-											break;
-										}
-
-										if (this.listBalloon_Expert.Count > this.listBalloon_Expert_数値管理) {
-											chip.nBalloon = this.listBalloon_Expert[this.listBalloon_Expert_数値管理];
-											this.listBalloon_Expert_数値管理++;
-											break;
-										}
-										break;
-									case ECourse.eMaster:
-										if (this.listBalloon_Master.Count == 0) {
-											chip.nBalloon = 5;
-											break;
-										}
-
-										if (this.listBalloon_Master.Count > this.listBalloon_Master_数値管理) {
-											chip.nBalloon = this.listBalloon_Master[this.listBalloon_Master_数値管理];
-											this.listBalloon_Master_数値管理++;
-											break;
-										}
-										break;
-								}
-
-								#endregion
-
-							}
-							if (NotesManager.IsRollEnd(chip)) {
-								if (this.nNowRollCountBranch[iBranch] < 0) {
-									// stray roll end; treated as blank
-									continue; // process this note symbol in the next branch
-								}
-
-								CChip chipHead = this.listChip_Branch[iBranch][this.nNowRollCountBranch[iBranch]];
-								chipHead.nNoteEndPosition = chip.nNoteEndPosition = chip.n発声位置;
-								chipHead.nNoteEndTimems = chip.nNoteEndTimems = chip.n発声時刻ms;
-								chipHead.fBMSCROLLTime_end = chip.fBMSCROLLTime_end = chip.fBMSCROLLTime;
-
-								chip.nノーツ出現時刻ms = chipHead.nノーツ出現時刻ms;
-								chip.nノーツ移動開始時刻ms = chipHead.nノーツ移動開始時刻ms;
-								chip.n連打音符State = chipHead.nChannelNo - 0x10;
-
-								nNowRollCountBranch[iBranch] = -1;
-							}
-
-							if (IsEnabledFixSENote) {
-								chip.IsFixedSENote = true;
-								chip.nSenote = FixSENote - 1;
-							}
-
-							#region[ 固定される種類のsenotesはここで設定しておく。 ]
-							switch (nObjectNum) {
-								case 3:
-									chip.nSenote = 5;
-									break;
-								case 4:
-									chip.nSenote = 6;
-									break;
-								case 5:
-									chip.nSenote = 7;
-									break;
-								case 6:
-									chip.nSenote = 0xA;
-									break;
-								case 7:
-									chip.nSenote = 0xB;
-									break;
-								case 8:
-									chip.nSenote = 0xC;
-									break;
-								case 9:
-									chip.nSenote = 0xB;
-									break;
-								case 0xA:
-									chip.nSenote = 5;
-									break;
-								case 0xB:
-									chip.nSenote = 6;
-									break;
-								case 0xD:
-									chip.nSenote = 0xB;
-									break;
-								case 0xF1:
-									chip.nSenote = 5;
-									break;
-							}
-							#endregion
-
-
-							if (NotesManager.IsMissableNote(chip)) {
-								#region [ 作り直し ]
-								//譜面分岐がない譜面でも値は加算されてしまうがしゃあない
-								//分岐を開始しない間は共通譜面としてみなす。
-								if (IsEndedBranching) {
-									this.nノーツ数_Branch[i]++;
-
-									if (i == 0) {
-										if (this.n参照中の難易度 == (int)Difficulty.Dan) {
-											this.nDan_NotesCount[DanSongs.Number - 1]++;
-										}
-										this.nノーツ数[3]++;
-									}
-								} else {
-									this.nノーツ数_Branch[(int)chip.nBranch]++;
-									if (this.n参照中の難易度 == (int)Difficulty.Dan && chip.nBranch == ECourse.eMaster) {
-										this.nDan_NotesCount[DanSongs.Number - 1]++;
-									}
-
-									if (!this.b分岐を一回でも開始した) {
-										//IsEndedBranching==false = forloopが行われていないときのみ
-										for (int l = 0; l < 3; l++)
-											this.nノーツ数_Branch[l]++;
-									}
-								}
-
-								#endregion
-							} else if (NotesManager.IsGenericBalloon(chip)) {
-								//風船はこのままでも機能しているので何もしない.
-								if (IsEndedBranching) {
-									if (this.n参照中の難易度 == (int)Difficulty.Dan) {
-										this.nDan_BalloonCount[DanSongs.Number - 1]++;
-									}
-								} else {
-									if (this.n参照中の難易度 == (int)Difficulty.Dan && chip.nBranch == ECourse.eMaster) {
-										this.nDan_BalloonCount[DanSongs.Number - 1]++;
-									}
-								}
-
-								if (this.b最初の分岐である == false) {
-									this.n風船数[(int)this.n現在のコース]++;
-								} else {
-									this.n風船数[3]++;
-								}
-
-							}
-
-							Array.Resize(ref nDan_NotesCount, nDan_NotesCount.Length + 1);
-							Array.Resize(ref nDan_BalloonCount, nDan_BalloonCount.Length + 1);
-							if (IsEndedBranching) {
-								this.listChip_Branch[i].Add(chip);
-								if (i == 0)
-									this.listChip.Add(chip);
-							} else {
-								this.listChip_Branch[(int)chip.nBranch].Add(chip);
-								this.listChip.Add(chip);
-							}
-
+							InsertNoteAtDefCursor(nObjectNum, n, n文字数, (ECourse)iBranch);
 						}
 					}
 
@@ -5119,6 +4910,215 @@ internal class CTja : CActivity {
 					this.dbNowBMScollTime += (((this.fNow_Measure_s / this.fNow_Measure_m)) * (16.0 / (double)n文字数));
 				}
 			}
+		}
+	}
+
+	private void InsertNoteAtDefCursor(int noteType, int iDiv, int divsPerMeasure, ECourse branch) {
+		int iBranch = (int)branch;
+
+		var chip = new CChip();
+		chip.IsMissed = false;
+		chip.bHit = false;
+		chip.bVisible = true;
+		chip.bShow = true;
+		chip.bShowRoll = true;
+		chip.nChannelNo = 0x10 + noteType;
+		//chip.n発声位置 = (this.n現在の小節数 * 384) + ((384 * iDiv) / divsPerMeasure);
+		chip.n発声位置 = (int)((this.n現在の小節数 * 384.0) + ((384.0 * iDiv) / divsPerMeasure));
+		chip.db発声位置 = this.dbNowTime;
+		chip.n発声時刻ms = (int)this.dbNowTime;
+		//chip.fBMSCROLLTime = (float)(( this.dbBarLength ) * (16.0f / this.n各小節の文字数[this.n現在の小節数]));
+		chip.fBMSCROLLTime = (float)this.dbNowBMScollTime;
+		chip.n整数値 = noteType;
+		chip.n整数値_内部番号 = 1;
+		chip.IsEndedBranching = IsEndedBranching;
+		chip.fNow_Measure_m = this.fNow_Measure_m;
+		chip.fNow_Measure_s = this.fNow_Measure_s;
+		chip.dbBPM = this.dbNowBPM;
+		chip.dbSCROLL = this.dbNowScroll;
+		chip.dbSCROLL_Y = this.dbNowScrollY;
+		chip.nScrollDirection = this.nスクロール方向;
+		chip.eScrollMode = eScrollMode;
+		chip.nBranch = branch;
+		chip.n分岐回数 = this.n内部番号BRANCH1to;
+		chip.nノーツ出現時刻ms = (int)(this.db出現時刻 * 1000.0);
+		chip.nノーツ移動開始時刻ms = (int)(this.db移動待機時刻 * 1000.0);
+		chip.nPlayerSide = this.nPlayerSide;
+		chip.bGOGOTIME = this.bGOGOTIME;
+
+		if (NotesManager.IsKusudama(chip)) {
+			if (IsEndedBranching) {
+			} else {
+				// Balloon in branches
+				chip.nChannelNo = 0x19;
+			}
+		}
+
+		if (NotesManager.IsGenericBalloon(chip)) {
+			//this.n現在のコースをswitchで分岐していたため風船の値がうまく割り当てられていない 2020.04.21 akasoko26
+
+			#region [Balloons]
+
+			switch (chip.nBranch) {
+				case ECourse.eNormal:
+					if (this.listBalloon_Normal.Count == 0) {
+						chip.nBalloon = 5;
+						break;
+					}
+
+					if (this.listBalloon_Normal.Count > this.listBalloon_Normal_数値管理) {
+						chip.nBalloon = this.listBalloon_Normal[this.listBalloon_Normal_数値管理];
+						this.listBalloon_Normal_数値管理++;
+						break;
+					}
+					break;
+				case ECourse.eExpert:
+					if (this.listBalloon_Expert.Count == 0) {
+						chip.nBalloon = 5;
+						break;
+					}
+
+					if (this.listBalloon_Expert.Count > this.listBalloon_Expert_数値管理) {
+						chip.nBalloon = this.listBalloon_Expert[this.listBalloon_Expert_数値管理];
+						this.listBalloon_Expert_数値管理++;
+						break;
+					}
+					break;
+				case ECourse.eMaster:
+					if (this.listBalloon_Master.Count == 0) {
+						chip.nBalloon = 5;
+						break;
+					}
+
+					if (this.listBalloon_Master.Count > this.listBalloon_Master_数値管理) {
+						chip.nBalloon = this.listBalloon_Master[this.listBalloon_Master_数値管理];
+						this.listBalloon_Master_数値管理++;
+						break;
+					}
+					break;
+			}
+
+			#endregion
+
+		}
+		if (NotesManager.IsRollEnd(chip)) {
+			if (this.nNowRollCountBranch[iBranch] < 0) {
+				// stray roll end; treated as blank
+				return; // process this note symbol in the next branch
+			}
+
+			CChip chipHead = this.listChip_Branch[iBranch][this.nNowRollCountBranch[iBranch]];
+			chipHead.nNoteEndPosition = chip.nNoteEndPosition = chip.n発声位置;
+			chipHead.nNoteEndTimems = chip.nNoteEndTimems = chip.n発声時刻ms;
+			chipHead.fBMSCROLLTime_end = chip.fBMSCROLLTime_end = chip.fBMSCROLLTime;
+
+			chip.nノーツ出現時刻ms = chipHead.nノーツ出現時刻ms;
+			chip.nノーツ移動開始時刻ms = chipHead.nノーツ移動開始時刻ms;
+			chip.n連打音符State = chipHead.nChannelNo - 0x10;
+
+			this.nNowRollCountBranch[iBranch] = -1;
+		}
+
+		if (IsEnabledFixSENote) {
+			chip.IsFixedSENote = true;
+			chip.nSenote = FixSENote - 1;
+		}
+
+		#region[ 固定される種類のsenotesはここで設定しておく。 ]
+		switch (noteType) {
+			case 3:
+				chip.nSenote = 5;
+				break;
+			case 4:
+				chip.nSenote = 6;
+				break;
+			case 5:
+				chip.nSenote = 7;
+				break;
+			case 6:
+				chip.nSenote = 0xA;
+				break;
+			case 7:
+				chip.nSenote = 0xB;
+				break;
+			case 8:
+				chip.nSenote = 0xC;
+				break;
+			case 9:
+				chip.nSenote = 0xB;
+				break;
+			case 0xA:
+				chip.nSenote = 5;
+				break;
+			case 0xB:
+				chip.nSenote = 6;
+				break;
+			case 0xD:
+				chip.nSenote = 0xB;
+				break;
+			case 0xF1:
+				chip.nSenote = 5;
+				break;
+		}
+		#endregion
+
+
+		if (NotesManager.IsMissableNote(chip)) {
+			#region [ 作り直し ]
+			//譜面分岐がない譜面でも値は加算されてしまうがしゃあない
+			//分岐を開始しない間は共通譜面としてみなす。
+			if (IsEndedBranching) {
+				this.nノーツ数_Branch[iBranch]++;
+
+				if (branch == ECourse.eNormal) {
+					if (this.n参照中の難易度 == (int)Difficulty.Dan) {
+						this.nDan_NotesCount[DanSongs.Number - 1]++;
+					}
+					this.nノーツ数[3]++;
+				}
+			} else {
+				this.nノーツ数_Branch[(int)chip.nBranch]++;
+				if (this.n参照中の難易度 == (int)Difficulty.Dan && chip.nBranch == ECourse.eMaster) {
+					this.nDan_NotesCount[DanSongs.Number - 1]++;
+				}
+
+				if (!this.b分岐を一回でも開始した) {
+					//IsEndedBranching==false = forloopが行われていないときのみ
+					for (int l = 0; l < 3; l++)
+						this.nノーツ数_Branch[l]++;
+				}
+			}
+
+			#endregion
+		} else if (NotesManager.IsGenericBalloon(chip)) {
+			//風船はこのままでも機能しているので何もしない.
+			if (IsEndedBranching) {
+				if (this.n参照中の難易度 == (int)Difficulty.Dan) {
+					this.nDan_BalloonCount[DanSongs.Number - 1]++;
+				}
+			} else {
+				if (this.n参照中の難易度 == (int)Difficulty.Dan && chip.nBranch == ECourse.eMaster) {
+					this.nDan_BalloonCount[DanSongs.Number - 1]++;
+				}
+			}
+
+			if (this.b最初の分岐である == false) {
+				this.n風船数[(int)this.n現在のコース]++;
+			} else {
+				this.n風船数[3]++;
+			}
+
+		}
+
+		Array.Resize(ref nDan_NotesCount, nDan_NotesCount.Length + 1);
+		Array.Resize(ref nDan_BalloonCount, nDan_BalloonCount.Length + 1);
+		if (IsEndedBranching) {
+			this.listChip_Branch[iBranch].Add(chip);
+			if (branch == ECourse.eNormal)
+				this.listChip.Add(chip);
+		} else {
+			this.listChip_Branch[(int)chip.nBranch].Add(chip);
+			this.listChip.Add(chip);
 		}
 	}
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -5002,28 +5002,22 @@ internal class CTja : CActivity {
 
 							}
 							if (NotesManager.IsRollEnd(chip)) {
-								chip.nNoteEndPosition = (this.n現在の小節数 * 384) + ((384 * n) / n文字数);
-								chip.nNoteEndTimems = (int)this.dbNowTime;
-								chip.fBMSCROLLTime_end = (float)this.dbNowBMScollTime;
-
 								chip.nノーツ出現時刻ms = listChip[nNowRollCount].nノーツ出現時刻ms;
 								chip.nノーツ移動開始時刻ms = listChip[nNowRollCount].nノーツ移動開始時刻ms;
 
 								chip.n連打音符State = nNowRoll;
 
+								CChip chipHead;
 								if (!IsEndedBranching || i == 0) {
-									listChip[nNowRollCount].nNoteEndPosition = (this.n現在の小節数 * 384) + ((384 * n) / n文字数);
-									listChip[nNowRollCount].nNoteEndTimems = (int)this.dbNowTime;
-									listChip[nNowRollCount].fBMSCROLLTime_end = (int)this.dbNowBMScollTime;
+									chipHead = listChip[nNowRollCount];
 								} else if (!IsEndedBranching) {
-									listChip_Branch[(int)chip.nBranch][nNowRollCountBranch[(int)chip.nBranch]].nNoteEndPosition = (this.n現在の小節数 * 384) + ((384 * n) / n文字数);
-									listChip_Branch[(int)chip.nBranch][nNowRollCountBranch[(int)chip.nBranch]].nNoteEndTimems = (int)this.dbNowTime;
-									listChip_Branch[(int)chip.nBranch][nNowRollCountBranch[(int)chip.nBranch]].fBMSCROLLTime_end = (int)this.dbNowBMScollTime;
+									chipHead = listChip_Branch[(int)chip.nBranch][nNowRollCountBranch[(int)chip.nBranch]];
 								} else {
-									listChip_Branch[i][nNowRollCountBranch[i]].nNoteEndPosition = (this.n現在の小節数 * 384) + ((384 * n) / n文字数);
-									listChip_Branch[i][nNowRollCountBranch[i]].nNoteEndTimems = (int)this.dbNowTime;
-									listChip_Branch[i][nNowRollCountBranch[i]].fBMSCROLLTime_end = (int)this.dbNowBMScollTime;
+									chipHead = listChip_Branch[i][nNowRollCountBranch[i]];
 								}
+								chipHead.nNoteEndPosition = chip.nNoteEndPosition = chip.n発声位置;
+								chipHead.nNoteEndTimems = chip.nNoteEndTimems = chip.n発声時刻ms;
+								chipHead.fBMSCROLLTime_end = chip.fBMSCROLLTime_end = chip.fBMSCROLLTime;
 
 								if (!IsEndedBranching || i == 2)
 									nNowRoll = 0;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -619,7 +619,7 @@ internal class CTja : CActivity {
 
 	private int nNowRoll = 0;
 	private int nNowRollCount = 0;
-	private int[] nNowRollCountBranch = new int[3];
+	private int[] nNowRollCountBranch = new int[3] { -1, -1, -1 };
 
 	private int[] n連打チップ_temp = new int[3];
 	public int nOFFSET = 0;
@@ -4901,7 +4901,7 @@ internal class CTja : CActivity {
 							int iBranch = this.IsEndedBranching ? i : (int)this.n現在のコース;
 
 							if ((nObjectNum >= 5 && nObjectNum <= 7) || nObjectNum == 9 || nObjectNum == 13 || nObjectNum == 16 || nObjectNum == 17) {
-								if (this.nNowRollCountBranch[iBranch] > 0) {
+								if (this.nNowRollCountBranch[iBranch] >= 0) {
 									// repeated roll head; treated as blank
 									continue; // process this note symbol in the next branch
 								} else {
@@ -5010,7 +5010,7 @@ internal class CTja : CActivity {
 								chip.nノーツ移動開始時刻ms = chipHead.nノーツ移動開始時刻ms;
 								chip.n連打音符State = chipHead.nChannelNo - 0x10;
 
-								nNowRollCountBranch[iBranch] = 0;
+								nNowRollCountBranch[iBranch] = -1;
 							}
 
 							if (IsEnabledFixSENote) {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -617,8 +617,6 @@ internal class CTja : CActivity {
 
 	private int n現在の小節数 = 1;
 
-	private int nNowRoll = 0;
-	private int nNowRollCount = 0;
 	private int[] nNowRollCountBranch = new int[3] { -1, -1, -1 };
 
 	private int[] n連打チップ_temp = new int[3];
@@ -1405,9 +1403,6 @@ internal class CTja : CActivity {
 				int ms = 0;
 				int nBar = 0;
 				int nCount = 0;
-				this.nNowRollCount = 0;
-				for (int i = 0; i < this.nNowRollCountBranch.Length; i++)
-					this.nNowRollCountBranch[i] = 0;
 
 				List<STLYRIC> tmplistlyric = new List<STLYRIC>();
 				int BGM番号 = 0;
@@ -1421,9 +1416,6 @@ internal class CTja : CActivity {
 					ch = chip.nChannelNo;
 
 					nCount++;
-					this.nNowRollCount++;
-					for (int i = 0; i < this.nNowRollCountBranch.Length; i++)
-						this.nNowRollCountBranch[i]++;
 
 					switch (ch) {
 						case 0x01: {
@@ -1483,8 +1475,6 @@ internal class CTja : CActivity {
 									chip.n発声時刻ms += this.nOFFSET;
 									chip.nNoteEndTimems += this.nOFFSET;
 								}
-
-								this.nNowRoll = this.nNowRollCount - 1;
 								continue;
 							}
 						case 0x18: {
@@ -1556,8 +1546,6 @@ internal class CTja : CActivity {
 									chip.n発声時刻ms += this.nOFFSET;
 									chip.nNoteEndTimems += this.nOFFSET;
 								}
-								this.nNowRoll = this.nNowRollCount - 1;
-
 								continue;
 							}
 						case 0x9A: {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -4895,22 +4895,21 @@ internal class CTja : CActivity {
 					int nObjectNum = this.CharConvertNote(InputText.Substring(n, 1));
 
 					if (nObjectNum != 0) {
-						if ((nObjectNum >= 5 && nObjectNum <= 7) || nObjectNum == 9 || nObjectNum == 13 || nObjectNum == 16 || nObjectNum == 17) {
-							if (nNowRoll != 0) {
-								this.dbNowTime += (15000.0 / this.dbNowBPM * (this.fNow_Measure_s / this.fNow_Measure_m) * (16.0 / n文字数));
-								this.dbNowBMScollTime += (double)((this.dbBarLength) * (16.0 / n文字数));
-								continue;
-							} else {
-								this.nNowRollCount = listChip.Count;
-								for (int i = 0; i < this.nNowRollCountBranch.Length; i++)
-									this.nNowRollCountBranch[i] = listChip_Branch[i].Count;
-								nNowRoll = nObjectNum;
-							}
-						}
-
 						// IsEndedBranchingがfalseで1回
 						// trueで3回だよ3回
 						for (int i = 0; i < (IsEndedBranching == true ? 3 : 1); i++) {
+							int iBranch = this.IsEndedBranching ? i : (int)this.n現在のコース;
+
+							if ((nObjectNum >= 5 && nObjectNum <= 7) || nObjectNum == 9 || nObjectNum == 13 || nObjectNum == 16 || nObjectNum == 17) {
+								if (this.nNowRollCountBranch[iBranch] > 0) {
+									// repeated roll head; treated as blank
+									continue; // process this note symbol in the next branch
+								} else {
+									// real roll head; predict chip index
+									this.nNowRollCountBranch[iBranch] = listChip_Branch[iBranch].Count;
+								}
+							}
+
 							var chip = new CChip();
 							chip.IsMissed = false;
 							chip.bHit = false;
@@ -5002,14 +5001,7 @@ internal class CTja : CActivity {
 
 							}
 							if (NotesManager.IsRollEnd(chip)) {
-								CChip chipHead;
-								if (!IsEndedBranching || i == 0) {
-									chipHead = listChip[nNowRollCount];
-								} else if (!IsEndedBranching) {
-									chipHead = listChip_Branch[(int)chip.nBranch][nNowRollCountBranch[(int)chip.nBranch]];
-								} else {
-									chipHead = listChip_Branch[i][nNowRollCountBranch[i]];
-								}
+								CChip chipHead = this.listChip_Branch[iBranch][this.nNowRollCountBranch[iBranch]];
 								chipHead.nNoteEndPosition = chip.nNoteEndPosition = chip.n発声位置;
 								chipHead.nNoteEndTimems = chip.nNoteEndTimems = chip.n発声時刻ms;
 								chipHead.fBMSCROLLTime_end = chip.fBMSCROLLTime_end = chip.fBMSCROLLTime;
@@ -5018,8 +5010,7 @@ internal class CTja : CActivity {
 								chip.nノーツ移動開始時刻ms = chipHead.nノーツ移動開始時刻ms;
 								chip.n連打音符State = chipHead.nChannelNo - 0x10;
 
-								if (!IsEndedBranching || i == 2)
-									nNowRoll = 0;
+								nNowRollCountBranch[iBranch] = 0;
 							}
 
 							if (IsEnabledFixSENote) {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -5002,11 +5002,6 @@ internal class CTja : CActivity {
 
 							}
 							if (NotesManager.IsRollEnd(chip)) {
-								chip.nノーツ出現時刻ms = listChip[nNowRollCount].nノーツ出現時刻ms;
-								chip.nノーツ移動開始時刻ms = listChip[nNowRollCount].nノーツ移動開始時刻ms;
-
-								chip.n連打音符State = nNowRoll;
-
 								CChip chipHead;
 								if (!IsEndedBranching || i == 0) {
 									chipHead = listChip[nNowRollCount];
@@ -5018,6 +5013,10 @@ internal class CTja : CActivity {
 								chipHead.nNoteEndPosition = chip.nNoteEndPosition = chip.n発声位置;
 								chipHead.nNoteEndTimems = chip.nNoteEndTimems = chip.n発声時刻ms;
 								chipHead.fBMSCROLLTime_end = chip.fBMSCROLLTime_end = chip.fBMSCROLLTime;
+
+								chip.nノーツ出現時刻ms = chipHead.nノーツ出現時刻ms;
+								chip.nノーツ移動開始時刻ms = chipHead.nノーツ移動開始時刻ms;
+								chip.n連打音符State = chipHead.nChannelNo - 0x10;
 
 								if (!IsEndedBranching || i == 2)
 									nNowRoll = 0;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -5001,6 +5001,11 @@ internal class CTja : CActivity {
 
 							}
 							if (NotesManager.IsRollEnd(chip)) {
+								if (this.nNowRollCountBranch[iBranch] < 0) {
+									// stray roll end; treated as blank
+									continue; // process this note symbol in the next branch
+								}
+
 								CChip chipHead = this.listChip_Branch[iBranch][this.nNowRollCountBranch[iBranch]];
 								chipHead.nNoteEndPosition = chip.nNoteEndPosition = chip.n発声位置;
 								chipHead.nNoteEndTimems = chip.nNoteEndTimems = chip.n発声時刻ms;


### PR DESCRIPTION
fixes 0auBSQ/OpenTaiko#579 completely.

## Fixed Issues

* Fix end of bar drumrolls wrongly snapped to 1/16th (only visually) in HB/BMScroll
* Fix incorrect roll duration, missing rolls, or unended chart for rolls across branch sections
    * A roll still can have incorrect roll duration if it begins in non-branched section and ends in Expert or Master branch, which has not been supported yet.
* Force unended roll to end at the first non-roll note after it or `#END`, as in TaikoJiro.

## Test Cases

* ⚠️→⭕ [Rolls-in-NM-HB-BMScroll.tja](https://github.com/user-attachments/files/17979636/Rolls-in-NM-HB-BMScroll.tja.txt)
* ❌→⚠️ [rolls_across_branches.tja](https://github.com/user-attachments/files/17979633/rolls_across_branches.tja.txt)
    * For rolls begin/end in Expert/Master branch and end/being in non-branch section, they are parsed correctly with correct roll time and beat position and duration, but they have not been supported in gameplay yet, which will be addressed in another PR.
* ⭕→⭕ [repeat-roll-heads.tja](https://github.com/user-attachments/files/17979635/repeat-roll-heads.tja.txt)
* ❌→⭕ [rolls-ended-by-nonrolls.tja](https://github.com/user-attachments/files/17979634/rolls-ended-by-nonrolls.tja.txt)

### Before

⚠️: Incorrect bar roll length in HB/BMScroll

https://github.com/user-attachments/assets/e7a49ea4-96db-4541-9ede-5ea70afda161

❌: Wrong roll duration in all branches, missing rolls, unended chart

https://github.com/user-attachments/assets/117df14c-92dc-4bd4-be6f-175fe2aae38a

⭕

https://github.com/user-attachments/assets/dcf8100e-fa75-460e-a95a-e1af80a646a8

❌: Missing rolls, last bar roll has its end stuck to the judgement mark

https://github.com/user-attachments/assets/a9de977c-b41b-4eed-9378-655c2e3028a6

### After

⭕

https://github.com/user-attachments/assets/5fbd6c30-529b-4cd6-acef-1dd6010a232b

⚠️: Correct roll duration in Normal branch, still incorrect roll duration if the roll begins in non-branched section and ends in non-Normal branch section.

https://github.com/user-attachments/assets/2ee4cc65-57aa-483c-92f9-f82e67b192bb

⭕

https://github.com/user-attachments/assets/ad1d5af0-5662-400b-8682-67e5a039e8f8

⭕

https://github.com/user-attachments/assets/f9868fab-1958-412e-a507-e5d91822b019

## Log files

Log messages for `rolls-ended-by-nonrolls.tja`. This PR adds the `[WARNING]     CTja: ` lines.

```txt
2024/12/02 23:16:57.094 [INFO]     ----------------------
2024/12/02 23:16:57.094 [INFO]     ■ Song Loading
58585858: Cacheにヒットせず。(cachesize=1)
50585058: Cacheにヒットせず。(cachesize=2)
51525354: Cacheにヒットせず。(cachesize=3)
2024/12/02 23:16:57.127 [WARNING]     CTja: An unended roll is ended by a non-roll of type 1 at measure 3. Input: 51525354, In C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\rolls-ended-by-nonrolls.tja
2024/12/02 23:16:57.127 [WARNING]     CTja: An unended roll is ended by a non-roll of type 2 at measure 3. Input: 51525354, In C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\rolls-ended-by-nonrolls.tja
2024/12/02 23:16:57.127 [WARNING]     CTja: An unended roll is ended by a non-roll of type 3 at measure 3. Input: 51525354, In C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\rolls-ended-by-nonrolls.tja
2024/12/02 23:16:57.127 [WARNING]     CTja: An unended roll is ended by a non-roll of type 4 at measure 3. Input: 51525354, In C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\rolls-ended-by-nonrolls.tja
5657595D: Cacheにヒットせず。(cachesize=4)
#END: Cacheにヒットせず。(cachesize=5)
2024/12/02 23:16:57.128 [WARNING]     CTja: An unended roll is ended by #END. In C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\rolls-ended-by-nonrolls.tja
2024/12/02 23:16:57.128 [INFO]     ---- Song information -----------------
2024/12/02 23:16:57.128 [INFO]     TITLE: Rolls Ended by Non-rolls
2024/12/02 23:16:57.128 [INFO]     FILE: C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\rolls-ended-by-nonrolls.tja
2024/12/02 23:16:57.128 [INFO]     ---------------------------
2024/12/02 23:16:57.128 [INFO]     Chart loading time:           00:00:00.0028461
2024/12/02 23:16:58.426 [INFO]     Song loading time(   0):     00:00:01.2982694
2024/12/02 23:16:58.944 [WARNING]     Could not find specified texture file. (C:\Users\User\Games\git\OpenTaiko\OpenTaiko\bin\Debug\net8.0\System\Open-World Memories\Graphics\5_Game\9_End\AllPerfect\bg.png)
2024/12/02 23:16:59.792 [WARNING]     Could not find specified texture file. (C:\Users\User\Games\OpenTaiko Hub\OpenTaiko\Songs\L2 Custom Charts\99 Extra\Test Cases\Dan_Plate.png)
Rolls Ended by Non-rolls: Cacheにヒットせず。(cachesize=1)
1曲目: Cacheにヒットせず。(cachesize=2)
2024/12/02 23:16:59.795 [WARNING]     Could not find specified texture file. (C:\Users\User\Games\git\OpenTaiko\OpenTaiko\bin\Debug\net8.0\System\Open-World Memories\Graphics\5_Game\13_GENRE\Songs.png)
2024/12/02 23:16:59.797 [WARNING]     Could not find specified texture file. (C:\Users\User\Games\git\OpenTaiko\OpenTaiko\bin\Debug\net8.0\System\Open-World Memories\Graphics\5_Game\5_Background\0\Background.png)
2024/12/02 23:16:59.799 [INFO]     総読込時間:                00:00:02.6742467
2024/12/02 23:17:00.093 [INFO]     曲読み込みステージを非活性化します。
2024/12/02 23:17:00.094 [INFO]         曲読み込みステージの非活性化を完了しました。
2024/12/02 23:17:00.094 [INFO]     ----------------------
2024/12/02 23:17:00.094 [INFO]     ■ Gameplay (Drum Screen)
```
