### PR TITLE
Add ability to search for songs via. text

### DIFF
--- a/OpenTaiko/Songs/X4 Search By Text/box.def
+++ b/OpenTaiko/Songs/X4 Search By Text/box.def
@@ -1,0 +1,10 @@
+﻿#TITLE:Search by text
+#GENRE:SearchT
+#FORECOLOR:#FFFFFF
+#BACKCOLOR:#213d18
+#BOXEXPLANATION1:Search for your favorite
+#BOXEXPLANATION2:songs via. text search!
+#BGTYPE:1
+#BOXTYPE:0
+#BOXCOLOR:#5ac736
+#BGCOLOR:#80e65e

--- a/OpenTaiko/src/Common/CSongDict.cs
+++ b/OpenTaiko/src/Common/CSongDict.cs
@@ -219,7 +219,7 @@ internal class CSongDict {
 
 	// Generate search by difficulty folder
 	public static List<CSongListNode> tFetchSongsByDifficulty(CSongListNode parent, int difficulty = (int)Difficulty.Oni, int level = 8) {
-		List<CSongListNode> childList = new List<CSongListNode>();
+		List<CSongListNode> childList = [];
 
 		foreach (CSongListNode nodeT in nodes.Values) {
 			var score = nodeT.nLevel;
@@ -227,8 +227,41 @@ internal class CSongDict {
 				|| (difficulty == (int)Difficulty.Oni && tLevelMatches(score[(int)Difficulty.Edit], level))) // Oni includes Ura
 			{
 				var node = tReadaptChildNote(parent, nodeT);
-				if (node != null) {
-					childList.Add(node);
+				if (node != null) childList.Add(node);
+			}
+		}
+
+		// Generate back buttons
+
+		string favPath = "./" + parent.ldTitle.GetString("") + "/";
+
+		tReinsertBackButtons(parent, childList, favPath);
+
+		return childList;
+	}
+
+	public static List<CSongListNode> tFetchSongsByTitle(CSongListNode parent, ETitleType type, string text) {
+		List<CSongListNode> childList = [];
+
+		foreach (CSongListNode nodeT in nodes.Values) {
+			string name = type switch {
+				ETitleType.Title => nodeT.ldTitle.GetString(""),
+				ETitleType.Subtitle => nodeT.ldSubtitle.GetString(""),
+				ETitleType.Charter => nodeT.strMaker,
+				_ => nodeT.ldTitle.GetString("")
+			};
+			if (name.Contains(text, StringComparison.InvariantCultureIgnoreCase)) {
+				var node = tReadaptChildNote(parent, nodeT);
+				if (node != null) childList.Add(node);
+			}
+			// Check if Charter is listed in NOTESDESIGNER(x) command instead
+			else if (type == ETitleType.Charter) { 
+				foreach (string charter in nodeT.strNotesDesigner) {
+					if (charter.Contains(text, StringComparison.InvariantCultureIgnoreCase)) {
+						var node = tReadaptChildNote(parent, nodeT);
+						if (node != null) childList.Add(node);
+						break;
+					}
 				}
 			}
 		}

--- a/OpenTaiko/src/Common/CSongDict.cs
+++ b/OpenTaiko/src/Common/CSongDict.cs
@@ -219,7 +219,7 @@ internal class CSongDict {
 
 	// Generate search by difficulty folder
 	public static List<CSongListNode> tFetchSongsByDifficulty(CSongListNode parent, int difficulty = (int)Difficulty.Oni, int level = 8) {
-		List<CSongListNode> childList = [];
+		List<CSongListNode> childList = new List<CSongListNode>();
 
 		foreach (CSongListNode nodeT in nodes.Values) {
 			var score = nodeT.nLevel;
@@ -241,7 +241,7 @@ internal class CSongDict {
 	}
 
 	public static List<CSongListNode> tFetchSongsByTitle(CSongListNode parent, ETitleType type, string text) {
-		List<CSongListNode> childList = [];
+		List<CSongListNode> childList = new List<CSongListNode>();
 
 		foreach (CSongListNode nodeT in nodes.Values) {
 			string name = type switch {

--- a/OpenTaiko/src/Helpers/HSongTraverse.cs
+++ b/OpenTaiko/src/Helpers/HSongTraverse.cs
@@ -1,7 +1,7 @@
 ﻿namespace OpenTaiko;
 
 class HSongTraverse {
-	public static List<string> SpecialFolders = new List<string> { "Favorite", "最近遊んだ曲", "SearchD" };
+	public static List<string> SpecialFolders = new List<string> { "Favorite", "最近遊んだ曲", "SearchD", "SearchT" };
 
 	public static bool IsRegularFolder(CSongListNode node) {
 		if (node.nodeType != CSongListNode.ENodeType.BOX) return false;

--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -2043,7 +2043,6 @@ internal class CActSelect曲リスト : CActivity {
 
 			}
 		}
-		// god this context var code stinks, anyways,
 		// Context vars :
 		// 0 - Position
 		// 1 - Title type

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
@@ -739,6 +739,24 @@ internal class CStageSongSelect : CStage {
 							CMenuCharacter.tMenuResetTimer(CMenuCharacter.ECharacterAnimation.SELECT);
 
 							#endregion
+						}
+						else if (this.actSongList.latestContext == eMenuContext.SearchByText) {
+							#region [Trigger context box]
+
+							this.actSongList.rCurrentlySelectedSong.childrenList = CSongDict.tFetchSongsByTitle(
+								this.actSongList.rCurrentlySelectedSong,
+								(ETitleType)this.actSongList.tMenuContextGetVar(1),
+								this.actSongList.searchTextResult);
+
+							CSongSelectSongManager.disable();
+
+							OpenTaiko.Skin.soundDecideSFX.tPlay();
+							this.actSongList.ctBarFlash.Start(0, 2700, 1, OpenTaiko.Timer);
+							this.actSongList.ctBoxOpen.Start(200, 2700, 1.3f, OpenTaiko.Timer);
+							this.actSongList.bBoxOpen = true;
+
+							CMenuCharacter.tMenuResetTimer(CMenuCharacter.ECharacterAnimation.SELECT);
+							#endregion
 						} else if (this.actSongList.latestContext == eMenuContext.Random) {
 							#region [Trigger context box]
 
@@ -919,11 +937,15 @@ internal class CStageSongSelect : CStage {
 														OpenTaiko.Skin.soundDecideSFX.tPlay();
 														goto Decided;
 														//this.act曲リスト.r現在選択中の曲.list子リスト = CSongDict.tFetchSongsByDifficulty(this.act曲リスト.r現在選択中の曲, (int)Difficulty.Oni, 8);
+													} else if (this.actSongList.rCurrentlySelectedSong.songGenre == "SearchT") {
+														this.actSongList.tMenuContextTrigger(eMenuContext.SearchByText);
+														OpenTaiko.Skin.soundDecideSFX.tPlay();
+														goto Decided;
 													}
 
-													#endregion
+														#endregion
 
-													CSongSelectSongManager.disable();
+														CSongSelectSongManager.disable();
 
 													OpenTaiko.Skin.soundDecideSFX.tPlay();
 													this.actSongList.ctBarFlash.Start(0, 2700, OpenTaiko.Skin.SongSelect_Box_Opening_Interval, OpenTaiko.Timer);

--- a/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
@@ -461,7 +461,7 @@ class CStageHeya : CStage {
 
 			HBlackBackdrop.Draw(191);
 
-			if (textInput.Text != textInputTitle.str) { textInputTitle = new TitleTextureKey(textInput.Text, pfHeyaFont, Color.White, Color.Black, 1000); }
+			if (textInput.DisplayText != textInputTitle.str) { textInputTitle = new TitleTextureKey(textInput.DisplayText, pfHeyaFont, Color.White, Color.Black, 1000); }
 			CTexture text_tex = TitleTextureKey.ResolveTitleTexture(textInputTitle);
 			CTexture text_info = TitleTextureKey.ResolveTitleTexture(textInputInfo);
 
@@ -720,7 +720,7 @@ class CStageHeya : CStage {
 			return 0;
 		}
 		else if (iCurrentMenu == CurrentMenu.Name && OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape)) {
-			OpenTaiko.Skin.soundDecideSFX.tPlay();
+			OpenTaiko.Skin.soundCancelSFX.tPlay();
 			iCurrentMenu = CurrentMenu.ReturnToMenu;
 			this.ttkInfoSection = null;
 			this.tResetOpts();

--- a/OpenTaiko/src/Stages/11.Heya/CTextInput.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CTextInput.cs
@@ -37,6 +37,15 @@ namespace OpenTaiko {
 
 		public string Text = "";
 		/// <summary>
+		/// Used to display the current text with a blinking cursor, to imitate an input text box. For actual text, use <seealso cref="Text"/>.
+		/// </summary>
+		public string DisplayText {
+			get
+			{
+				return Text + (OpenTaiko.Timer.SystemTimeMs % 1000 >= 300 ? "|" : "");
+			}
+		}
+		/// <summary>
 		/// Length in bytes, not char count.
 		/// </summary>
 		public uint MaxLength = 64;


### PR DESCRIPTION
Adds a new folder with a similar appearance to Search by Difficulty. Text comparison is case-insensitive.

Can search via. :
- Title
- Subtitle
- Charter (reads `MAKER` and `NOTESDESIGNER(x)` commands)

![20241219022825](https://github.com/user-attachments/assets/c2f1207c-b60c-4b43-97dd-03287007f079)
