### PR TITLE
Fix input timestamp inaccuracy

### DIFF
--- a/FDK/src/00.Common/CTimer.cs
+++ b/FDK/src/00.Common/CTimer.cs
@@ -5,9 +5,9 @@ namespace FDK;
 public class CTimer : CTimerBase {
 	public enum TimerType {
 		Unknown = -1,
-		PerformanceCounter = 0,
-		MultiMedia = 0, // deprecated. was Windows-only, now treated the same as PerformanceCounter
-		GetTickCount = 2,
+		PerformanceCounter = 0, // always accurate, mainly for event-based input timing
+		MultiMedia = 1, // same accuracy at integer frame but not fraction frame, mainly for drawing
+		GetTickCount = 2, // 10~16ms low precision (unused)
 	}
 	public TimerType CurrentTimerType {
 		get;
@@ -20,6 +20,9 @@ public class CTimer : CTimerBase {
 			switch (this.CurrentTimerType) {
 				case TimerType.PerformanceCounter:
 					return performanceTimer?.ElapsedMilliseconds ?? 0;
+
+				case TimerType.MultiMedia:
+					return SampleFramework.Game.TimeMs;
 
 				case TimerType.GetTickCount:
 					return (long)Environment.TickCount;
@@ -37,6 +40,9 @@ public class CTimer : CTimerBase {
 				case TimerType.PerformanceCounter:
 					if (!this.GetSetPerformanceCounter())
 						this.GetSetTickCount();
+					break;
+
+				case TimerType.MultiMedia:
 					break;
 
 				case TimerType.GetTickCount:

--- a/FDK/src/00.Common/CTimerBase.cs
+++ b/FDK/src/00.Common/CTimerBase.cs
@@ -92,7 +92,7 @@ public abstract class CTimerBase : IDisposable {
 
 		this.StopCount++;
 	}
-	public void Update() {
+	public virtual void Update() {
 		this.UpdateSystemTime = this.SystemTimeMs;
 		this.UpdateSystemTime_Double = this.SystemTimeMs_Double;
 	}

--- a/FDK/src/02.Input/CInputButtonsBase.cs
+++ b/FDK/src/02.Input/CInputButtonsBase.cs
@@ -1,0 +1,102 @@
+﻿namespace FDK;
+
+public abstract class CInputButtonsBase : IInputDevice, IDisposable {
+	// Constructor
+
+	public CInputButtonsBase() {
+		this.ButtonStates = [];
+		this.InputEvents = new List<STInputEvent>(32);
+	}
+
+
+	// メソッド
+
+	public void SetID(int nID) => this.ID = nID;
+
+	#region [ IInputDevice 実装 ]
+	//-----------------
+	public InputDeviceType CurrentType { get; protected set; }
+	public string GUID { get; protected set; }
+	public int ID { get; protected set; }
+	public string Name { get; protected set; }
+	public List<STInputEvent> InputEvents { get; protected set; }
+	public string strDeviceName { get; set; }
+
+	public virtual void Polling(bool useBufferInput) {
+		InputEvents.Clear();
+
+		for (int i = 0; i < ButtonStates.Length; i++) {
+			if (ButtonStates[i].isPressed) {
+				if (ButtonStates[i].state >= 1) {
+					ButtonStates[i].state = 2;
+				} else {
+					ButtonStates[i].state = 1;
+
+					InputEvents.Add(
+						new STInputEvent() {
+							nKey = i,
+							Pressed = true,
+							Released = false,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
+							nVelocity = 0,
+						}
+					);
+				}
+			} else {
+				if (ButtonStates[i].state <= -1) {
+					ButtonStates[i].state = -2;
+				} else {
+					ButtonStates[i].state = -1;
+
+					InputEvents.Add(
+						new STInputEvent() {
+							nKey = i,
+							Pressed = false,
+							Released = true,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
+							nVelocity = 0,
+						}
+					);
+				}
+			}
+		}
+	}
+
+	public bool KeyPressed(int nButton) {
+		return ButtonStates[nButton].state == 1;
+	}
+	public bool KeyPressing(int nButton) {
+		return ButtonStates[nButton].state >= 1;
+	}
+	public bool KeyReleased(int nButton) {
+		return ButtonStates[nButton].state == -1;
+	}
+	public bool KeyReleasing(int nButton) {
+		return ButtonStates[nButton].state <= -1;
+	}
+	//-----------------
+	#endregion
+
+	#region [ IDisposable 実装 ]
+	//-----------------
+	public void Dispose() {
+		if (!this.IsDisposed) {
+			if (this.InputEvents != null) {
+				this.InputEvents = null;
+			}
+			this.IsDisposed = true;
+		}
+	}
+	//-----------------
+	#endregion
+
+
+	// その他
+
+	#region [ private ]
+	//-----------------
+	public (bool isPressed, int state)[] ButtonStates { get; protected set; }
+	private bool IsDisposed;
+	//-----------------
+	#endregion
+}

--- a/FDK/src/02.Input/CInputButtonsBase.cs
+++ b/FDK/src/02.Input/CInputButtonsBase.cs
@@ -21,8 +21,9 @@ public abstract class CInputButtonsBase : IInputDevice, IDisposable {
 	public string Name { get; protected set; }
 	public List<STInputEvent> InputEvents { get; protected set; }
 	public string strDeviceName { get; set; }
+	public bool useBufferInput { get; set; }
 
-	public void Polling(bool useBufferInput) {
+	public void Polling() {
 		InputEvents.Clear();
 
 		for (int i = 0; i < ButtonStates.Length; i++) {

--- a/FDK/src/02.Input/CInputButtonsBase.cs
+++ b/FDK/src/02.Input/CInputButtonsBase.cs
@@ -32,20 +32,21 @@ public abstract class CInputButtonsBase : IInputDevice, IDisposable {
 		// update per-frame button state, also fill the new input buffer for non-buffered input
 		// for buffered input, the input buffer has already been filled.
 		for (int i = 0; i < ButtonStates.Length; i++) {
-			this.ProcessButtonState(i);
+			// Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
+			this.ProcessButtonState(i, SoundManager.PlayTimer.SystemTimeMs);
 		}
 		// swap input buffer
 		(this.InputEvents, this.EventBuffer) = (this.EventBuffer, this.InputEvents);
 	}
 
-	protected void ProcessButtonState(int idxBtn) {
+	protected void ProcessButtonState(int idxBtn, long msTimestamp) {
 		if (ButtonStates[idxBtn].isPressed) {
 			if (ButtonStates[idxBtn].state >= 1) {
 				ButtonStates[idxBtn].state = 2;
 			} else {
 				ButtonStates[idxBtn].state = 1;
 				if (!this.useBufferInput) {
-					this.AddPressedEvent(idxBtn);
+					this.AddPressedEvent(idxBtn, msTimestamp);
 				}
 			}
 		} else {
@@ -54,40 +55,40 @@ public abstract class CInputButtonsBase : IInputDevice, IDisposable {
 			} else {
 				ButtonStates[idxBtn].state = -1;
 				if (!this.useBufferInput) {
-					this.AddReleasedEvent(idxBtn);
+					this.AddReleasedEvent(idxBtn, msTimestamp);
 				}
 			}
 		}
 	}
 
-	protected void AddReleasedEvent(int idxBtn)
+	protected void AddReleasedEvent(int idxBtn, long msTImestamp)
 		=> this.EventBuffer.Add(new STInputEvent() {
 			nKey = idxBtn,
 			Pressed = false,
 			Released = true,
-			nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
+			nTimeStamp = msTImestamp,
 			nVelocity = 0,
 		});
 
-	protected void AddPressedEvent(int idxBtn)
+	protected void AddPressedEvent(int idxBtn, long msTimestamp)
 		=> this.EventBuffer.Add(new STInputEvent() {
 			nKey = idxBtn,
 			Pressed = true,
 			Released = false,
-			nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
+			nTimeStamp = msTimestamp,
 			nVelocity = 0,
 		});
 
 	protected void ButtonDown(int idxBtn) {
 		if (this.useBufferInput && !this.ButtonStates[idxBtn].isPressed) {
-			this.AddPressedEvent(idxBtn);
+			this.AddPressedEvent(idxBtn, SoundManager.PlayTimer.msGetPreciseNowSoundTimerTime());
 		}
 		this.ButtonStates[idxBtn].isPressed = true;
 	}
 
 	protected void ButtonUp(int idxBtn) {
 		if (this.useBufferInput && this.ButtonStates[idxBtn].isPressed) {
-			this.AddReleasedEvent(idxBtn);
+			this.AddReleasedEvent(idxBtn, SoundManager.PlayTimer.msGetPreciseNowSoundTimerTime());
 		}
 		this.ButtonStates[idxBtn].isPressed = false;
 	}

--- a/FDK/src/02.Input/CInputButtonsBase.cs
+++ b/FDK/src/02.Input/CInputButtonsBase.cs
@@ -22,7 +22,7 @@ public abstract class CInputButtonsBase : IInputDevice, IDisposable {
 	public List<STInputEvent> InputEvents { get; protected set; }
 	public string strDeviceName { get; set; }
 
-	public virtual void Polling(bool useBufferInput) {
+	public void Polling(bool useBufferInput) {
 		InputEvents.Clear();
 
 		for (int i = 0; i < ButtonStates.Length; i++) {

--- a/FDK/src/02.Input/CInputGamepad.cs
+++ b/FDK/src/02.Input/CInputGamepad.cs
@@ -2,133 +2,20 @@ using Silk.NET.Input;
 
 namespace FDK;
 
-public class CInputGamepad : IInputDevice, IDisposable {
-	// Constructor
-
+public class CInputGamepad : CInputButtonsBase, IInputDevice, IDisposable {
 	private IGamepad Gamepad { get; set; }
 
-	public CInputGamepad(IGamepad gamepad) {
+	public CInputGamepad(IGamepad gamepad) : base() {
 		this.Gamepad = gamepad;
 		this.CurrentType = InputDeviceType.Gamepad;
 		this.GUID = gamepad.Index.ToString();
 		this.ID = gamepad.Index;
 		this.Name = gamepad.Name;
-
-		this.InputEvents = new List<STInputEvent>(32);
+		this.ButtonStates = new (bool, int)[15];
 
 		gamepad.ButtonDown += Joystick_ButtonDown;
 		gamepad.ButtonUp += Joystick_ButtonUp;
 	}
-
-
-	// メソッド
-
-	public void SetID(int nID) {
-		this.ID = nID;
-	}
-
-	#region [ IInputDevice 実装 ]
-	//-----------------
-	public InputDeviceType CurrentType {
-		get;
-		private set;
-	}
-	public string GUID {
-		get;
-		private set;
-	}
-	public int ID {
-		get;
-		private set;
-	}
-	public string Name {
-		get;
-		private set;
-	}
-	public List<STInputEvent> InputEvents {
-		get;
-		private set;
-	}
-	public string strDeviceName {
-		get;
-		set;
-	}
-
-	public void Polling(bool useBufferInput) {
-		InputEvents.Clear();
-
-		for (int i = 0; i < ButtonStates.Length; i++) {
-			if (ButtonStates[i].isPressed) {
-				if (ButtonStates[i].state >= 1) {
-					ButtonStates[i].state = 2;
-				} else {
-					ButtonStates[i].state = 1;
-
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = true,
-							Released = false,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			} else {
-				if (ButtonStates[i].state <= -1) {
-					ButtonStates[i].state = -2;
-				} else {
-					ButtonStates[i].state = -1;
-
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = false,
-							Released = true,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			}
-		}
-	}
-
-	public bool KeyPressed(int nButton) {
-		return ButtonStates[nButton].state == 1;
-	}
-	public bool KeyPressing(int nButton) {
-		return ButtonStates[nButton].state >= 1;
-	}
-	public bool KeyReleased(int nButton) {
-		return ButtonStates[nButton].state == -1;
-	}
-	public bool KeyReleasing(int nButton) {
-		return ButtonStates[nButton].state <= -1;
-	}
-	//-----------------
-	#endregion
-
-	#region [ IDisposable 実装 ]
-	//-----------------
-	public void Dispose() {
-		if (!this.IsDisposed) {
-			if (this.InputEvents != null) {
-				this.InputEvents = null;
-			}
-			this.IsDisposed = true;
-		}
-	}
-	//-----------------
-	#endregion
-
-
-	// その他
-
-	#region [ private ]
-	//-----------------
-	public (bool isPressed, int state)[] ButtonStates { get; private set; } = new (bool, int)[15];
-	private bool IsDisposed;
 
 	private void Joystick_ButtonDown(IGamepad joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
@@ -141,6 +28,4 @@ public class CInputGamepad : IInputDevice, IDisposable {
 			ButtonStates[(int)button.Name].isPressed = false;
 		}
 	}
-	//-----------------
-	#endregion
 }

--- a/FDK/src/02.Input/CInputGamepad.cs
+++ b/FDK/src/02.Input/CInputGamepad.cs
@@ -5,13 +5,12 @@ namespace FDK;
 public class CInputGamepad : CInputButtonsBase, IInputDevice, IDisposable {
 	private IGamepad Gamepad { get; set; }
 
-	public CInputGamepad(IGamepad gamepad) : base() {
+	public CInputGamepad(IGamepad gamepad) : base(15) {
 		this.Gamepad = gamepad;
 		this.CurrentType = InputDeviceType.Gamepad;
 		this.GUID = gamepad.Index.ToString();
 		this.ID = gamepad.Index;
 		this.Name = gamepad.Name;
-		this.ButtonStates = new (bool, int)[15];
 
 		gamepad.ButtonDown += Joystick_ButtonDown;
 		gamepad.ButtonUp += Joystick_ButtonUp;
@@ -19,13 +18,13 @@ public class CInputGamepad : CInputButtonsBase, IInputDevice, IDisposable {
 
 	private void Joystick_ButtonDown(IGamepad joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].isPressed = true;
+			base.ButtonDown((int)button.Name);
 		}
 	}
 
 	private void Joystick_ButtonUp(IGamepad joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].isPressed = false;
+			base.ButtonUp((int)button.Name);
 		}
 	}
 }

--- a/FDK/src/02.Input/CInputGamepad.cs
+++ b/FDK/src/02.Input/CInputGamepad.cs
@@ -69,7 +69,7 @@ public class CInputGamepad : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = true,
 							Released = false,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);
@@ -85,7 +85,7 @@ public class CInputGamepad : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = false,
 							Released = true,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);

--- a/FDK/src/02.Input/CInputGamepad.cs
+++ b/FDK/src/02.Input/CInputGamepad.cs
@@ -58,11 +58,11 @@ public class CInputGamepad : IInputDevice, IDisposable {
 		InputEvents.Clear();
 
 		for (int i = 0; i < ButtonStates.Length; i++) {
-			if (ButtonStates[i].Item1) {
-				if (ButtonStates[i].Item2 >= 1) {
-					ButtonStates[i].Item2 = 2;
+			if (ButtonStates[i].isPressed) {
+				if (ButtonStates[i].state >= 1) {
+					ButtonStates[i].state = 2;
 				} else {
-					ButtonStates[i].Item2 = 1;
+					ButtonStates[i].state = 1;
 
 					InputEvents.Add(
 						new STInputEvent() {
@@ -75,10 +75,10 @@ public class CInputGamepad : IInputDevice, IDisposable {
 					);
 				}
 			} else {
-				if (ButtonStates[i].Item2 <= -1) {
-					ButtonStates[i].Item2 = -2;
+				if (ButtonStates[i].state <= -1) {
+					ButtonStates[i].state = -2;
 				} else {
-					ButtonStates[i].Item2 = -1;
+					ButtonStates[i].state = -1;
 
 					InputEvents.Add(
 						new STInputEvent() {
@@ -95,16 +95,16 @@ public class CInputGamepad : IInputDevice, IDisposable {
 	}
 
 	public bool KeyPressed(int nButton) {
-		return ButtonStates[nButton].Item2 == 1;
+		return ButtonStates[nButton].state == 1;
 	}
 	public bool KeyPressing(int nButton) {
-		return ButtonStates[nButton].Item2 >= 1;
+		return ButtonStates[nButton].state >= 1;
 	}
 	public bool KeyReleased(int nButton) {
-		return ButtonStates[nButton].Item2 == -1;
+		return ButtonStates[nButton].state == -1;
 	}
 	public bool KeyReleasing(int nButton) {
-		return ButtonStates[nButton].Item2 <= -1;
+		return ButtonStates[nButton].state <= -1;
 	}
 	//-----------------
 	#endregion
@@ -127,18 +127,18 @@ public class CInputGamepad : IInputDevice, IDisposable {
 
 	#region [ private ]
 	//-----------------
-	public (bool, int)[] ButtonStates { get; private set; } = new (bool, int)[15];
+	public (bool isPressed, int state)[] ButtonStates { get; private set; } = new (bool, int)[15];
 	private bool IsDisposed;
 
 	private void Joystick_ButtonDown(IGamepad joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].Item1 = true;
+			ButtonStates[(int)button.Name].isPressed = true;
 		}
 	}
 
 	private void Joystick_ButtonUp(IGamepad joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].Item1 = false;
+			ButtonStates[(int)button.Name].isPressed = false;
 		}
 	}
 	//-----------------

--- a/FDK/src/02.Input/CInputJoystick.cs
+++ b/FDK/src/02.Input/CInputJoystick.cs
@@ -5,13 +5,12 @@ namespace FDK;
 public class CInputJoystick : CInputButtonsBase, IInputDevice, IDisposable {
 	public IJoystick Joystick { get; private set; }
 
-	public CInputJoystick(IJoystick joystick) : base() {
+	public CInputJoystick(IJoystick joystick) : base(18) {
 		this.Joystick = joystick;
 		this.CurrentType = InputDeviceType.Joystick;
 		this.GUID = joystick.Index.ToString();
 		this.ID = joystick.Index;
 		this.Name = joystick.Name;
-		this.ButtonStates = new (bool, int)[18];
 
 		joystick.ButtonDown += Joystick_ButtonDown;
 		joystick.ButtonUp += Joystick_ButtonUp;
@@ -19,13 +18,13 @@ public class CInputJoystick : CInputButtonsBase, IInputDevice, IDisposable {
 
 	private void Joystick_ButtonDown(IJoystick joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].isPressed = true;
+			base.ButtonDown((int)button.Name);
 		}
 	}
 
 	private void Joystick_ButtonUp(IJoystick joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].isPressed = false;
+			base.ButtonUp((int)button.Name);
 		}
 	}
 }

--- a/FDK/src/02.Input/CInputJoystick.cs
+++ b/FDK/src/02.Input/CInputJoystick.cs
@@ -17,18 +17,6 @@ public class CInputJoystick : CInputButtonsBase, IInputDevice, IDisposable {
 		joystick.ButtonUp += Joystick_ButtonUp;
 	}
 
-	public override void Polling(bool useBufferInput) {
-		// BUG: In Silk.NET, GLFW input does not fire events, so we have to poll
-		// 			them instead.
-		// 			https://github.com/dotnet/Silk.NET/issues/1889
-		foreach (var button in Joystick.Buttons) {
-			// also, in GLFW the buttons don't have names, so the indices are the names
-			ButtonStates[button.Index].isPressed = button.Pressed;
-		}
-
-		base.Polling(useBufferInput);
-	}
-
 	private void Joystick_ButtonDown(IJoystick joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
 			ButtonStates[(int)button.Name].isPressed = true;

--- a/FDK/src/02.Input/CInputJoystick.cs
+++ b/FDK/src/02.Input/CInputJoystick.cs
@@ -62,15 +62,15 @@ public class CInputJoystick : IInputDevice, IDisposable {
 		// 			https://github.com/dotnet/Silk.NET/issues/1889
 		foreach (var button in Joystick.Buttons) {
 			// also, in GLFW the buttons don't have names, so the indices are the names
-			ButtonStates[button.Index].Item1 = button.Pressed;
+			ButtonStates[button.Index].isPressed = button.Pressed;
 		}
 
 		for (int i = 0; i < ButtonStates.Length; i++) {
-			if (ButtonStates[i].Item1) {
-				if (ButtonStates[i].Item2 >= 1) {
-					ButtonStates[i].Item2 = 2;
+			if (ButtonStates[i].isPressed) {
+				if (ButtonStates[i].state >= 1) {
+					ButtonStates[i].state = 2;
 				} else {
-					ButtonStates[i].Item2 = 1;
+					ButtonStates[i].state = 1;
 
 					InputEvents.Add(
 						new STInputEvent() {
@@ -83,10 +83,10 @@ public class CInputJoystick : IInputDevice, IDisposable {
 					);
 				}
 			} else {
-				if (ButtonStates[i].Item2 <= -1) {
-					ButtonStates[i].Item2 = -2;
+				if (ButtonStates[i].state <= -1) {
+					ButtonStates[i].state = -2;
 				} else {
-					ButtonStates[i].Item2 = -1;
+					ButtonStates[i].state = -1;
 
 					InputEvents.Add(
 						new STInputEvent() {
@@ -103,16 +103,16 @@ public class CInputJoystick : IInputDevice, IDisposable {
 	}
 
 	public bool KeyPressed(int nButton) {
-		return ButtonStates[nButton].Item2 == 1;
+		return ButtonStates[nButton].state == 1;
 	}
 	public bool KeyPressing(int nButton) {
-		return ButtonStates[nButton].Item2 >= 1;
+		return ButtonStates[nButton].state >= 1;
 	}
 	public bool KeyReleased(int nButton) {
-		return ButtonStates[nButton].Item2 == -1;
+		return ButtonStates[nButton].state == -1;
 	}
 	public bool KeyReleasing(int nButton) {
-		return ButtonStates[nButton].Item2 <= -1;
+		return ButtonStates[nButton].state <= -1;
 	}
 	//-----------------
 	#endregion
@@ -135,18 +135,18 @@ public class CInputJoystick : IInputDevice, IDisposable {
 
 	#region [ private ]
 	//-----------------
-	public (bool, int)[] ButtonStates { get; private set; } = new (bool, int)[18];
+	public (bool isPressed, int state)[] ButtonStates { get; private set; } = new (bool, int)[18];
 	private bool IsDisposed;
 
 	private void Joystick_ButtonDown(IJoystick joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].Item1 = true;
+			ButtonStates[(int)button.Name].isPressed = true;
 		}
 	}
 
 	private void Joystick_ButtonUp(IJoystick joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
-			ButtonStates[(int)button.Name].Item1 = false;
+			ButtonStates[(int)button.Name].isPressed = false;
 		}
 	}
 	//-----------------

--- a/FDK/src/02.Input/CInputJoystick.cs
+++ b/FDK/src/02.Input/CInputJoystick.cs
@@ -77,7 +77,7 @@ public class CInputJoystick : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = true,
 							Released = false,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);
@@ -93,7 +93,7 @@ public class CInputJoystick : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = false,
 							Released = true,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);

--- a/FDK/src/02.Input/CInputJoystick.cs
+++ b/FDK/src/02.Input/CInputJoystick.cs
@@ -2,61 +2,22 @@
 
 namespace FDK;
 
-public class CInputJoystick : IInputDevice, IDisposable {
-	// Constructor
-
+public class CInputJoystick : CInputButtonsBase, IInputDevice, IDisposable {
 	public IJoystick Joystick { get; private set; }
 
-	public CInputJoystick(IJoystick joystick) {
+	public CInputJoystick(IJoystick joystick) : base() {
 		this.Joystick = joystick;
 		this.CurrentType = InputDeviceType.Joystick;
 		this.GUID = joystick.Index.ToString();
 		this.ID = joystick.Index;
 		this.Name = joystick.Name;
-
-		this.InputEvents = new List<STInputEvent>(32);
+		this.ButtonStates = new (bool, int)[18];
 
 		joystick.ButtonDown += Joystick_ButtonDown;
 		joystick.ButtonUp += Joystick_ButtonUp;
 	}
 
-
-	// メソッド
-
-	public void SetID(int nID) {
-		this.ID = nID;
-	}
-
-	#region [ IInputDevice 実装 ]
-	//-----------------
-	public InputDeviceType CurrentType {
-		get;
-		private set;
-	}
-	public string GUID {
-		get;
-		private set;
-	}
-	public int ID {
-		get;
-		private set;
-	}
-	public string Name {
-		get;
-		private set;
-	}
-	public List<STInputEvent> InputEvents {
-		get;
-		private set;
-	}
-	public string strDeviceName {
-		get;
-		set;
-	}
-
-	public void Polling(bool useBufferInput) {
-		InputEvents.Clear();
-
+	public override void Polling(bool useBufferInput) {
 		// BUG: In Silk.NET, GLFW input does not fire events, so we have to poll
 		// 			them instead.
 		// 			https://github.com/dotnet/Silk.NET/issues/1889
@@ -65,78 +26,8 @@ public class CInputJoystick : IInputDevice, IDisposable {
 			ButtonStates[button.Index].isPressed = button.Pressed;
 		}
 
-		for (int i = 0; i < ButtonStates.Length; i++) {
-			if (ButtonStates[i].isPressed) {
-				if (ButtonStates[i].state >= 1) {
-					ButtonStates[i].state = 2;
-				} else {
-					ButtonStates[i].state = 1;
-
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = true,
-							Released = false,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			} else {
-				if (ButtonStates[i].state <= -1) {
-					ButtonStates[i].state = -2;
-				} else {
-					ButtonStates[i].state = -1;
-
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = false,
-							Released = true,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			}
-		}
+		base.Polling(useBufferInput);
 	}
-
-	public bool KeyPressed(int nButton) {
-		return ButtonStates[nButton].state == 1;
-	}
-	public bool KeyPressing(int nButton) {
-		return ButtonStates[nButton].state >= 1;
-	}
-	public bool KeyReleased(int nButton) {
-		return ButtonStates[nButton].state == -1;
-	}
-	public bool KeyReleasing(int nButton) {
-		return ButtonStates[nButton].state <= -1;
-	}
-	//-----------------
-	#endregion
-
-	#region [ IDisposable 実装 ]
-	//-----------------
-	public void Dispose() {
-		if (!this.IsDisposed) {
-			if (this.InputEvents != null) {
-				this.InputEvents = null;
-			}
-			this.IsDisposed = true;
-		}
-	}
-	//-----------------
-	#endregion
-
-
-	// その他
-
-	#region [ private ]
-	//-----------------
-	public (bool isPressed, int state)[] ButtonStates { get; private set; } = new (bool, int)[18];
-	private bool IsDisposed;
 
 	private void Joystick_ButtonDown(IJoystick joystick, Button button) {
 		if (button.Name != ButtonName.Unknown) {
@@ -149,6 +40,4 @@ public class CInputJoystick : IInputDevice, IDisposable {
 			ButtonStates[(int)button.Name].isPressed = false;
 		}
 	}
-	//-----------------
-	#endregion
 }

--- a/FDK/src/02.Input/CInputKeyboard.cs
+++ b/FDK/src/02.Input/CInputKeyboard.cs
@@ -38,11 +38,11 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 		InputEvents.Clear();
 
 		for (int i = 0; i < KeyStates.Length; i++) {
-			if (KeyStates[i].Item1) {
-				if (KeyStates[i].Item2 >= 1) {
-					KeyStates[i].Item2 = 2;
+			if (KeyStates[i].isPressed) {
+				if (KeyStates[i].state >= 1) {
+					KeyStates[i].state = 2;
 				} else {
-					KeyStates[i].Item2 = 1;
+					KeyStates[i].state = 1;
 					InputEvents.Add(
 						new STInputEvent() {
 							nKey = i,
@@ -54,10 +54,10 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 					);
 				}
 			} else {
-				if (KeyStates[i].Item2 <= -1) {
-					KeyStates[i].Item2 = -2;
+				if (KeyStates[i].state <= -1) {
+					KeyStates[i].state = -2;
 				} else {
-					KeyStates[i].Item2 = -1;
+					KeyStates[i].state = -1;
 					InputEvents.Add(
 						new STInputEvent() {
 							nKey = i,
@@ -75,25 +75,25 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
 	/// </param>
 	public bool KeyPressed(int nKey) {
-		return KeyStates[nKey].Item2 == 1;
+		return KeyStates[nKey].state == 1;
 	}
 	/// <param name="nKey">
 	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
-	/// </param>
+	/// </param>	
 	public bool KeyPressing(int nKey) {
-		return KeyStates[nKey].Item2 >= 1;
+		return KeyStates[nKey].state >= 1;
 	}
 	/// <param name="nKey">
 	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
 	/// </param>
 	public bool KeyReleased(int nKey) {
-		return KeyStates[nKey].Item2 == -1;
+		return KeyStates[nKey].state == -1;
 	}
 	/// <param name="nKey">
 	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
 	/// </param>
 	public bool KeyReleasing(int nKey) {
-		return KeyStates[nKey].Item2 <= -1;
+		return KeyStates[nKey].state <= -1;
 	}
 	//-----------------
 	#endregion
@@ -116,7 +116,7 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 
 	#region [ private ]
 	//-----------------
-	public (bool, int)[] KeyStates { get; private set; } = new (bool, int)[144];
+	public (bool isPressed, int state)[] KeyStates { get; private set; } = new (bool, int)[144];
 	private bool IsDisposed;
 	//private CTimer timer;
 	//private CTimer ct;
@@ -125,14 +125,14 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 	private void KeyDown(IKeyboard keyboard, Key key, int keyCode) {
 		if (key != Key.Unknown) {
 			var keyNum = DeviceConstantConverter.DIKtoKey(key);
-			KeyStates[(int)keyNum].Item1 = true;
+			KeyStates[(int)keyNum].isPressed = true;
 		}
 	}
 
 	private void KeyUp(IKeyboard keyboard, Key key, int keyCode) {
 		if (key != Key.Unknown) {
 			var keyNum = DeviceConstantConverter.DIKtoKey(key);
-			KeyStates[(int)keyNum].Item1 = false;
+			KeyStates[(int)keyNum].isPressed = false;
 		}
 	}
 

--- a/FDK/src/02.Input/CInputKeyboard.cs
+++ b/FDK/src/02.Input/CInputKeyboard.cs
@@ -2,143 +2,37 @@
 
 namespace FDK;
 
-public class CInputKeyboard : IInputDevice, IDisposable {
-	// Constructor
-
-	public CInputKeyboard(IReadOnlyList<IKeyboard> keyboards) {
+public class CInputKeyboard : CInputButtonsBase, IInputDevice, IDisposable {
+	public CInputKeyboard(IReadOnlyList<IKeyboard> keyboards) : base() {
 		this.CurrentType = InputDeviceType.Keyboard;
 		this.GUID = "";
 		this.ID = 0;
 		this.Name = keyboards.Count > 0 ? keyboards[0].Name : "";
+		this.ButtonStates = new (bool, int)[144];
 
 		foreach (var keyboard in keyboards) {
 			keyboard.KeyDown += KeyDown;
 			keyboard.KeyUp += KeyUp;
 			keyboard.KeyChar += KeyChar;
 		}
-
-		//this.timer = new CTimer( CTimer.E種別.MultiMedia );
-		this.InputEvents = new List<STInputEvent>(32);
-		// this.ct = new CTimer( CTimer.E種別.PerformanceCounter );
 	}
-
-
-	// メソッド
-
-	#region [ IInputDevice 実装 ]
-	//-----------------
-	public InputDeviceType CurrentType { get; private set; }
-	public string GUID { get; private set; }
-	public int ID { get; private set; }
-	public string Name { get; private set; }
-	public List<STInputEvent> InputEvents { get; private set; }
-	public string strDeviceName { get; set; }
-
-	public void Polling(bool useBufferInput) {
-		InputEvents.Clear();
-
-		for (int i = 0; i < KeyStates.Length; i++) {
-			if (KeyStates[i].isPressed) {
-				if (KeyStates[i].state >= 1) {
-					KeyStates[i].state = 2;
-				} else {
-					KeyStates[i].state = 1;
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = true,
-							Released = false,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			} else {
-				if (KeyStates[i].state <= -1) {
-					KeyStates[i].state = -2;
-				} else {
-					KeyStates[i].state = -1;
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = false,
-							Released = true,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			}
-		}
-	}
-	/// <param name="nKey">
-	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
-	/// </param>
-	public bool KeyPressed(int nKey) {
-		return KeyStates[nKey].state == 1;
-	}
-	/// <param name="nKey">
-	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
-	/// </param>	
-	public bool KeyPressing(int nKey) {
-		return KeyStates[nKey].state >= 1;
-	}
-	/// <param name="nKey">
-	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
-	/// </param>
-	public bool KeyReleased(int nKey) {
-		return KeyStates[nKey].state == -1;
-	}
-	/// <param name="nKey">
-	///		調べる SlimDX.DirectInput.Key を int にキャストした値。（SharpDX.DirectInput.Key ではないので注意。）
-	/// </param>
-	public bool KeyReleasing(int nKey) {
-		return KeyStates[nKey].state <= -1;
-	}
-	//-----------------
-	#endregion
-
-	#region [ IDisposable 実装 ]
-	//-----------------
-	public void Dispose() {
-		if (!this.IsDisposed) {
-			if (this.InputEvents != null) {
-				this.InputEvents = null;
-			}
-			this.IsDisposed = true;
-		}
-	}
-	//-----------------
-	#endregion
-
-
-	// その他
-
-	#region [ private ]
-	//-----------------
-	public (bool isPressed, int state)[] KeyStates { get; private set; } = new (bool, int)[144];
-	private bool IsDisposed;
-	//private CTimer timer;
-	//private CTimer ct;
-
+	public (bool isPressed, int state)[] KeyStates => this.ButtonStates;
 
 	private void KeyDown(IKeyboard keyboard, Key key, int keyCode) {
 		if (key != Key.Unknown) {
 			var keyNum = DeviceConstantConverter.DIKtoKey(key);
-			KeyStates[(int)keyNum].isPressed = true;
+			ButtonStates[(int)keyNum].isPressed = true;
 		}
 	}
 
 	private void KeyUp(IKeyboard keyboard, Key key, int keyCode) {
 		if (key != Key.Unknown) {
 			var keyNum = DeviceConstantConverter.DIKtoKey(key);
-			KeyStates[(int)keyNum].isPressed = false;
+			ButtonStates[(int)keyNum].isPressed = false;
 		}
 	}
 
 	private void KeyChar(IKeyboard keyboard, char ch) {
 
 	}
-	//-----------------
-	#endregion
 }

--- a/FDK/src/02.Input/CInputKeyboard.cs
+++ b/FDK/src/02.Input/CInputKeyboard.cs
@@ -3,12 +3,11 @@
 namespace FDK;
 
 public class CInputKeyboard : CInputButtonsBase, IInputDevice, IDisposable {
-	public CInputKeyboard(IReadOnlyList<IKeyboard> keyboards) : base() {
+	public CInputKeyboard(IReadOnlyList<IKeyboard> keyboards) : base(144) {
 		this.CurrentType = InputDeviceType.Keyboard;
 		this.GUID = "";
 		this.ID = 0;
 		this.Name = keyboards.Count > 0 ? keyboards[0].Name : "";
-		this.ButtonStates = new (bool, int)[144];
 
 		foreach (var keyboard in keyboards) {
 			keyboard.KeyDown += KeyDown;
@@ -16,19 +15,20 @@ public class CInputKeyboard : CInputButtonsBase, IInputDevice, IDisposable {
 			keyboard.KeyChar += KeyChar;
 		}
 	}
+
 	public (bool isPressed, int state)[] KeyStates => this.ButtonStates;
 
 	private void KeyDown(IKeyboard keyboard, Key key, int keyCode) {
 		if (key != Key.Unknown) {
 			var keyNum = DeviceConstantConverter.DIKtoKey(key);
-			ButtonStates[(int)keyNum].isPressed = true;
+			base.ButtonDown((int)keyNum);
 		}
 	}
 
 	private void KeyUp(IKeyboard keyboard, Key key, int keyCode) {
 		if (key != Key.Unknown) {
 			var keyNum = DeviceConstantConverter.DIKtoKey(key);
-			ButtonStates[(int)keyNum].isPressed = false;
+			base.ButtonUp((int)keyNum);
 		}
 	}
 

--- a/FDK/src/02.Input/CInputKeyboard.cs
+++ b/FDK/src/02.Input/CInputKeyboard.cs
@@ -48,7 +48,7 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = true,
 							Released = false,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);
@@ -63,7 +63,7 @@ public class CInputKeyboard : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = false,
 							Released = true,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);

--- a/FDK/src/02.Input/CInputMIDI.cs
+++ b/FDK/src/02.Input/CInputMIDI.cs
@@ -11,7 +11,7 @@ public class CInputMIDI : IInputDevice, IDisposable {
 	public CInputMIDI(uint nID) {
 		this.MidiInPtr = IntPtr.Zero;
 		this.EventBuffers = new List<STInputEvent>(32);
-		this.InputEvents = new List<STInputEvent>(32);
+		this.InputEvents = [];
 		this.CurrentType = InputDeviceType.MidiIn;
 		this.GUID = "";
 		this.ID = (int)nID;
@@ -67,13 +67,10 @@ public class CInputMIDI : IInputDevice, IDisposable {
 	public bool useBufferInput { get; set; }
 
 	public void Polling() {
+		// always buffered input
 		// this.list入力イベント = new List<STInputEvent>( 32 );
 		this.InputEvents.Clear();                                // #xxxxx 2012.6.11 yyagi; To optimize, I removed new();
-
-		for (int i = 0; i < this.EventBuffers.Count; i++)
-			this.InputEvents.Add(this.EventBuffers[i]);
-
-		this.EventBuffers.Clear();
+		(this.InputEvents, this.EventBuffers) = (this.EventBuffers, this.InputEvents); // swap buffer
 	}
 	public bool KeyPressed(int nKey) {
 		foreach (STInputEvent event2 in this.InputEvents) {
@@ -98,12 +95,8 @@ public class CInputMIDI : IInputDevice, IDisposable {
 	#region [ IDisposable 実装 ]
 	//-----------------
 	public void Dispose() {
-		if (this.EventBuffers != null) {
-			this.EventBuffers = null;
-		}
-		if (this.InputEvents != null) {
-			this.InputEvents = null;
-		}
+		this.EventBuffers.Clear();
+		this.InputEvents.Clear();
 	}
 	//-----------------
 	#endregion

--- a/FDK/src/02.Input/CInputMIDI.cs
+++ b/FDK/src/02.Input/CInputMIDI.cs
@@ -64,8 +64,9 @@ public class CInputMIDI : IInputDevice, IDisposable {
 	public string Name { get; private set; }
 	public List<STInputEvent> InputEvents { get; private set; }
 	public string strDeviceName { get; set; }
+	public bool useBufferInput { get; set; }
 
-	public void Polling(bool bWindowがアクティブ中) {
+	public void Polling() {
 		// this.list入力イベント = new List<STInputEvent>( 32 );
 		this.InputEvents.Clear();                                // #xxxxx 2012.6.11 yyagi; To optimize, I removed new();
 

--- a/FDK/src/02.Input/CInputManager.cs
+++ b/FDK/src/02.Input/CInputManager.cs
@@ -47,11 +47,11 @@ public class CInputManager : IDisposable {
 
 
 	// Constructor
-	public CInputManager(IWindow window, bool bUseMidiIn = true) {
-		Initialize(window, bUseMidiIn);
+	public CInputManager(IWindow window, bool useBufferedInput, bool bUseMidiIn = true) {
+		Initialize(window, useBufferedInput, bUseMidiIn);
 	}
 
-	public void Initialize(IWindow window, bool bUseMidiIn) {
+	public void Initialize(IWindow window, bool useBufferedInput, bool bUseMidiIn) {
 		Context = window.CreateInput();
 
 		this.InputDevices = new List<IInputDevice>(10);
@@ -131,14 +131,23 @@ public class CInputManager : IDisposable {
 		}
 		return null;
 	}
-	public void Polling(bool useBufferInput) {
+	public void SetUseBufferInput(bool useBufferInput) {
+		lock (this.objMidiIn排他用) {
+			for (int i = this.InputDevices.Count - 1; i >= 0; i--)
+			{
+				IInputDevice device = this.InputDevices[i];
+				device.useBufferInput = useBufferInput;
+			}
+		}
+	}
+	public void Polling() {
 		lock (this.objMidiIn排他用) {
 			//				foreach( IInputDevice device in this.list入力デバイス )
 			for (int i = this.InputDevices.Count - 1; i >= 0; i--)    // #24016 2011.1.6 yyagi: change not to use "foreach" to avoid InvalidOperation exception by Remove().
 			{
 				IInputDevice device = this.InputDevices[i];
 				try {
-					device.Polling(useBufferInput);
+					device.Polling();
 				} catch (Exception e)                                      // #24016 2011.1.6 yyagi: catch exception for unplugging USB joystick, and remove the device object from the polling items.
 				{
 					this.InputDevices.Remove(device);

--- a/FDK/src/02.Input/CInputMouse.cs
+++ b/FDK/src/02.Input/CInputMouse.cs
@@ -52,7 +52,7 @@ public class CInputMouse : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = true,
 							Released = false,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);
@@ -67,7 +67,7 @@ public class CInputMouse : IInputDevice, IDisposable {
 							nKey = i,
 							Pressed = false,
 							Released = true,
-							nTimeStamp = SampleFramework.Game.TimeMs,
+							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
 							nVelocity = 0,
 						}
 					);

--- a/FDK/src/02.Input/CInputMouse.cs
+++ b/FDK/src/02.Input/CInputMouse.cs
@@ -42,11 +42,11 @@ public class CInputMouse : IInputDevice, IDisposable {
 		InputEvents.Clear();
 
 		for (int i = 0; i < MouseStates.Length; i++) {
-			if (MouseStates[i].Item1) {
-				if (MouseStates[i].Item2 >= 1) {
-					MouseStates[i].Item2 = 2;
+			if (MouseStates[i].isPressed) {
+				if (MouseStates[i].state >= 1) {
+					MouseStates[i].state = 2;
 				} else {
-					MouseStates[i].Item2 = 1;
+					MouseStates[i].state = 1;
 					InputEvents.Add(
 						new STInputEvent() {
 							nKey = i,
@@ -58,10 +58,10 @@ public class CInputMouse : IInputDevice, IDisposable {
 					);
 				}
 			} else {
-				if (MouseStates[i].Item2 <= -1) {
-					MouseStates[i].Item2 = -2;
+				if (MouseStates[i].state <= -1) {
+					MouseStates[i].state = -2;
 				} else {
-					MouseStates[i].Item2 = -1;
+					MouseStates[i].state = -1;
 					InputEvents.Add(
 						new STInputEvent() {
 							nKey = i,
@@ -76,16 +76,16 @@ public class CInputMouse : IInputDevice, IDisposable {
 		}
 	}
 	public bool KeyPressed(int nButton) {
-		return MouseStates[nButton].Item2 == 1;
+		return MouseStates[nButton].state == 1;
 	}
 	public bool KeyPressing(int nButton) {
-		return MouseStates[nButton].Item2 >= 1;
+		return MouseStates[nButton].state >= 1;
 	}
 	public bool KeyReleased(int nButton) {
-		return MouseStates[nButton].Item2 == -1;
+		return MouseStates[nButton].state == -1;
 	}
 	public bool KeyReleasing(int nButton) {
-		return MouseStates[nButton].Item2 <= -1;
+		return MouseStates[nButton].state <= -1;
 	}
 	//-----------------
 	#endregion
@@ -108,7 +108,7 @@ public class CInputMouse : IInputDevice, IDisposable {
 
 	#region [ private ]
 	//-----------------
-	public (bool, int)[] MouseStates { get; private set; } = new (bool, int)[12];
+	public (bool isPressed, int state)[] MouseStates { get; private set; } = new (bool, int)[12];
 	private bool IsDisposed;
 
 	private void Mouse_Click(IMouse mouse, MouseButton mouseButton, Vector2 vector2) {
@@ -121,13 +121,13 @@ public class CInputMouse : IInputDevice, IDisposable {
 
 	private void Mouse_MouseDown(IMouse mouse, MouseButton mouseButton) {
 		if (mouseButton != MouseButton.Unknown) {
-			MouseStates[(int)mouseButton].Item1 = true;
+			MouseStates[(int)mouseButton].isPressed = true;
 		}
 	}
 
 	private void Mouse_MouseUp(IMouse mouse, MouseButton mouseButton) {
 		if (mouseButton != MouseButton.Unknown) {
-			MouseStates[(int)mouseButton].Item1 = false;
+			MouseStates[(int)mouseButton].isPressed = false;
 		}
 	}
 

--- a/FDK/src/02.Input/CInputMouse.cs
+++ b/FDK/src/02.Input/CInputMouse.cs
@@ -4,112 +4,24 @@ using Silk.NET.Input;
 
 namespace FDK;
 
-public class CInputMouse : IInputDevice, IDisposable {
-	// 定数
-
+public class CInputMouse : CInputButtonsBase, IInputDevice, IDisposable {
 	public const int MouseButtonCount = 8;
 
-
-	// Constructor
-
-	public CInputMouse(IMouse mouse) {
+	public CInputMouse(IMouse mouse) : base() {
 		this.CurrentType = InputDeviceType.Mouse;
 		this.GUID = "";
 		this.ID = 0;
 		this.Name = mouse.Name;
+		this.ButtonStates = new (bool, int)[12];
 
 		mouse.Click += Mouse_Click;
 		mouse.DoubleClick += Mouse_DoubleClick;
 		mouse.MouseDown += Mouse_MouseDown;
 		mouse.MouseUp += Mouse_MouseUp;
 		mouse.MouseMove += Mouse_MouseMove;
-
-		this.InputEvents = new List<STInputEvent>(32);
 	}
 
-
-	// メソッド
-
-	#region [ IInputDevice 実装 ]
-	//-----------------
-	public InputDeviceType CurrentType { get; private set; }
-	public string GUID { get; private set; }
-	public int ID { get; private set; }
-	public string Name { get; private set; }
-	public List<STInputEvent> InputEvents { get; private set; }
-
-	public void Polling(bool useBufferInput) {
-		InputEvents.Clear();
-
-		for (int i = 0; i < MouseStates.Length; i++) {
-			if (MouseStates[i].isPressed) {
-				if (MouseStates[i].state >= 1) {
-					MouseStates[i].state = 2;
-				} else {
-					MouseStates[i].state = 1;
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = true,
-							Released = false,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			} else {
-				if (MouseStates[i].state <= -1) {
-					MouseStates[i].state = -2;
-				} else {
-					MouseStates[i].state = -1;
-					InputEvents.Add(
-						new STInputEvent() {
-							nKey = i,
-							Pressed = false,
-							Released = true,
-							nTimeStamp = SoundManager.PlayTimer.SystemTimeMs, // Use the same timer used in gameplay to prevent desyncs between BGM/chart and input.
-							nVelocity = 0,
-						}
-					);
-				}
-			}
-		}
-	}
-	public bool KeyPressed(int nButton) {
-		return MouseStates[nButton].state == 1;
-	}
-	public bool KeyPressing(int nButton) {
-		return MouseStates[nButton].state >= 1;
-	}
-	public bool KeyReleased(int nButton) {
-		return MouseStates[nButton].state == -1;
-	}
-	public bool KeyReleasing(int nButton) {
-		return MouseStates[nButton].state <= -1;
-	}
-	//-----------------
-	#endregion
-
-	#region [ IDisposable 実装 ]
-	//-----------------
-	public void Dispose() {
-		if (!this.IsDisposed) {
-			if (this.InputEvents != null) {
-				this.InputEvents = null;
-			}
-			this.IsDisposed = true;
-		}
-	}
-	//-----------------
-	#endregion
-
-
-	// その他
-
-	#region [ private ]
-	//-----------------
-	public (bool isPressed, int state)[] MouseStates { get; private set; } = new (bool, int)[12];
-	private bool IsDisposed;
+	public (bool isPressed, int state)[] MouseStates => this.ButtonStates;
 
 	private void Mouse_Click(IMouse mouse, MouseButton mouseButton, Vector2 vector2) {
 
@@ -121,19 +33,17 @@ public class CInputMouse : IInputDevice, IDisposable {
 
 	private void Mouse_MouseDown(IMouse mouse, MouseButton mouseButton) {
 		if (mouseButton != MouseButton.Unknown) {
-			MouseStates[(int)mouseButton].isPressed = true;
+			ButtonStates[(int)mouseButton].isPressed = true;
 		}
 	}
 
 	private void Mouse_MouseUp(IMouse mouse, MouseButton mouseButton) {
 		if (mouseButton != MouseButton.Unknown) {
-			MouseStates[(int)mouseButton].isPressed = false;
+			ButtonStates[(int)mouseButton].isPressed = false;
 		}
 	}
 
 	private void Mouse_MouseMove(IMouse mouse, Vector2 vector2) {
 
 	}
-	//-----------------
-	#endregion
 }

--- a/FDK/src/02.Input/CInputMouse.cs
+++ b/FDK/src/02.Input/CInputMouse.cs
@@ -7,12 +7,11 @@ namespace FDK;
 public class CInputMouse : CInputButtonsBase, IInputDevice, IDisposable {
 	public const int MouseButtonCount = 8;
 
-	public CInputMouse(IMouse mouse) : base() {
+	public CInputMouse(IMouse mouse) : base(12) {
 		this.CurrentType = InputDeviceType.Mouse;
 		this.GUID = "";
 		this.ID = 0;
 		this.Name = mouse.Name;
-		this.ButtonStates = new (bool, int)[12];
 
 		mouse.Click += Mouse_Click;
 		mouse.DoubleClick += Mouse_DoubleClick;
@@ -33,13 +32,13 @@ public class CInputMouse : CInputButtonsBase, IInputDevice, IDisposable {
 
 	private void Mouse_MouseDown(IMouse mouse, MouseButton mouseButton) {
 		if (mouseButton != MouseButton.Unknown) {
-			ButtonStates[(int)mouseButton].isPressed = true;
+			base.ButtonDown((int)mouseButton);
 		}
 	}
 
 	private void Mouse_MouseUp(IMouse mouse, MouseButton mouseButton) {
 		if (mouseButton != MouseButton.Unknown) {
-			ButtonStates[(int)mouseButton].isPressed = false;
+			base.ButtonUp((int)mouseButton);
 		}
 	}
 

--- a/FDK/src/02.Input/IInputDevice.cs
+++ b/FDK/src/02.Input/IInputDevice.cs
@@ -18,11 +18,12 @@ public interface IInputDevice : IDisposable {
 	List<STInputEvent> InputEvents {
 		get;
 	}
+	bool useBufferInput { get; set; }
 
 
 	// メソッドインターフェース
 
-	void Polling(bool bバッファ入力を使用する);
+	void Polling();
 	bool KeyPressed(int nKey);
 	bool KeyPressed(List<int> nKey) { return nKey.Any(key => KeyPressed(key)); }
 	bool KeyPressing(int nKey);

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -136,8 +136,8 @@
 		"SETTINGS_SYSTEM_WASAPIBUFFER_DESC": "Change the sound buffer for wasapi sound playback mode.\nSet the number to be as low as possible\nwithout causing sound issues such as\nsong freezing and incorrect timing.\nSet it to 0 to use an estimated correct value,\nor use trial and error to find the correct value.\nNote: Exit CONFIGURATION to make\n     the setting take effect.",
 		"SETTINGS_SYSTEM_BASSBUFFER": "Bass Buffer Size",
 		"SETTINGS_SYSTEM_BASSBUFFER_DESC": "Buffer size when using Bass:\nSize can be between 0～99999ms.\nA value of 0 will make the OS\nautomatically decide the size.\nThe smaller the value, the less\naudio lag there is, but may also\ncause abnormal/crackling audio.\n※ NOTE: Exit CONFIGURATION to make the\n　      settings take effect.",
-		"SETTINGS_SYSTEM_OSTIMER": "OS Timer Mode",
-		"SETTINGS_SYSTEM_OSTIMER_DESC": "Turning this on will create smoother note scroll,\nbut may introduce sound lag.\nTurning it off will create unstable note scroll,\nbut ensure no sound lag occurs.\n\nIf OFF, DTXMania uses its original\ntimer and the effect is vice versa.",
+		"SETTINGS_SYSTEM_OSTIMER": "Use OS Timer",
+		"SETTINGS_SYSTEM_OSTIMER_DESC": "Turning this on will make notes scroll more smoothly,\nbut might cause the chart to desync with song.\nTurning it off will prevent the chart\nfrom desyncing with the song,\nbut might make notes jitter when scrolling.",
 
 		// Settings - System - Misc.
 		"SETTINGS_SYSTEM_LOG": "Create Log File",

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -151,7 +151,7 @@
 		"SETTINGS_SYSTEM_DISCORDRPC": "Discord Rich Presence",
 		"SETTINGS_SYSTEM_DISCORDRPC_DESC": "Toggle whether song information is shared with Discord.",
 		"SETTINGS_SYSTEM_BUFFEREDINPUT": "Buffered Input Mode",
-		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "When this is turned on, no inputs will be dropped\nbut the input poll rate will decrease.\nWhen this is turned off, inputs may be dropped\nbut they will be polled more often.",
+		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "When this is turned on,\nthe input resolution can exceed FPS\nand no inputs will be dropped\nWhen this is turned off,\nthe input resolution is limited by FPS\nand inputs may be dropped.",
 
 		// Settings - Gameplay
 		"SETTINGS_GAME_GLOBALOFFSET": "Global Offset",

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -151,7 +151,7 @@
 		"SETTINGS_SYSTEM_DISCORDRPC": "Discord 状态显示",
 		"SETTINGS_SYSTEM_DISCORDRPC_DESC": "选择是否在 Discord 上共享曲目信息。",
 		"SETTINGS_SYSTEM_BUFFEREDINPUT": "输入缓冲模式",
-		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "开启时所有输入都会被保留，但输入采样率会会降低，\n关闭时部分输入可能会被丢弃，但输入采样率会增高。",
+		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "开启时，判定时间精度将不受帧率限制，\n且所有输入都不会被忽略。\n关闭时，判定时间精度将受帧率限制，\n且部分输入可能会被忽略。",
 
 		// Settings - Gameplay
 		"SETTINGS_GAME_GLOBALOFFSET": "全局偏移量",

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -136,8 +136,8 @@
 		"SETTINGS_SYSTEM_WASAPIBUFFER_DESC": "调整声音播放模式为 WASAPI 时的声音缓冲。\n没有出现如曲目冻结或时间错误的声音问题时，该项设置\n越小越好。\n建议设为 0 以使用估计值或通过不断尝试进行调整。\n退出设置界面以使此选项生效。",
 		"SETTINGS_SYSTEM_BASSBUFFER": "Bass 模式缓冲区大小",
 		"SETTINGS_SYSTEM_BASSBUFFER_DESC": "当使用 Bass 模式时的缓冲区大小：\n— 范围： 0-99999 ms\n— 0：系统决定该值的大小\n该值越小，音频卡顿/延迟会更小，但或导致声音异常或\n爆音。\n退出设置界面以使此选项生效。",
-		"SETTINGS_SYSTEM_OSTIMER": "操作系统计时器模式",
-		"SETTINGS_SYSTEM_OSTIMER_DESC": "开启时音符滚动会更加顺畅，但或将导致声音延迟。\n关闭会确保无声音延迟，但音符滚动会更加不稳定。\n关闭时 DTXMania 会使用其原始的计时器。\n其效果反之亦然。",
+		"SETTINGS_SYSTEM_OSTIMER": "使用系统计时器",
+		"SETTINGS_SYSTEM_OSTIMER_DESC": "开启时音符滚动会更加顺畅，但可能导致谱面与歌曲不同步。\n关闭会确保谱面与歌曲同步，但音符滚动会较不顺畅。",
 
 		// Settings - System - Misc.
 		"SETTINGS_SYSTEM_LOG": "创建报错记录",

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -540,7 +540,7 @@ internal class OpenTaiko : Game {
 		base.OnExiting();
 	}
 	protected override void Update() {
-		InputManager?.Polling(OpenTaiko.ConfigIni.bBufferedInputs);
+		InputManager?.Polling();
 	}
 	protected override void Draw() {
 #if !DEBUG
@@ -1650,7 +1650,7 @@ internal class OpenTaiko : Game {
 		Trace.Indent();
 		try {
 			bool bUseMIDIIn = true;
-			InputManager = new CInputManager(Window_);
+			InputManager = new CInputManager(Window_, OpenTaiko.ConfigIni.bBufferedInputs);
 			foreach (IInputDevice device in InputManager.InputDevices) {
 				if ((device.CurrentType == InputDeviceType.Joystick) && !ConfigIni.dicJoystick.ContainsValue(device.GUID)) {
 					int key = 0;

--- a/OpenTaiko/src/Stages/04.Config/CActConfigKeyAssign.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigKeyAssign.cs
@@ -93,10 +93,10 @@ internal class CActConfigKeyAssign : CActivity {
 				if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape)) {
 					OpenTaiko.Skin.soundCancelSFX.tPlay();
 					this.bキー入力待ち = false;
-					OpenTaiko.InputManager.Polling(false);
+					OpenTaiko.InputManager.Polling();
 				} else if ((this.tキーチェックとアサイン_Keyboard() || this.tキーチェックとアサイン_MidiIn()) || (this.tキーチェックとアサイン_Joypad() || tキーチェックとアサイン_Gamepad() || this.tキーチェックとアサイン_Mouse())) {
 					this.bキー入力待ち = false;
-					OpenTaiko.InputManager.Polling(false);
+					OpenTaiko.InputManager.Polling();
 				}
 			} else if ((OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Delete) && (this.n現在の選択行 >= 0)) && (this.n現在の選択行 <= 15)) {
 				OpenTaiko.Skin.soundDecideSFX.tPlay();

--- a/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
@@ -1613,6 +1613,7 @@ internal class CActConfigList : CActivity {
 
 		OpenTaiko.ConfigIni.bEnableVSync = this.iSystemVSyncWait.bON;
 		OpenTaiko.ConfigIni.bBufferedInputs = this.iSystemBufferedInput.bON;
+		OpenTaiko.InputManager?.SetUseBufferInput(OpenTaiko.ConfigIni.bBufferedInputs);
 		OpenTaiko.ConfigIni.bEnableAVI = this.iSystemAVI.bON;
 		OpenTaiko.ConfigIni.eClipDispType = (EClipDispType)this.iSystemAVIDisplayMode.n現在選択されている項目番号;
 		OpenTaiko.ConfigIni.bEnableBGA = this.iSystemBGA.bON;

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -971,9 +971,9 @@ internal abstract class CStage演奏画面共通 : CStage {
 	private ENoteJudge e指定時刻からChipのJUDGEを返すImpl(long nTime, CChip pChip, int player = 0) {
 
 		if (pChip != null) {
-			pChip.nLag = (int)(nTime - pChip.n発声時刻ms);      // #23580 2011.1.3 yyagi: add "nInputAdjustTime" to add input timing adjust feature
+			pChip.nLag = (int)(nTime - pChip.n発声時刻ms);
 			int nDeltaTime = Math.Abs(pChip.nLag);
-			//Debug.WriteLine("nAbsTime=" + (nTime - pChip.n発声時刻ms) + ", nDeltaTime=" + (nTime + nInputAdjustTime - pChip.n発声時刻ms));
+			//Debug.WriteLine("nAbsTime=" + (nTime - pChip.n発声時刻ms) + ", nDeltaTime=" + (nTime - pChip.n発声時刻ms));
 			if (NotesManager.IsRoll(pChip) || NotesManager.IsFuzeRoll(pChip)) {
 				if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) > pChip.n発声時刻ms && (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) < pChip.nNoteEndTimems) {
 					return ENoteJudge.Perfect;
@@ -1007,10 +1007,9 @@ internal abstract class CStage演奏画面共通 : CStage {
 		return ENoteJudge.Miss;
 	}
 
-	protected CChip r指定時刻に一番近い連打Chip_ヒット未済問わず不可視考慮(long nTime, int nChannel, int nInputAdjustTime, int nPlayer) {
+	protected CChip r指定時刻に一番近い連打Chip_ヒット未済問わず不可視考慮(long nTime, int nChannel, int nPlayer) {
 		//sw2.Start();
 		//Trace.TraceInformation( "NTime={0}, nChannel={1:x2}", nTime, nChannel );
-		nTime += nInputAdjustTime;                      // #24239 2011.1.23 yyagi InputAdjust
 
 		int nIndex_InitialPositionSearchingToPast;
 		if (this.nCurrentTopChip == -1)             // 演奏データとして1個もチップがない場合は
@@ -2396,10 +2395,9 @@ internal abstract class CStage演奏画面共通 : CStage {
     */
 
 
-	protected CChip r指定時刻に一番近い未ヒットChip(long nTime, int nChannel, int nInputAdjustTime, int n検索範囲時間ms, int nPlayer) {
+	protected CChip r指定時刻に一番近い未ヒットChip(long nTime, int nChannel, int n検索範囲時間ms, int nPlayer) {
 		//sw2.Start();
 		//Trace.TraceInformation( "nTime={0}, nChannel={1:x2}, 現在のTop={2}", nTime, nChannel,CDTXMania.DTX.listChip[ this.n現在のトップChip ].n発声時刻ms );
-		nTime += nInputAdjustTime;
 
 		int nIndex_InitialPositionSearchingToPast;
 		int nTimeDiff;
@@ -2519,9 +2517,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		//sw2.Stop();
 		return nearestChip;
 	}
-	public bool r検索範囲内にチップがあるか調べる(long nTime, int nInputAdjustTime, int n検索範囲時間ms, int nPlayer) {
-		nTime += nInputAdjustTime;
-
+	public bool r検索範囲内にチップがあるか調べる(long nTime, int n検索範囲時間ms, int nPlayer) {
 		for (int i = 0; i < listChip[nPlayer].Count; i++) {
 			CChip chip = listChip[nPlayer][i];
 			if (!chip.bHit) {
@@ -2824,7 +2820,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 		NowAIBattleSectionTime = (int)n現在時刻ms - NowAIBattleSection.StartTime;
 
-		if (this.r指定時刻に一番近い未ヒットChip((long)n現在時刻ms, 0x50, 0, 1000000, nPlayer) == null) {
+		if (this.r指定時刻に一番近い未ヒットChip((long)n現在時刻ms, 0x50, 1000000, nPlayer) == null) {
 			this.actChara.b演奏中[nPlayer] = false;
 		}
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -388,7 +388,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			if (this.st叩ききりまショー.bタイマー使用中) {
 				if (!this.st叩ききりまショー.ct残り時間.IsStoped || this.st叩ききりまショー.b加算アニメ中 == true) {
 					this.st叩ききりまショー.ct残り時間.Tick();
-					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0, 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
+					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
 						this.st叩ききりまショー.bタイマー使用中 = false;
 						this.st叩ききりまショー.ct残り時間.Stop();
 					}
@@ -396,7 +396,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			}
 
 			if (!this.st叩ききりまショー.bタイマー使用中 && this.st叩ききりまショー.b加算アニメ中 == false) {
-				if ((this.st叩ききりまショー.b最初のチップが叩かれた == true && (OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる(SoundManager.PlayTimer.NowTimeMs, 0, 2000, 0)))) {
+				if ((this.st叩ききりまショー.b最初のチップが叩かれた == true && (OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる(SoundManager.PlayTimer.NowTimeMs, 2000, 0)))) {
 					this.st叩ききりまショー.bタイマー使用中 = true;
 					int nCount = this.st叩ききりまショー.ct残り時間.CurrentValue;
 					this.st叩ききりまショー.ct残り時間 = new CCounter(0, 25000, 1, OpenTaiko.Timer);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -796,7 +796,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 	protected override void t入力処理_ドラム() {
 		// Input adjust deprecated
-		var nInputAdjustTimeMs = 0; // TJAPlayer3.ConfigIni.nInputAdjustTimeMs;
+		var nInputAdjustTimeMs = 0; // OpenTaiko.ConfigIni.nInputAdjustTimeMs;
 
 		for (int nPad = 0; nPad < (int)EPad.Max; nPad++)        // #27029 2012.1.4 from: <10 to <=10; Eパッドの要素が１つ（HP）増えたため。
 																//		  2012.1.5 yyagi: (int)Eパッド.MAX に変更。Eパッドの要素数への依存を無くすため。
@@ -1672,7 +1672,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				CChip cChip = null;
 				if (pChip.nノーツ移動開始時刻ms != 0) // n先頭発声位置 value is only used when this condition is met
 				{
-					cChip = OpenTaiko.stageGameScreen.r指定時刻に一番近い連打Chip_ヒット未済問わず不可視考慮(pChip.n発声時刻ms, 0x10 + pChip.n連打音符State, 0, nPlayer);
+					cChip = OpenTaiko.stageGameScreen.r指定時刻に一番近い連打Chip_ヒット未済問わず不可視考慮(pChip.n発声時刻ms, 0x10 + pChip.n連打音符State, nPlayer);
 					if (cChip != null) {
 						n先頭発声位置 = cChip.n発声時刻ms;
 					}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -812,7 +812,9 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				if (!inputEvent.Pressed)
 					continue;
 
-				long nTime = (long)(((SoundManager.PlayTimer.NowTimeMs + nInputAdjustTimeMs) * OpenTaiko.ConfigIni.SongPlaybackSpeed));
+				// convert input time (mixer space) to note time
+				long msInputMixer = inputEvent.nTimeStamp - SoundManager.PlayTimer.PrevResetTimeMs;
+				long nTime = (long)((msInputMixer + nInputAdjustTimeMs) * OpenTaiko.ConfigIni.SongPlaybackSpeed);
 				//int nPad09 = ( nPad == (int) Eパッド.HP ) ? (int) Eパッド.BD : nPad;		// #27029 2012.1.5 yyagi
 
 				bool bHitted = false;


### PR DESCRIPTION
Fixed buffer input before 0auBSQ/OpenTaiko#760.

## Fixed Issues

* fix in-game timer precision being fps-limited
* fix incorrect input timestamp and use input timestamp for input judgement
* remove workaround for not fired Silk.NET GLFW input event (fixed in Silk.NET 2.21) (0auBSQ/OpenTaiko#543)
* reimplement buffered input

## Fixed Development issues

* The duplicated codes in `CInput*` classes have been deduplicated.

## How

* port some lines of translated TJAPlayer3 codes.
* IDE refactoring
* trials and errors

## Prove

Completing the following table is left as an exercise to the readers.

Settings \\ Play speed | 0.75x | 0x75x <br> VSync | 1.00x | 1.00x <br> VSync | 1.25x | 1.25x <br> VSync
--- | --- | --- | --- | --- | --- | ---
Buffered input disabled <br/> OS timer disabled | | | | | |
Buffered input disabled <br/> OS timer enabled | | | | | |
Buffered input enabled <br/> OS timer disabled | | | | | |
Buffered input enabled <br/> OS timer enabled | | | | | |