### PR TITLE
fix: prevent CCounter from halting due to very large BPM

### DIFF
--- a/FDK/src/00.Common/CCounter.cs
+++ b/FDK/src/00.Common/CCounter.cs
@@ -13,6 +13,7 @@
 ///
 /// double値を使う場合、t進行db、t進行LoopDbを使うこと。
 /// また、double版では間隔の値はミリ秒単位ではなく、通常の秒単位になります。
+/// Note: For the double version, the given interval is in second only for new CCounter(), not for Start().
 /// </remarks>
 public class CCounter {
 	public bool IsStarted {
@@ -33,23 +34,23 @@ public class CCounter {
 		set;
 	}
 
-	public double _Interval {
+	public double _msInterval {
 		get {
-			return this.Interval;
+			return this.msInterval;
 		}
 		set {
-			this.Interval = value >= 0 ? value : value * -1;
+			this.msInterval = value >= 0 ? value : value * -1;
 		}
 	}
 
-	public double NowTime {
+	public double msNowTime {
 		get;
 		set;
 	}
 	// 状態プロパティ
 
 	public bool IsTicked {
-		get { return (this.NowTime != -1); }
+		get { return (this.msNowTime != -1); }
 	}
 	public bool IsStoped {
 		get { return !this.IsTicked; }
@@ -69,19 +70,19 @@ public class CCounter {
 		this.EndValue = 0;
 		this.CurrentValue = 0;
 		this.CurrentValue = 0;
-		this.NowTime = CSoundTimer.UnusedNum;
+		this.msNowTime = CSoundTimer.UnusedNum;
 	}
 
 	/// <summary>生成と同時に開始する。</summary>
-	public CCounter(double begin, double end, double interval, CTimer timer)
+	public CCounter(double begin, double end, double msInterval, CTimer timer)
 		: this() {
-		this.Start(begin, end, interval, timer);
+		this.Start(begin, end, msInterval, timer);
 	}
 
 	/// <summary>生成と同時に開始する。(double版)</summary>
-	public CCounter(double begin, double end, double interval, CSoundTimer timer)
+	public CCounter(double begin, double end, double secInterval, CSoundTimer timer)
 		: this() {
-		this.Start(begin, end, interval * 1000.0f, timer);
+		this.Start(begin, end, secInterval * 1000.0f, timer);
 	}
 
 
@@ -92,14 +93,14 @@ public class CCounter {
 	/// </summary>
 	/// <param name="begin">最初のカウント値。</param>
 	/// <param name="end">最後のカウント値。</param>
-	/// <param name="interval">カウント値を１増加させるのにかける時間（ミリ秒単位）。</param>
+	/// <param name="msInterval">カウント値を１増加させるのにかける時間（ミリ秒単位）。</param>
 	/// <param name="timer">カウントに使用するタイマ。</param>
-	public void Start(double begin, double end, double interval, CTimer timer) {
+	public void Start(double begin, double end, double msInterval, CTimer timer) {
 		this.BeginValue = begin;
 		this.EndValue = end;
-		this._Interval = interval;
+		this._msInterval = msInterval;
 		this.NormalTimer = timer;
-		this.NowTime = this.NormalTimer.NowTimeMs;
+		this.msNowTime = this.NormalTimer.NowTimeMs;
 		this.CurrentValue = (int)begin;
 		this.IsStarted = true;
 	}
@@ -109,14 +110,14 @@ public class CCounter {
 	/// </summary>
 	/// <param name="begin">最初のカウント値。</param>
 	/// <param name="end">最後のカウント値。</param>
-	/// <param name="interval">カウント値を１増加させるのにかける時間（秒単位）。</param>
+	/// <param name="msInterval">カウント値を１増加させるのにかける時間（ミリ秒単位）。</param>
 	/// <param name="timer">カウントに使用するタイマ。</param>
-	public void Start(double begin, double end, double interval, CSoundTimer timer) {
+	public void Start(double begin, double end, double msInterval, CSoundTimer timer) {
 		this.BeginValue = begin;
 		this.EndValue = end;
-		this._Interval = interval;
+		this._msInterval = msInterval;
 		this.TimerDB = timer;
-		this.NowTime = this.TimerDB.SystemTimeMs_Double;
+		this.msNowTime = this.TimerDB.SystemTimeMs_Double;
 		this.CurrentValue = (int)begin;
 		this.IsStarted = true;
 	}
@@ -126,16 +127,16 @@ public class CCounter {
 	/// カウント値が終了値に達している場合は、それ以上増加しない（終了値を維持する）。
 	/// </summary>
 	public void Tick() {
-		if ((this.NormalTimer != null) && (this.NowTime != CTimer.UnusedNum)) {
-			long num = this.NormalTimer.NowTimeMs;
-			if (num < this.NowTime)
-				this.NowTime = num;
+		if ((this.NormalTimer != null) && (this.msNowTime != CTimer.UnusedNum)) {
+			long msNow = this.NormalTimer.NowTimeMs;
+			if (msNow < this.msNowTime)
+				this.msNowTime = msNow;
 
-			while ((num - this.NowTime) >= this.Interval) {
+			while ((msNow - this.msNowTime) >= this.msInterval) {
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.EndValue;
 
-				this.NowTime += this.Interval;
+				this.msNowTime += this.msInterval;
 			}
 		}
 	}
@@ -145,16 +146,16 @@ public class CCounter {
 	/// カウント値が終了値に達している場合は、それ以上増加しない（終了値を維持する）。
 	/// </summary>
 	public void TickDB() {
-		if ((this.TimerDB != null) && (this.NowTime != CSoundTimer.UnusedNum)) {
-			double num = this.TimerDB.NowTimeMs;
-			if (num < this.NowTime)
-				this.NowTime = num;
+		if ((this.TimerDB != null) && (this.msNowTime != CSoundTimer.UnusedNum)) {
+			double msNow = this.TimerDB.NowTimeMs;
+			if (msNow < this.msNowTime)
+				this.msNowTime = msNow;
 
-			while ((num - this.NowTime) >= this.Interval) {
+			while ((msNow - this.msNowTime) >= this.msInterval) {
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.EndValue;
 
-				this.NowTime += this.Interval;
+				this.msNowTime += this.msInterval;
 			}
 		}
 	}
@@ -164,16 +165,16 @@ public class CCounter {
 	/// カウント値が終了値に達している場合は、次の増加タイミングで開始値に戻る（値がループする）。
 	/// </summary>
 	public void TickLoop() {
-		if ((this.NormalTimer != null) && (this.NowTime != CTimer.UnusedNum)) {
-			long num = this.NormalTimer.NowTimeMs;
-			if (num < this.NowTime)
-				this.NowTime = num;
+		if ((this.NormalTimer != null) && (this.msNowTime != CTimer.UnusedNum)) {
+			long msNow = this.NormalTimer.NowTimeMs;
+			if (msNow < this.msNowTime)
+				this.msNowTime = msNow;
 
-			while ((num - this.NowTime) >= this.Interval) {
+			while ((msNow - this.msNowTime) >= this.msInterval) {
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.BeginValue;
 
-				this.NowTime += this.Interval;
+				this.msNowTime += this.msInterval;
 			}
 		}
 	}
@@ -183,16 +184,16 @@ public class CCounter {
 	/// カウント値が終了値に達している場合は、次の増加タイミングで開始値に戻る（値がループする）。
 	/// </summary>
 	public void TickLoopDB() {
-		if ((this.TimerDB != null) && (this.NowTime != CSoundTimer.UnusedNum)) {
-			double num = this.TimerDB.NowTimeMs;
-			if (num < this.NowTime)
-				this.NowTime = num;
+		if ((this.TimerDB != null) && (this.msNowTime != CSoundTimer.UnusedNum)) {
+			double msNow = this.TimerDB.NowTimeMs;
+			if (msNow < this.msNowTime)
+				this.msNowTime = msNow;
 
-			while ((num - this.NowTime) >= this.Interval) {
+			while ((msNow - this.msNowTime) >= this.msInterval) {
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.BeginValue;
 
-				this.NowTime += this.Interval;
+				this.msNowTime += this.msInterval;
 			}
 		}
 	}
@@ -202,11 +203,11 @@ public class CCounter {
 	/// これ以降に t進行() や t進行Loop() を呼び出しても何も処理されない。
 	/// </summary>
 	public void Stop() {
-		this.NowTime = CTimer.UnusedNum;
+		this.msNowTime = CTimer.UnusedNum;
 	}
 
 	public void ChangeInterval(double Value) {
-		this._Interval = Value;
+		this._msInterval = Value;
 	}
 
 	// その他
@@ -232,23 +233,23 @@ public class CCounter {
 
 					keyProcess();
 					this.CurrentValue = second;
-					this.NowTime = this.NormalTimer.NowTimeMs;
+					this.msNowTime = this.NormalTimer.NowTimeMs;
 					return;
 
 				case second:
 
-					if ((this.NormalTimer.NowTimeMs - this.NowTime) > 200) {
+					if ((this.NormalTimer.NowTimeMs - this.msNowTime) > 200) {
 						keyProcess();
-						this.NowTime = this.NormalTimer.NowTimeMs;
+						this.msNowTime = this.NormalTimer.NowTimeMs;
 						this.CurrentValue = later;
 					}
 					return;
 
 				case later:
 
-					if ((this.NormalTimer.NowTimeMs - this.NowTime) > 30) {
+					if ((this.NormalTimer.NowTimeMs - this.msNowTime) > 30) {
 						keyProcess();
-						this.NowTime = this.NormalTimer.NowTimeMs;
+						this.msNowTime = this.NormalTimer.NowTimeMs;
 					}
 					return;
 			}
@@ -265,7 +266,7 @@ public class CCounter {
 	//-----------------
 	private CTimer NormalTimer;
 	private CSoundTimer TimerDB;
-	private double Interval;
+	private double msInterval;
 	//-----------------
 	#endregion
 }

--- a/FDK/src/00.Common/CCounter.cs
+++ b/FDK/src/00.Common/CCounter.cs
@@ -39,7 +39,7 @@ public class CCounter {
 			return this.msInterval;
 		}
 		set {
-			this.msInterval = value >= 0 ? value : value * -1;
+			this.msInterval = Math.Max(1e-6, Math.Abs(value));
 		}
 	}
 

--- a/FDK/src/00.Common/CCounter.cs
+++ b/FDK/src/00.Common/CCounter.cs
@@ -99,7 +99,7 @@ public class CCounter {
 		this.EndValue = end;
 		this._Interval = interval;
 		this.NormalTimer = timer;
-		this.NowTime = this.NormalTimer.NowTime;
+		this.NowTime = this.NormalTimer.NowTimeMs;
 		this.CurrentValue = (int)begin;
 		this.IsStarted = true;
 	}
@@ -116,7 +116,7 @@ public class CCounter {
 		this.EndValue = end;
 		this._Interval = interval;
 		this.TimerDB = timer;
-		this.NowTime = this.TimerDB.SystemTime_Double;
+		this.NowTime = this.TimerDB.SystemTimeMs_Double;
 		this.CurrentValue = (int)begin;
 		this.IsStarted = true;
 	}
@@ -127,7 +127,7 @@ public class CCounter {
 	/// </summary>
 	public void Tick() {
 		if ((this.NormalTimer != null) && (this.NowTime != CTimer.UnusedNum)) {
-			long num = this.NormalTimer.NowTime;
+			long num = this.NormalTimer.NowTimeMs;
 			if (num < this.NowTime)
 				this.NowTime = num;
 
@@ -146,7 +146,7 @@ public class CCounter {
 	/// </summary>
 	public void TickDB() {
 		if ((this.TimerDB != null) && (this.NowTime != CSoundTimer.UnusedNum)) {
-			double num = this.TimerDB.NowTime;
+			double num = this.TimerDB.NowTimeMs;
 			if (num < this.NowTime)
 				this.NowTime = num;
 
@@ -165,7 +165,7 @@ public class CCounter {
 	/// </summary>
 	public void TickLoop() {
 		if ((this.NormalTimer != null) && (this.NowTime != CTimer.UnusedNum)) {
-			long num = this.NormalTimer.NowTime;
+			long num = this.NormalTimer.NowTimeMs;
 			if (num < this.NowTime)
 				this.NowTime = num;
 
@@ -184,7 +184,7 @@ public class CCounter {
 	/// </summary>
 	public void TickLoopDB() {
 		if ((this.TimerDB != null) && (this.NowTime != CSoundTimer.UnusedNum)) {
-			double num = this.TimerDB.NowTime;
+			double num = this.TimerDB.NowTimeMs;
 			if (num < this.NowTime)
 				this.NowTime = num;
 
@@ -232,23 +232,23 @@ public class CCounter {
 
 					keyProcess();
 					this.CurrentValue = second;
-					this.NowTime = this.NormalTimer.NowTime;
+					this.NowTime = this.NormalTimer.NowTimeMs;
 					return;
 
 				case second:
 
-					if ((this.NormalTimer.NowTime - this.NowTime) > 200) {
+					if ((this.NormalTimer.NowTimeMs - this.NowTime) > 200) {
 						keyProcess();
-						this.NowTime = this.NormalTimer.NowTime;
+						this.NowTime = this.NormalTimer.NowTimeMs;
 						this.CurrentValue = later;
 					}
 					return;
 
 				case later:
 
-					if ((this.NormalTimer.NowTime - this.NowTime) > 30) {
+					if ((this.NormalTimer.NowTimeMs - this.NowTime) > 30) {
 						keyProcess();
-						this.NowTime = this.NormalTimer.NowTime;
+						this.NowTime = this.NormalTimer.NowTimeMs;
 					}
 					return;
 			}

--- a/FDK/src/00.Common/CCounter.cs
+++ b/FDK/src/00.Common/CCounter.cs
@@ -132,12 +132,16 @@ public class CCounter {
 			if (msNow < this.msNowTime)
 				this.msNowTime = msNow;
 
-			while ((msNow - this.msNowTime) >= this.msInterval) {
+			for (int i = 0; i < 8; ++i) {
+				if ((msNow - this.msNowTime) < this.msInterval)
+					return;
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.EndValue;
 
 				this.msNowTime += this.msInterval;
 			}
+
+			this.TickJump(msNow);
 		}
 	}
 
@@ -151,13 +155,31 @@ public class CCounter {
 			if (msNow < this.msNowTime)
 				this.msNowTime = msNow;
 
-			while ((msNow - this.msNowTime) >= this.msInterval) {
+			for (int i = 0; i < 8; ++i) {
+				if ((msNow - this.msNowTime) < this.msInterval)
+					return;
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.EndValue;
 
 				this.msNowTime += this.msInterval;
 			}
+
+			this.TickJump(msNow);
 		}
+	}
+
+	/// Jump over precalculated steps. Might be slower due to float division.
+	private void TickJump(double msNow) {
+		if ((msNow - this.msNowTime) < this.msInterval)
+			return;
+		int nStepsMax = (int)this.EndValue + 1 - (int)this.BeginValue;
+		long nSteps = (long)((msNow - this.msNowTime) / this.msInterval);
+		if (nSteps >= nStepsMax // attempt to prevent overflow
+			|| (this.CurrentValue += (int)nSteps) > this.EndValue
+			) {
+			this.CurrentValue = (int)this.EndValue;
+		}
+		this.msNowTime += nSteps * this.msInterval;
 	}
 
 	/// <summary>
@@ -170,12 +192,16 @@ public class CCounter {
 			if (msNow < this.msNowTime)
 				this.msNowTime = msNow;
 
-			while ((msNow - this.msNowTime) >= this.msInterval) {
+			for (int i = 0; i < 8; ++i) {
+				if ((msNow - this.msNowTime) < this.msInterval)
+					return;
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.BeginValue;
 
 				this.msNowTime += this.msInterval;
 			}
+
+			this.TickLoopJump(msNow);
 		}
 	}
 
@@ -189,13 +215,30 @@ public class CCounter {
 			if (msNow < this.msNowTime)
 				this.msNowTime = msNow;
 
-			while ((msNow - this.msNowTime) >= this.msInterval) {
+			for (int i = 0; i < 8; ++i) {
+				if ((msNow - this.msNowTime) < this.msInterval)
+					return;
 				if (++this.CurrentValue > this.EndValue)
 					this.CurrentValue = (int)this.BeginValue;
 
 				this.msNowTime += this.msInterval;
 			}
+
+			this.TickLoopJump(msNow);
 		}
+	}
+
+	/// Jump over precalculated steps. Might be slower due to float division.
+	private void TickLoopJump(double msNow) {
+		if ((msNow - this.msNowTime) < this.msInterval)
+			return;
+		int nStepsMax = (int)this.EndValue + 1 - (int)this.BeginValue;
+		long nSteps = (long)((msNow - this.msNowTime) / this.msInterval);
+		int dVal = (int)(nSteps % nStepsMax); // attempt to prevent overflow
+		if ((this.CurrentValue += dVal) > this.EndValue) {
+			this.CurrentValue = (int)this.BeginValue;
+		}
+		this.msNowTime += nSteps * this.msInterval;
 	}
 
 	/// <summary>

--- a/FDK/src/00.Common/CFPS.cs
+++ b/FDK/src/00.Common/CFPS.cs
@@ -23,7 +23,7 @@ public class CFPS {
 		this.NowFPS = 0;
 		this.DeltaTime = 0;
 		this.FPSTimer = new CTimer(CTimer.TimerType.MultiMedia);
-		this.BeginTime = this.FPSTimer.NowTime;
+		this.BeginTime = this.FPSTimer.NowTimeMs;
 		this.CoreFPS = 0;
 		this.ChangedFPS = false;
 	}
@@ -36,9 +36,9 @@ public class CFPS {
 		this.ChangedFPS = false;
 
 		const long INTERVAL = 1000;
-		this.DeltaTime = (this.FPSTimer.NowTime - this.PrevFrameTime) / 1000.0;
-		PrevFrameTime = this.FPSTimer.NowTime;
-		while ((this.FPSTimer.NowTime - this.BeginTime) >= INTERVAL) {
+		this.DeltaTime = (this.FPSTimer.NowTimeMs - this.PrevFrameTime) / 1000.0;
+		PrevFrameTime = this.FPSTimer.NowTimeMs;
+		while ((this.FPSTimer.NowTimeMs - this.BeginTime) >= INTERVAL) {
 			this.NowFPS = this.CoreFPS;
 			this.CoreFPS = 0;
 			this.ChangedFPS = true;

--- a/FDK/src/00.Common/CTimerBase.cs
+++ b/FDK/src/00.Common/CTimerBase.cs
@@ -17,31 +17,6 @@ public abstract class CTimerBase : IDisposable {
 	}
 	public abstract void Dispose();
 
-	#region [ DTXMania用に、語尾にmsのつかない宣言を追加 ]
-	public long SystemTime {
-		get { return SystemTimeMs; }
-	}
-	public long NowTime {
-		get { return NowTimeMs; }
-		set { NowTimeMs = value; }
-	}
-	public long PrevResetTime {
-		get { return PrevResetTimeMs; }
-	}
-
-	//double
-	public double SystemTime_Double {
-		get { return SystemTimeMs_Double; }
-	}
-	public double NowTime_Double {
-		get { return NowTimeMs_Double; }
-		set { NowTimeMs_Double = value; }
-	}
-	public double PrevResetTime_Double {
-		get { return PrevResetTimeMs_Double; }
-	}
-	#endregion
-
 	public long NowTimeMs {
 		get {
 			if (this.StopCount > 0)

--- a/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
@@ -1083,7 +1083,7 @@ internal class CActConfigList : CActivity {
 		#region [ 初めての進行描画 ]
 		//-----------------
 		if (base.IsFirstDraw) {
-			this.nスクロール用タイマ値 = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.nスクロール用タイマ値 = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 			this.ct三角矢印アニメ.Start(0, 9, 50, OpenTaiko.Timer);
 			base.IsFirstDraw = false;
 		}
@@ -1094,7 +1094,7 @@ internal class CActConfigList : CActivity {
 
 		#region [ 項目スクロールの進行 ]
 		//-----------------
-		long n現在時刻 = OpenTaiko.Timer.NowTime;
+		long n現在時刻 = OpenTaiko.Timer.NowTimeMs;
 		if (n現在時刻 < this.nスクロール用タイマ値) this.nスクロール用タイマ値 = n現在時刻;
 
 		const int INTERVAL = 2; // [ms]

--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelectPreimageパネル.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelectPreimageパネル.cs
@@ -50,7 +50,7 @@ internal class CActSelectPreimageパネル : CActivity {
 				if ((this.ctDelayedDisplay.CurrentValue >= 0) && this.bNewPreimageStillLoading) {
 					this.tUpdatePreimage(OpenTaiko.stageSongSelect.r現在選択中のスコア);
 					OpenTaiko.Timer.Update();
-					this.ctDelayedDisplay.NowTime = OpenTaiko.Timer.NowTime;
+					this.ctDelayedDisplay.NowTime = OpenTaiko.Timer.NowTimeMs;
 					this.bNewPreimageLoaded = true;
 				} else if (this.ctDelayedDisplay.IsEnded && this.ctDelayedDisplay.IsTicked) {
 					this.ctDelayedDisplay.Stop();

--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelectPreimageパネル.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelectPreimageパネル.cs
@@ -50,7 +50,7 @@ internal class CActSelectPreimageパネル : CActivity {
 				if ((this.ctDelayedDisplay.CurrentValue >= 0) && this.bNewPreimageStillLoading) {
 					this.tUpdatePreimage(OpenTaiko.stageSongSelect.r現在選択中のスコア);
 					OpenTaiko.Timer.Update();
-					this.ctDelayedDisplay.NowTime = OpenTaiko.Timer.NowTimeMs;
+					this.ctDelayedDisplay.msNowTime = OpenTaiko.Timer.NowTimeMs;
 					this.bNewPreimageLoaded = true;
 				} else if (this.ctDelayedDisplay.IsEnded && this.ctDelayedDisplay.IsTicked) {
 					this.ctDelayedDisplay.Stop();

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
@@ -1373,7 +1373,7 @@ internal class CStageSongSelect : CStage {
 			STCommandTime _stct = new STCommandTime {
 				eInst = _eInst,
 				ePad = _ePad,
-				time = OpenTaiko.Timer.NowTime
+				time = OpenTaiko.Timer.NowTimeMs
 			};
 
 			if (stct.Count >= buffersize) {
@@ -1400,7 +1400,7 @@ internal class CStageSongSelect : CStage {
 				return false;
 			}
 
-			long curTime = OpenTaiko.Timer.NowTime;
+			long curTime = OpenTaiko.Timer.NowTimeMs;
 			//Debug.WriteLine("Start checking...targetCount=" + targetCount);
 			for (int i = targetCount - 1, j = stciCount - 1; i >= 0; i--, j--) {
 				if (_ePad[i] != stct[j].ePad) {

--- a/OpenTaiko/src/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/OpenTaiko/src/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -140,11 +140,11 @@ internal class CStage曲読み込み : CStage {
 					CSkin.CSystemSound.r最後に再生した排他システムサウンド.tStop();
 				}
 				this.sd読み込み音.PlayStart();
-				this.nBGM再生開始時刻 = SoundManager.PlayTimer.NowTime;
+				this.nBGM再生開始時刻 = SoundManager.PlayTimer.NowTimeMs;
 				this.nBGMの総再生時間ms = this.sd読み込み音.TotalPlayTime;
 			} else {
 				OpenTaiko.Skin.sound曲読込開始音.tPlay();
-				this.nBGM再生開始時刻 = SoundManager.PlayTimer.NowTime;
+				this.nBGM再生開始時刻 = SoundManager.PlayTimer.NowTimeMs;
 				this.nBGMの総再生時間ms = OpenTaiko.Skin.sound曲読込開始音.n長さ_現在のサウンド;
 			}
 			//this.actFI.tフェードイン開始();							// #27787 2012.3.10 yyagi 曲読み込み画面のフェードインの省略
@@ -472,7 +472,7 @@ internal class CStage曲読み込み : CStage {
 				}
 
 			case CStage.EPhase.SongLoading_WaitForSoundSystemBGM: {
-					long nCurrentTime = OpenTaiko.Timer.NowTime;
+					long nCurrentTime = OpenTaiko.Timer.NowTimeMs;
 					if (nCurrentTime < this.nBGM再生開始時刻)
 						this.nBGM再生開始時刻 = nCurrentTime;
 

--- a/OpenTaiko/src/Stages/07.Game/CActTaikoScrollSpeed.cs
+++ b/OpenTaiko/src/Stages/07.Game/CActTaikoScrollSpeed.cs
@@ -31,13 +31,13 @@ internal class CActTaikoScrollSpeed : CActivity {
 		if (!base.IsDeActivated) {
 			if (base.IsFirstDraw) {
 				for (int i = 0; i < 5; i++) {
-					this.nScrollExclusiveTimer[i] = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+					this.nScrollExclusiveTimer[i] = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 
 				}
 
 				base.IsFirstDraw = false;
 			}
-			long nNowTime = SoundManager.PlayTimer.NowTime;
+			long nNowTime = SoundManager.PlayTimer.NowTimeMs;
 			for (int i = 0; i < 5; i++) {
 				double dbScrollSpeed = (double)OpenTaiko.ConfigIni.nScrollSpeed[OpenTaiko.GetActualPlayer(i)];
 				if (nNowTime < this.nScrollExclusiveTimer[i]) {

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏Combo共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏Combo共通.cs
@@ -575,11 +575,11 @@ internal class CAct演奏Combo共通 : CActivity {
 			#region [ nジャンプインデックス値 の進行。]
 			//-----------------
 			if (this.status[i].nジャンプインデックス値 < 360) {
-				if ((this.status[i].n前回の時刻_ジャンプ用 == -1) || (OpenTaiko.Timer.NowTime < this.status[i].n前回の時刻_ジャンプ用))
-					this.status[i].n前回の時刻_ジャンプ用 = OpenTaiko.Timer.NowTime;
+				if ((this.status[i].n前回の時刻_ジャンプ用 == -1) || (OpenTaiko.Timer.NowTimeMs < this.status[i].n前回の時刻_ジャンプ用))
+					this.status[i].n前回の時刻_ジャンプ用 = OpenTaiko.Timer.NowTimeMs;
 
 				const long INTERVAL = 2;
-				while ((OpenTaiko.Timer.NowTime - this.status[i].n前回の時刻_ジャンプ用) >= INTERVAL) {
+				while ((OpenTaiko.Timer.NowTimeMs - this.status[i].n前回の時刻_ジャンプ用) >= INTERVAL) {
 					if (this.status[i].nジャンプインデックス値 < 2000)
 						this.status[i].nジャンプインデックス値 += 3;
 
@@ -600,7 +600,7 @@ internal class CAct演奏Combo共通 : CActivity {
 						// モード変更
 						this.status[i].e現在のモード = EMode.進行表示中;
 						this.status[i].nジャンプインデックス値 = 0;
-						this.status[i].n前回の時刻_ジャンプ用 = OpenTaiko.Timer.NowTime;
+						this.status[i].n前回の時刻_ジャンプ用 = OpenTaiko.Timer.NowTimeMs;
 						goto Retry;
 					}
 
@@ -617,13 +617,13 @@ internal class CAct演奏Combo共通 : CActivity {
 						// モード変更
 						this.status[i].e現在のモード = EMode.残像表示中;
 						this.status[i].n残像表示中のCOMBO値 = this.status[i].n現在表示中のCOMBO値;
-						this.status[i].nコンボが切れた時刻 = OpenTaiko.Timer.NowTime;
+						this.status[i].nコンボが切れた時刻 = OpenTaiko.Timer.NowTimeMs;
 						goto Retry;
 					}
 
 					if (e今回の状態遷移イベント == EEvent.数値更新) {
 						this.status[i].nジャンプインデックス値 = 0;
-						this.status[i].n前回の時刻_ジャンプ用 = OpenTaiko.Timer.NowTime;
+						this.status[i].n前回の時刻_ジャンプ用 = OpenTaiko.Timer.NowTimeMs;
 					}
 
 					this.status[i].n現在表示中のCOMBO値 = this.status[i].nCOMBO値;
@@ -660,7 +660,7 @@ internal class CAct演奏Combo共通 : CActivity {
 						this.status[i].e現在のモード = EMode.進行表示中;
 						goto Retry;
 					}
-					if ((OpenTaiko.Timer.NowTime - this.status[i].nコンボが切れた時刻) > 1000) {
+					if ((OpenTaiko.Timer.NowTimeMs - this.status[i].nコンボが切れた時刻) > 1000) {
 						// モード変更２
 						this.status[i].e現在のモード = EMode.非表示中;
 						goto Retry;

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏ステージ失敗.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏ステージ失敗.cs
@@ -62,7 +62,7 @@ internal class CAct演奏ステージ失敗 : CActivity {
 	// メソッド
 
 	public void Start() {
-		this.dbFailedTime = OpenTaiko.Timer.NowTime;
+		this.dbFailedTime = OpenTaiko.Timer.NowTimeMs;
 		this.ct進行 = new CCounter(0, 300, 22, OpenTaiko.Timer);
 		if (OpenTaiko.ConfigIni.eGameMode != EGame.Off) {
 			this.ct進行 = new CCounter(0, 4000, 2, OpenTaiko.Timer);

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
@@ -48,7 +48,7 @@ internal class CAct演奏演奏情報 : CActivity {
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Song/G. Offset:{0:####0}/{1:####0} ms", OpenTaiko.TJA.nBGMAdjust, OpenTaiko.ConfigIni.nGlobalOffsetMs));
 			y -= 0x10;
 			int num = (OpenTaiko.TJA.listChip.Count > 0) ? OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms : 0;
-			string str = "Time:          " + ((((double)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0)).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
+			string str = "Time:          " + ((((double)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0)).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, str);
 			y -= 0x10;
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Part:          {0:####0}/{1:####0}", NowMeasure[0], NowMeasure[1]));

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -1444,7 +1444,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (this.bPAUSE == false && rollSpeed > 0) // && TJAPlayer3.ConfigIni.bAuto先生の連打)
 					{
 						double rollSpeedScaled = rollSpeed / OpenTaiko.ConfigIni.SongPlaybackSpeed;
-						if ((SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)
+						if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)
 							> (pChip.n発声時刻ms + (1000.0 / rollSpeedScaled) * pChip.nRollCount)) {
 							EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(nPlayer)];
 							int nLane = 0;
@@ -1466,13 +1466,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 							if (pChip.nChannelNo == 0x20 && _gt == EGameType.Konga) nLane = 4;
 							else if (pChip.nChannelNo == 0x21 && _gt == EGameType.Konga) nLane = 1;
 
-							this.tRollProcess(pChip, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), 1, nLane, 0, nPlayer);
+							this.tRollProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 1, nLane, 0, nPlayer);
 						}
 					}
 				}
 				if (!bAutoPlay && !rollEffectHit) {
 					this.eRollState = ERollState.Roll;
-					this.tRollProcess(pChip, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), 1, nNowInput, 0, nPlayer);
+					this.tRollProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 1, nNowInput, 0, nPlayer);
 				}
 				//---------------------------
 				#endregion
@@ -1526,7 +1526,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 						int balloonDuration = bAutoPlay ? (pChip.nNoteEndTimems - pChip.n発声時刻ms) : 1000;
 
-						if ((SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed) >
+						if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) >
 							(pChip.n発声時刻ms + (balloonDuration / (double)rollSpeed) * rollCount)) {
 							if (this.nHand[nPlayer] == 0)
 								this.nHand[nPlayer]++;
@@ -1536,18 +1536,18 @@ internal abstract class CStage演奏画面共通 : CStage {
 							OpenTaiko.stageGameScreen.actTaikoLaneFlash.PlayerLane[nPlayer].Start(PlayerLane.FlashType.Red);
 							OpenTaiko.stageGameScreen.actMtaiko.tMtaikoEvent(pChip.nChannelNo, this.nHand[nPlayer], nPlayer);
 
-							this.tBalloonProcess(pChip, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), nPlayer);
+							this.tBalloonProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), nPlayer);
 						}
 					}
 				}
 				if (!bAutoPlay && !rollEffectHit) {
 					if (!IsKusudama || nCurrentKusudamaCount > 0) {
-						this.tBalloonProcess(pChip, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), nPlayer);
+						this.tBalloonProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), nPlayer);
 					}
 				}
 				#endregion
 			} else if (NotesManager.IsRollEnd(pChip)) {
-				if (pChip.nNoteEndTimems <= (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+				if (pChip.nNoteEndTimems <= (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
 					if (NotesManager.IsKusudama(pChip)) {
 						for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 							chip現在処理中の連打チップ[i].bHit = true;
@@ -2618,12 +2618,12 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
 
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eNormal, 0, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eNormal, 0, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eNormal, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eNormal, 0);
@@ -2643,13 +2643,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 				//rc演奏用タイマ.n現在時刻msから引っ張ることに
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
 
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eExpert, 0, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eExpert, 0, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eExpert, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eExpert, 0);
@@ -2669,13 +2669,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 				//rc演奏用タイマ.n現在時刻msから引っ張ることに
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
 
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eMaster, 0, (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eMaster, 0, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eMaster, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eMaster, 0);
@@ -2940,7 +2940,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!pChip.bHit && time < 0) {
 						pChip.bHit = true;
 						if (configIni.bBGMPlayVoiceSound) {
-							dTX.tチップの再生(pChip, SoundManager.PlayTimer.PrevResetTime + (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed));
+							dTX.tチップの再生(pChip, SoundManager.PlayTimer.PrevResetTimeMs + (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed));
 						}
 					}
 					break;
@@ -4059,7 +4059,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				break;
 		}
 
-		var n現在時刻ms = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		var n現在時刻ms = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 
 		//for ( int nCurrentTopChip = this.n現在のトップChip; nCurrentTopChip < dTX.listChip.Count; nCurrentTopChip++ )
 		for (int nCurrentTopChip = dTX.listChip.Count - 1; nCurrentTopChip > 0; nCurrentTopChip--) {
@@ -4550,7 +4550,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 										//{
 		SoundManager.PlayTimer.Pause();
 		//}
-		SoundManager.PlayTimer.NowTime = nStartTime;
+		SoundManager.PlayTimer.NowTimeMs = nStartTime;
 		#endregion
 
 		List<CSound> pausedCSound = new List<CSound>();
@@ -4569,7 +4569,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!b) continue;
 
 					if ((wc.bIsBGMSound && OpenTaiko.ConfigIni.bBGMPlayVoiceSound) || (!wc.bIsBGMSound)) {
-						OpenTaiko.TJA.tチップの再生(pChip, (long)(SoundManager.PlayTimer.PrevResetTime) + (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed));
+						OpenTaiko.TJA.tチップの再生(pChip, (long)(SoundManager.PlayTimer.PrevResetTimeMs) + (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed));
 						#region [ PAUSEする ]
 						int j = wc.n現在再生中のサウンド番号;
 						if (wc.rSound[j] != null) {
@@ -4608,9 +4608,9 @@ internal abstract class CStage演奏画面共通 : CStage {
 		#endregion
 		pausedCSound.Clear();
 		#region [ タイマを再開して、PAUSEから復帰する ]
-		SoundManager.PlayTimer.NowTime = nStartTime;
+		SoundManager.PlayTimer.NowTimeMs = nStartTime;
 		OpenTaiko.Timer.Reset();                       // これでPAUSE解除されるので、3行先の再開()は不要
-		OpenTaiko.Timer.NowTime = nStartTime;              // Debug表示のTime: 表記を正しくするために必要
+		OpenTaiko.Timer.NowTimeMs = nStartTime;              // Debug表示のTime: 表記を正しくするために必要
 		SoundManager.PlayTimer.Resume();
 		//CDTXMania.Timer.t再開();
 		this.bPAUSE = false;                                // システムがPAUSE状態だったら、強制解除

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -53,7 +53,7 @@ internal class CActImplLaneTaiko : CActivity {
 	public override int Draw() {
 		if (base.IsFirstDraw) {
 			for (int i = 0; i < 5; i++)
-				this.stBranch[i].nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				this.stBranch[i].nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 			base.IsFirstDraw = false;
 		}
 
@@ -93,7 +93,7 @@ internal class CActImplLaneTaiko : CActivity {
 
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			#region[ 分岐アニメ制御タイマー ]
-			long num = FDK.SoundManager.PlayTimer.NowTime;
+			long num = FDK.SoundManager.PlayTimer.NowTimeMs;
 			if (num < this.stBranch[i].nフラッシュ制御タイマ) {
 				this.stBranch[i].nフラッシュ制御タイマ = num;
 			}
@@ -581,7 +581,7 @@ internal class CActImplLaneTaiko : CActivity {
             }
             */
 		}
-		var nTime = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		var nTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			if (this.n総移動時間[i] != -1) {
@@ -791,7 +791,7 @@ internal class CActImplLaneTaiko : CActivity {
 	}
 
 	public void t判定枠移動(double db移動時間, int n移動px, int n移動方向, int nPlayer, int vJs) {
-		this.n移動開始時刻[nPlayer] = (int)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		this.n移動開始時刻[nPlayer] = (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 		this.n移動開始X[nPlayer] = OpenTaiko.stageGameScreen.JPOSCROLLX[nPlayer];
 		this.n移動開始Y[nPlayer] = OpenTaiko.stageGameScreen.JPOSCROLLY[nPlayer];
 		this.n総移動時間[nPlayer] = (int)(db移動時間 * 1000);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMtaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMtaiko.cs
@@ -48,11 +48,11 @@ internal class CActImplMtaiko : CActivity {
 
 	public override int Draw() {
 		if (base.IsFirstDraw) {
-			this.nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 			base.IsFirstDraw = false;
 		}
 
-		long num = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		long num = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 		if (num < this.nフラッシュ制御タイマ) {
 			this.nフラッシュ制御タイマ = num;
 		}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplPad.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplPad.cs
@@ -43,11 +43,11 @@ internal class CActImplPad : CActivity {
 	public override int Draw() {
 		if (!base.IsDeActivated) {
 			if (base.IsFirstDraw) {
-				this.nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
-				this.nY座標制御タイマ = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				this.nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				this.nY座標制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 				base.IsFirstDraw = false;
 			}
-			long num = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			long num = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 			if (num < this.nフラッシュ制御タイマ) {
 				this.nフラッシュ制御タイマ = num;
 			}
@@ -59,7 +59,7 @@ internal class CActImplPad : CActivity {
 				}
 				this.nフラッシュ制御タイマ += 15;
 			}
-			long num3 = SoundManager.PlayTimer.NowTime;
+			long num3 = SoundManager.PlayTimer.NowTimeMs;
 			if (num3 < this.nY座標制御タイマ) {
 				this.nY座標制御タイマ = num3;
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplScore.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplScore.cs
@@ -10,7 +10,7 @@ internal class CActImplScore : CAct演奏スコア共通 {
 			if (base.IsFirstDraw) {
 				base.IsFirstDraw = false;
 			}
-			long num = FDK.SoundManager.PlayTimer.NowTime;
+			long num = FDK.SoundManager.PlayTimer.NowTimeMs;
 
 
 			if (!this.ctTimer.IsStoped) {

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -388,7 +388,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			if (this.st叩ききりまショー.bタイマー使用中) {
 				if (!this.st叩ききりまショー.ct残り時間.IsStoped || this.st叩ききりまショー.b加算アニメ中 == true) {
 					this.st叩ききりまショー.ct残り時間.Tick();
-					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0, 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
+					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0, 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
 						this.st叩ききりまショー.bタイマー使用中 = false;
 						this.st叩ききりまショー.ct残り時間.Stop();
 					}
@@ -498,7 +498,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 		double n延長する時間 = 0;
 
 		//最後に延長した時刻から11秒経過していなければ延長を行わない。
-		if (this.n最後に時間延長した時刻 + 11000 <= (SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+		if (this.n最後に時間延長した時刻 + 11000 <= (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
 			//1項目につき5秒
 			//-精度
 			if (this.st叩ききりまショー.nヒット数_PERFECT != 0 || this.st叩ききりまショー.nヒット数_GREAT != 0) {
@@ -590,7 +590,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			#endregion
 
 
-			this.n最後に時間延長した時刻 = (int)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.n最後に時間延長した時刻 = (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 			if (this.st叩ききりまショー.n区間ノート数 == 0)
@@ -651,7 +651,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			}
 
 
-			this.n最後に時間延長した時刻 = (int)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.n最後に時間延長した時刻 = (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -489,7 +489,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			this.t進行描画_演奏情報();
 
-			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
 				this.actPanel.t歌詞テクスチャを生成する(OpenTaiko.TJA.listLyric2[ShownLyric2++].TextTex);
 			}
 
@@ -1930,7 +1930,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			var chkChip = this.chip現在処理中の連打チップ[i];
 			if (chkChip != null) {
-				long nowTime = (long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				long nowTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 				//int n = this.chip現在処理中の連打チップ[i].nチャンネル番号;
 				if ((NotesManager.IsGenericBalloon(chkChip) || NotesManager.IsKusudama(chkChip)) && (this.bCurrentlyDrumRoll[i] == true)) {
 					//if (this.chip現在処理中の連打チップ.n発声時刻ms <= (int)CSound管理.rc演奏用タイマ.n現在時刻ms && this.chip現在処理中の連打チップ.nノーツ終了時刻ms >= (int)CSound管理.rc演奏用タイマ.n現在時刻ms)
@@ -1959,7 +1959,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		//常時イベントが発生しているメソッドのほうがいいんじゃないかという予想。
 		//CDTX.CChip chipNoHit = this.r指定時刻に一番近い未ヒットChip((int)CSound管理.rc演奏用タイマ.n現在時刻ms, 0);
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
-			CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed), i);
+			CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), i);
 
 			EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(i)];
 			bool _isBigKaTaiko = NotesManager.IsBigKaTaiko(chipNoHit, _gt);
@@ -1968,10 +1968,10 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			if (chipNoHit != null && (_isBigDonTaiko || _isBigKaTaiko)) {
 				CConfigIni.CTimingZones tz = this.GetTimingZones(i);
-				float timeC = chipNoHit.n発声時刻ms - (float)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				float timeC = chipNoHit.n発声時刻ms - (float)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 				int nWaitTime = OpenTaiko.ConfigIni.nBigNoteWaitTimems;
 				if (chipNoHit.eNoteState == ENoteState.Wait && timeC <= tz.nBadZone
-															&& chipNoHit.nProcessTime + nWaitTime <= (int)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+															&& chipNoHit.nProcessTime + nWaitTime <= (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
 					if (!_isSwapNote) {
 						this.tドラムヒット処理(chipNoHit.nProcessTime, EPad.RRed, chipNoHit, false, i);
 						//this.nWaitButton = 0;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -267,8 +267,8 @@ internal class Dan_Cert : CActivity {
 
 				if (OpenTaiko.TJA.listChip.Count > 0) {
 					if (ExamChange[i]
-							? OpenTaiko.TJA.pDan_LastChip[NowShowingNumber].n発声時刻ms <= SoundManager.PlayTimer.NowTime//TJAPlayer3.Timer.n現在時刻
-							: OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms <= SoundManager.PlayTimer.NowTime)//TJAPlayer3.Timer.n現在時刻)
+							? OpenTaiko.TJA.pDan_LastChip[NowShowingNumber].n発声時刻ms <= SoundManager.PlayTimer.NowTimeMs//TJAPlayer3.Timer.n現在時刻
+							: OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms <= SoundManager.PlayTimer.NowTimeMs)//TJAPlayer3.Timer.n現在時刻)
 					{
 						switch (Challenge[i].GetExamType()) {
 							case Exam.Type.Score:

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -253,7 +253,7 @@ class ScriptBG : IDisposable {
 				double timeoffset = OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? -2.0 : -8.2;
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
-				timestamp = (((double)(SoundManager.PlayTimer.NowTime * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0) +
+				timestamp = (((double)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0) +
 							(-(OpenTaiko.ConfigIni.MusicPreTimeMs + OpenTaiko.TJA.nOFFSET) / 1000.0) +
 							timeoffset;
 			}


### PR DESCRIPTION
This should not affect the game performance in average gameplay.

## Before

* 60fps-ish (debug build) in 愛歌「ネグラドルナ」(kirura969), halts at end.
* 480fps-ish in average gameplay (debug build)

## After

* 60fps-ish (debug build) in 愛歌「ネグラドルナ」(kirura969), no halts at end.

https://github.com/user-attachments/assets/2bc0057e-ee61-4cf3-b374-8098dead215b

* 480fps-ish in average gameplay (debug build)

IMO the difference of fps is not very significant.