### PR TITLE
fix: forward-ize backslashes to fix path issues

### DIFF
--- a/OpenTaiko/System/Open-World Memories/Sounds/HitSounds/HitSounds.json
+++ b/OpenTaiko/System/Open-World Memories/Sounds/HitSounds/HitSounds.json
@@ -1,33 +1,33 @@
 [
 	{
 		"name": "Taiko",
-		"path": "Sounds\\Taiko\\",
+		"path": "Sounds/Taiko/",
 		"format": "OGG",
 	},
 	{
 		"name": "Electro",
-		"path": "Sounds\\HitSounds\\Electro\\",
+		"path": "Sounds/HitSounds/Electro/",
 		"format": "WAV",
 	},
 	{
 		"name": "Konga",
-		"path": "Sounds\\HitSounds\\Konga\\",
+		"path": "Sounds/HitSounds/Konga/",
 		"format": "WAV",
 	},
 	{
 		"name": "'08 Dual",
-		"path": "Sounds\\HitSounds\\'08 Dual\\",
+		"path": "Sounds/HitSounds/'08 Dual/",
 		"format": "WAV",
 
 	},
 	{
 		"name": "Break",
-		"path": "Sounds\\HitSounds\\Break\\",
+		"path": "Sounds/HitSounds/Break/",
 		"format": "WAV",
 	},
 	{
 		"name": "None",
-		"path": "Sounds\\HitSounds\\None\\",
+		"path": "Sounds/HitSounds/None/",
 		"format": "WAV",
 	},
 ]

--- a/OpenTaiko/src/Common/CConfigIni.cs
+++ b/OpenTaiko/src/Common/CConfigIni.cs
@@ -1842,9 +1842,9 @@ internal class CConfigIni : INotifyPropertyChanged {
 		#endregion
 
 		sw.WriteLine("; 使用するSkinのフォルダ名。");
-		sw.WriteLine("; 例えば System\\Default\\Graphics\\... などの場合は、SkinPath=.\\Default\\ を指定します。");
+		sw.WriteLine("; 例えば System/Default/Graphics/... などの場合は、SkinPath=./Default/ を指定します。");
 		sw.WriteLine("; Skin folder path.");
-		sw.WriteLine("; e.g. System\\Default\\Graphics\\... -> Set SkinPath=.\\Default\\");
+		sw.WriteLine("; e.g. System/Default/Graphics/... -> Set SkinPath=./Default/");
 		sw.WriteLine("SkinPath={0}", relPath);
 		sw.WriteLine();
 		sw.WriteLine("; 事前画像読み込み機能を使うかどうか。(0: OFF, 1: ON)");

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -4108,7 +4108,9 @@ internal class CTja : CActivity {
 
 			string[] args = argument.Split(',');
 			try {
-				chip.strTargetTxName = args[0].Replace("/", "\\");
+				chip.strTargetTxName = args[0]
+					.Replace('/', Path.DirectorySeparatorChar)
+					.Replace('\\', Path.DirectorySeparatorChar);
 				chip.strNewPath = this.strフォルダ名 + args[1];
 
 				if (this.bSession譜面を読み込む) {
@@ -4138,7 +4140,9 @@ internal class CTja : CActivity {
 			chip.fNow_Measure_s = this.fNow_Measure_s;
 			chip.n整数値_内部番号 = 1;
 
-			chip.strTargetTxName = argument.Replace("/", "\\");
+			chip.strTargetTxName = argument
+				.Replace('/', Path.DirectorySeparatorChar)
+				.Replace('\\', Path.DirectorySeparatorChar);
 
 			// チップを配置。
 			this.listChip.Add(chip);

--- a/OpenTaiko/src/Stages/CActオプションパネル.cs
+++ b/OpenTaiko/src/Stages/CActオプションパネル.cs
@@ -12,7 +12,7 @@ internal class CActオプションパネル : CActivity {
 		}
 	}
 	public override void CreateManagedResource() {
-		this.txオプションパネル = OpenTaiko.tテクスチャの生成(CSkin.Path(@"Graphics\Screen option panels.png"), false);
+		this.txオプションパネル = OpenTaiko.tテクスチャの生成(CSkin.Path($@"Graphics{Path.DirectorySeparatorChar}Screen option panels.png"), false);
 		base.CreateManagedResource();
 	}
 	public override void ReleaseManagedResource() {


### PR DESCRIPTION
Notices that Windows supports the Unix directory separator `/` but not vice versa.

* `OpenTaiko/src/Songs/CTja.cs`
    * fix TJA command `#CHANGETEXTURE` & `#RESETTEXTURE` directory separator was Windows-ized into ``\``
* `OpenTaiko/src/Stages/CActオプションパネル.cs` [`CActOptionPanel`]
    * `CActオプションパネル.CreateManagedResource()`
        * fix `"Graphics\Screen option panels.png"` not-found error on non-Windows
* `OpenTaiko/src/Common/CConfigIni.cs`
    * `CConfigIni.t書き出し()` [`tWriteOut`]
        * Unix-ize directory separator for config examples into `/`
* `OpenTaiko/System/Open-World Memories/Sounds/HitSounds/HitSounds.json`
    * Unix-ize directory separators in `<json>[i].path` into `/`
	* but this file is now ignored?