### PR TITLE
fix: remove broken DTX legacy beatline chips processing (0x51)

### DIFF
--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1388,7 +1388,7 @@ internal class CTja : CActivity {
 						startIndex++;   // 1つ小さく過ぎているので、戻す
 					}
 					for (int j = startIndex; j <= i; j++) {
-						if (((this.listChip[j].nChannelNo == 0x50) || (this.listChip[j].nChannelNo == 0x51)) &&
+						if ((this.listChip[j].nChannelNo == 0x50) &&
 							(this.listChip[j].n整数値 == (36 * 36 - 1))) {
 							this.listChip[j].bVisible = bShowBeatBarLine;
 						}
@@ -1408,7 +1408,7 @@ internal class CTja : CActivity {
 				int BGM番号 = 0;
 
 				foreach (CChip chip in this.listChip) {
-					if (chip.nChannelNo == 0x02) { } else if (chip.nChannelNo == 0x01) { } else if (chip.nChannelNo == 0x08) { } else if (chip.nChannelNo >= 0x11 && chip.nChannelNo <= 0x1F) { } else if (chip.nChannelNo == 0x50) { } else if (chip.nChannelNo == 0x51) { } else if (chip.nChannelNo == 0x54) { } else if (chip.nChannelNo == 0x08) { } else if (chip.nChannelNo == 0xF1) { } else if (chip.nChannelNo == 0xF2) { } else if (chip.nChannelNo == 0xFF) { } else if (chip.nChannelNo == 0xDD) { chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm)); } else if (chip.nChannelNo == 0xDF) { chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm)); } else if (chip.nChannelNo < 0x93)
+					if (chip.nChannelNo == 0x02) { } else if (chip.nChannelNo == 0x01) { } else if (chip.nChannelNo == 0x08) { } else if (chip.nChannelNo >= 0x11 && chip.nChannelNo <= 0x1F) { } else if (chip.nChannelNo == 0x50) { } else if (chip.nChannelNo == 0x54) { } else if (chip.nChannelNo == 0x08) { } else if (chip.nChannelNo == 0xF1) { } else if (chip.nChannelNo == 0xF2) { } else if (chip.nChannelNo == 0xFF) { } else if (chip.nChannelNo == 0xDD) { chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm)); } else if (chip.nChannelNo == 0xDF) { chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm)); } else if (chip.nChannelNo < 0x93)
 						chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
 					else if ((chip.nChannelNo > 0x9F && chip.nChannelNo < 0xA0) || (chip.nChannelNo >= 0xF0 && chip.nChannelNo < 0xFE))
 						chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
@@ -4849,31 +4849,6 @@ internal class CTja : CActivity {
 
 					this.dbLastTime = this.dbNowTime;
 					this.b小節線を挿入している = true;
-
-					#region[ 拍線チップテスト ]
-					//1拍の時間を計算
-					double db1拍 = (60.0 / this.dbNowBPM) / 4.0;
-					//forループ(拍数)
-					for (int measure = 1; measure < this.fNow_Measure_s; measure++) {
-						CChip hakusen = new CChip();
-						hakusen.n発声位置 = ((this.n現在の小節数) * 384);
-						hakusen.n発声時刻ms = (int)(this.dbNowTime + (((db1拍 * 4.0)) * measure) * 1000.0);
-						hakusen.nChannelNo = 0x51;
-						hakusen.fBMSCROLLTime = this.dbNowBMScollTime;
-						hakusen.n整数値_内部番号 = this.n現在の小節数;
-						hakusen.n整数値 = 0;
-						hakusen.dbBPM = this.dbNowBPM;
-						hakusen.dbSCROLL = this.dbNowScroll;
-						hakusen.fNow_Measure_m = this.fNow_Measure_m;
-						hakusen.fNow_Measure_s = this.fNow_Measure_s;
-						hakusen.dbSCROLL_Y = this.dbNowScrollY;
-						hakusen.nBranch = n現在のコース;
-						hakusen.eScrollMode = eScrollMode;
-						this.listChip.Add(hakusen);
-					}
-
-					#endregion
-
 				}
 
 				for (int n = 0; n < InputText.Length; n++) {

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -3187,13 +3187,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 						break;
 					}
 				#endregion
-				#region [ 51: 拍線 ]
-				case 0x51:  // 拍線
-					if (!pChip.bHit && time < 0) {
-						pChip.bHit = true;
-					}
-					break;
-				#endregion
 				#region [ 54: 動画再生 ]
 				case 0x54:  // 動画再生
 					if (!pChip.bHit && time < 0) {


### PR DESCRIPTION
## Why

The insertion of beatlines failed to consider non-x/4 time signature, mid-measure #BPMCHANGE, and mid-measure #DELAY.

Beatline is unused in Taiko gameplay,
and the wrong insertion of beatline can cause
extremely long song duration, wrong retry position (when the calculated time overflows, the BPM is negative, or when the lower number of time signature is negative), and bad performance for charts containing high BPM and long time signature.

## Test Cases

Miracle 5ympho X (kirura969), chart download link is in channel description.

Intended behavior: https://youtu.be/rwArv-JyAW4

❌ Before behavior: Wrong chart length, wrong retry position.

https://github.com/user-attachments/assets/88a3cda8-d424-4113-ab26-b65c73914819

⭕ After behavior

https://github.com/user-attachments/assets/e20ed9e9-9572-4e17-8dcd-6ca49a299b25

## Benchmarks

愛歌「ネグラドルナ」(kirura969), chart download link is in channel description.

Intended behavior: https://youtu.be/2xtRk239msI (except for note count capping)

The ending part is different because the stopping effects of `#DELAY` has not been implemented in OpenTaiko.

❌ Before behavior: mostly 3x fps, halt at end

https://github.com/user-attachments/assets/c7563723-f039-4811-8e26-3622654526dc

❌ After behavior: mostly 5x fps, halt at end
※ 0auBSQ/OpenTaiko#757 is applied here.

https://github.com/user-attachments/assets/383f6e50-a3c8-46da-8099-4d22cd6d18c3

