### PR TITLE
Fix TJA offset

### DIFF
--- a/OpenTaiko/src/Character/PuchiChara.cs
+++ b/OpenTaiko/src/Character/PuchiChara.cs
@@ -33,9 +33,9 @@ class PuchiChara : CActivity {
 		return puriChar;
 	}
 
-	public void ChangeBPM(double bpm) {
-		Counter = new CCounter(0, OpenTaiko.Skin.Game_PuchiChara[2] - 1, (int)(OpenTaiko.Skin.Game_PuchiChara_Timer * bpm / OpenTaiko.Skin.Game_PuchiChara[2]), OpenTaiko.Timer);
-		SineCounter = new CCounter(1, 360, OpenTaiko.Skin.Game_PuchiChara_SineTimer * bpm / 180, SoundManager.PlayTimer);
+	public void ChangeBPM(double secPerBeat) {
+		Counter = new CCounter(0, OpenTaiko.Skin.Game_PuchiChara[2] - 1, (int)(OpenTaiko.Skin.Game_PuchiChara_Timer * secPerBeat / OpenTaiko.Skin.Game_PuchiChara[2]), OpenTaiko.Timer);
+		SineCounter = new CCounter(1, 360, OpenTaiko.Skin.Game_PuchiChara_SineTimer * secPerBeat / 180, SoundManager.PlayTimer);
 		this.inGame = true;
 	}
 

--- a/OpenTaiko/src/Common/ImGuiDebugWindow.cs
+++ b/OpenTaiko/src/Common/ImGuiDebugWindow.cs
@@ -463,7 +463,7 @@ public static class ImGuiDebugWindow {
 						if (ImGui.TreeNodeEx($"Player {i + 1}###GAME_CHART_{i}", ImGuiTreeNodeFlags.Framed)) {
 
 							Difficulty game_difficulty = OpenTaiko.DifficultyNumberToEnum(OpenTaiko.stageSongSelect.nChoosenSongDifficulty[i]);
-							var dtx = OpenTaiko.GetDTX(i);
+							var dtx = OpenTaiko.GetTJA(i);
 
 							switch (game_difficulty) {
 								case Difficulty.Dan:

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -65,106 +65,46 @@ internal class OpenTaiko : Game {
 	}
 
 	#region [DTX instances]
-	public static CTja TJA {
-		get {
-			return tja[0];
-		}
-		set {
-			if ((tja[0] != null) && (app != null)) {
-				tja[0].DeActivate();
-				tja[0].ReleaseManagedResource();
-				tja[0].ReleaseUnmanagedResource();
-				app.listTopLevelActivities.Remove(tja[0]);
-			}
-			tja[0] = value;
-			if ((tja[0] != null) && (app != null)) {
-				app.listTopLevelActivities.Add(tja[0]);
-			}
-		}
+	public static CTja? TJA {
+		get => tja[0];
+		set => SetTJA(0, value);
 	}
-	public static CTja TJA_2P {
-		get {
-			return tja[1];
-		}
-		set {
-			if ((tja[1] != null) && (app != null)) {
-				tja[1].DeActivate();
-				tja[1].ReleaseManagedResource();
-				tja[1].ReleaseUnmanagedResource();
-				app.listTopLevelActivities.Remove(tja[1]);
-			}
-			tja[1] = value;
-			if ((tja[1] != null) && (app != null)) {
-				app.listTopLevelActivities.Add(tja[1]);
-			}
-		}
+	public static CTja? TJA_2P {
+		get => tja[1];
+		set => SetTJA(1, value);
 	}
-	public static CTja TJA_3P {
-		get {
-			return tja[2];
-		}
-		set {
-			if ((tja[2] != null) && (app != null)) {
-				tja[2].DeActivate();
-				tja[2].ReleaseManagedResource();
-				tja[2].ReleaseUnmanagedResource();
-				app.listTopLevelActivities.Remove(tja[2]);
-			}
-			tja[2] = value;
-			if ((tja[2] != null) && (app != null)) {
-				app.listTopLevelActivities.Add(tja[2]);
-			}
-		}
+	public static CTja? TJA_3P {
+		get => tja[2];
+		set => SetTJA(2, value);
 	}
-	public static CTja TJA_4P {
-		get {
-			return tja[3];
-		}
-		set {
-			if ((tja[3] != null) && (app != null)) {
-				tja[3].DeActivate();
-				tja[3].ReleaseManagedResource();
-				tja[3].ReleaseUnmanagedResource();
-				app.listTopLevelActivities.Remove(tja[3]);
-			}
-			tja[3] = value;
-			if ((tja[3] != null) && (app != null)) {
-				app.listTopLevelActivities.Add(tja[3]);
-			}
-		}
+	public static CTja? TJA_4P {
+		get => tja[3];
+		set => SetTJA(3, value);
 	}
-	public static CTja TJA_5P {
-		get {
-			return tja[4];
-		}
-		set {
-			if ((tja[4] != null) && (app != null)) {
-				tja[4].DeActivate();
-				tja[4].ReleaseManagedResource();
-				tja[4].ReleaseUnmanagedResource();
-				app.listTopLevelActivities.Remove(tja[4]);
-			}
-			tja[4] = value;
-			if ((tja[4] != null) && (app != null)) {
-				app.listTopLevelActivities.Add(tja[4]);
-			}
-		}
+	public static CTja? TJA_5P {
+		get => tja[4];
+		set => SetTJA(4, value);
 	}
 
-	public static CTja GetDTX(int player) {
-		switch (player) {
-			case 0:
-				return OpenTaiko.TJA;
-			case 1:
-				return OpenTaiko.TJA_2P;
-			case 2:
-				return OpenTaiko.TJA_3P;
-			case 3:
-				return OpenTaiko.TJA_4P;
-			case 4:
-				return OpenTaiko.TJA_5P;
+	public static CTja?[] TJAs
+		=> tja.Select(x => x).ToArray();
+
+	public static CTja? GetTJA(int player)
+		=> tja.ElementAtOrDefault(player);
+	public static void SetTJA(int player, CTja? value) {
+		if (!(player >= 0 && player <= tja.Length)) {
+			return;
 		}
-		return null;
+		if ((tja[player] != null) && (app != null)) {
+			tja[player].DeActivate();
+			tja[player].ReleaseManagedResource();
+			tja[player].ReleaseUnmanagedResource();
+			app.listTopLevelActivities.Remove(tja[player]);
+		}
+		tja[player] = value;
+		if ((tja[player] != null) && (app != null)) {
+			app.listTopLevelActivities.Add(tja[player]);
+		}
 	}
 
 	#endregion

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2180,7 +2180,9 @@ internal class CTja : CActivity {
 			this.isOFFSET_Negative = (msOFFSET_Signed < 0);
 
 			//#STARTと同時に鳴らすのはどうかと思うけどしゃーなしだな。
-			AddMusicPreTimeMs(); // 音源を鳴らす前に遅延。
+			if (n参照中の難易度 != (int)Difficulty.Dan) { // applied instead at #NEXTSONG for Dans
+				AddMusicPreTimeMs(); // 音源を鳴らす前に遅延。
+			}
 			var chip = new CChip();
 
 			chip.nChannelNo = 0x01;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -620,10 +620,10 @@ internal class CTja : CActivity {
 	private int[] nNowRollCountBranch = new int[3] { -1, -1, -1 };
 
 	private int[] n連打チップ_temp = new int[3];
-	public int nOFFSET = 0;
-	private bool bOFFSETの値がマイナスである = false;
-	private int nMOVIEOFFSET = 0;
-	private bool bMOVIEOFFSETの値がマイナスである = false;
+	public int msOFFSET_Abs = 0; // from initial measure to music begin
+	private bool isOFFSET_Negative = false;
+	private int msMOVIEOFFSET_Abs = 0; // from music begin to video begin
+	private bool isMOVIEOFFSET_Negative = false;
 	private double dbNowBPM = 120.0;
 	private int nDELAY = 0;
 
@@ -763,8 +763,8 @@ internal class CTja : CActivity {
 		this.BACKGROUND_GR = "";
 		this.PATH_WAV = "";
 		this.BPM = 120.0;
-		this.nOFFSET = OpenTaiko.ConfigIni.nGlobalOffsetMs; // When OFFSET isn't called (typically in Dans), it should default to the game's Global Offset to avoid desync.
-		this.bOFFSETの値がマイナスである = nOFFSET < 0;
+		this.msOFFSET_Abs = OpenTaiko.ConfigIni.nGlobalOffsetMs; // When OFFSET isn't called (typically in Dans), it should default to the game's Global Offset to avoid desync.
+		this.isOFFSET_Negative = msOFFSET_Abs < 0;
 		STDGBVALUE<int> stdgbvalue = new STDGBVALUE<int>();
 		stdgbvalue.Drums = 0;
 		stdgbvalue.Guitar = 0;
@@ -1421,8 +1421,8 @@ internal class CTja : CActivity {
 						case 0x01: {
 								n発声位置 = chip.n発声位置;
 
-								if (this.bOFFSETの値がマイナスである == false)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative == false)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								ms = chip.n発声時刻ms;
 
 								#region[listlyric2の時間合わせ]
@@ -1444,8 +1444,8 @@ internal class CTja : CActivity {
 						case 0x02:  // BarLength
 						{
 								n発声位置 = chip.n発声位置;
-								if (this.bOFFSETの値がマイナスである == false)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative == false)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								ms = chip.n発声時刻ms;
 								dbBarLength = chip.db実数値;
 								continue;
@@ -1453,8 +1453,8 @@ internal class CTja : CActivity {
 						case 0x03:  // BPM
 						{
 								n発声位置 = chip.n発声位置;
-								if (this.bOFFSETの値がマイナスである == false)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative == false)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								ms = chip.n発声時刻ms;
 								bpm = this.BASEBPM + chip.n整数値;
 								this.dbNowBPM = bpm;
@@ -1471,15 +1471,15 @@ internal class CTja : CActivity {
 						case 0x1D:
 						case 0x20:
 						case 0x21: {
-								if (this.bOFFSETの値がマイナスである) {
-									chip.n発声時刻ms += this.nOFFSET;
-									chip.nNoteEndTimems += this.nOFFSET;
+								if (this.isOFFSET_Negative) {
+									chip.n発声時刻ms += this.msOFFSET_Abs;
+									chip.nNoteEndTimems += this.msOFFSET_Abs;
 								}
 								continue;
 							}
 						case 0x18: {
-								if (this.bOFFSETの値がマイナスである) {
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative) {
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								}
 								continue;
 							}
@@ -1493,8 +1493,8 @@ internal class CTja : CActivity {
 							break;
 
 						case 0x50: {
-								if (this.bOFFSETの値がマイナスである)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								if (this.n内部番号BRANCH1to + 1 > this.listBRANCH.Count)
 									continue;
 
@@ -1520,8 +1520,8 @@ internal class CTja : CActivity {
 						case 0x08:  // 拡張BPM
 						{
 								n発声位置 = chip.n発声位置;
-								if (this.bOFFSETの値がマイナスである == false)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative == false)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								ms = chip.n発声時刻ms;
 								if (this.listBPM.TryGetValue(chip.n整数値_内部番号, out CBPM cBPM)) {
 									bpm = (cBPM.n表記上の番号 == 0 ? 0.0 : this.BASEBPM) + cBPM.dbBPM値;
@@ -1531,27 +1531,27 @@ internal class CTja : CActivity {
 							}
 						case 0x54:  // 動画再生
 						{
-								if (this.bOFFSETの値がマイナスである == false)
-									chip.n発声時刻ms += this.nOFFSET;
-								if (this.bMOVIEOFFSETの値がマイナスである == false)
-									chip.n発声時刻ms += this.nMOVIEOFFSET;
+								if (this.isOFFSET_Negative == false)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
+								if (this.isMOVIEOFFSET_Negative == false)
+									chip.n発声時刻ms += this.msMOVIEOFFSET_Abs;
 								else
-									chip.n発声時刻ms -= this.nMOVIEOFFSET;
+									chip.n発声時刻ms -= this.msMOVIEOFFSET_Abs;
 								continue;
 							}
 						case 0x97:
 						case 0x98:
 						case 0x99: {
-								if (this.bOFFSETの値がマイナスである) {
-									chip.n発声時刻ms += this.nOFFSET;
-									chip.nNoteEndTimems += this.nOFFSET;
+								if (this.isOFFSET_Negative) {
+									chip.n発声時刻ms += this.msOFFSET_Abs;
+									chip.nNoteEndTimems += this.msOFFSET_Abs;
 								}
 								continue;
 							}
 						case 0x9A: {
 
-								if (this.bOFFSETの値がマイナスである) {
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative) {
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								}
 								continue;
 							}
@@ -1559,37 +1559,37 @@ internal class CTja : CActivity {
 								continue;
 							}
 						case 0xDC: {
-								if (this.bOFFSETの値がマイナスである)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								continue;
 							}
 						case 0xDE: {
-								if (this.bOFFSETの値がマイナスである) {
-									chip.n発声時刻ms += this.nOFFSET;
-									chip.n分岐時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative) {
+									chip.n発声時刻ms += this.msOFFSET_Abs;
+									chip.n分岐時刻ms += this.msOFFSET_Abs;
 								}
 								this.n現在のコース = chip.nBranch;
 								continue;
 							}
 						case 0x52: {
-								if (this.bOFFSETの値がマイナスである) {
-									chip.n発声時刻ms += this.nOFFSET;
-									chip.n分岐時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative) {
+									chip.n発声時刻ms += this.msOFFSET_Abs;
+									chip.n分岐時刻ms += this.msOFFSET_Abs;
 								}
 								this.n現在のコース = chip.nBranch;
 								continue;
 							}
 						case 0xDF: {
-								if (this.bOFFSETの値がマイナスである)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								continue;
 							}
 						case 0xE0: {
 								continue;
 							}
 						default: {
-								if (this.bOFFSETの値がマイナスである)
-									chip.n発声時刻ms += this.nOFFSET;
+								if (this.isOFFSET_Negative)
+									chip.n発声時刻ms += this.msOFFSET_Abs;
 								chip.dbBPM = this.dbNowBPM;
 								continue;
 							}
@@ -2196,10 +2196,10 @@ internal class CTja : CActivity {
 
 			var chip1 = new CChip();
 			chip1.nChannelNo = 0x54;
-			if (this.nMOVIEOFFSET == 0)
+			if (this.msMOVIEOFFSET_Abs == 0)
 				chip1.n発声時刻ms = (int)this.dbNowTime;
 			else
-				chip1.n発声時刻ms = (int)this.nMOVIEOFFSET;
+				chip1.n発声時刻ms = (int)this.msMOVIEOFFSET_Abs;
 			chip1.dbBPM = this.dbNowBPM;
 			chip1.fNow_Measure_m = this.fNow_Measure_m;
 			chip1.fNow_Measure_s = this.fNow_Measure_s;
@@ -4567,8 +4567,8 @@ internal class CTja : CActivity {
 			FixSENote = int.Parse(argument);
 			IsEnabledFixSENote = true;
 		} else if (command == "#NEXTSONG") {
-			nNextSongOffset += nOFFSET;
-			var delayTime = 6200.0 + nOFFSET; // 6.2秒ディレイ
+			nNextSongOffset += msOFFSET_Abs;
+			var delayTime = 6200.0 + msOFFSET_Abs; // 6.2秒ディレイ
 											  //チップ追加して割り込んでみる。
 			var chip = new CChip();
 
@@ -4578,7 +4578,7 @@ internal class CTja : CActivity {
 			chip.fNow_Measure_m = this.fNow_Measure_m;
 			chip.fNow_Measure_s = this.fNow_Measure_s;
 			this.dbNowTime += delayTime;
-			this.dbNowBMScollTime += (delayTime - nOFFSET) * this.dbNowBPM / 15000;
+			this.dbNowBMScollTime += (delayTime - msOFFSET_Abs) * this.dbNowBPM / 15000;
 			chip.n整数値_内部番号 = 0;
 			chip.nBranch = this.n現在のコース;
 
@@ -5490,23 +5490,23 @@ internal class CTja : CActivity {
 				}
 			}
 		} else if (strCommandName.Equals("OFFSET") && !string.IsNullOrEmpty(strCommandParam)) {
-			this.nOFFSET = (int)(Convert.ToDouble(strCommandParam) * 1000);
+			this.msOFFSET_Abs = (int)(Convert.ToDouble(strCommandParam) * 1000);
 
-			this.bOFFSETの値がマイナスである = this.nOFFSET < 0 ? true : false;
+			this.isOFFSET_Negative = this.msOFFSET_Abs < 0 ? true : false;
 
 			this.listBPM[0].bpm_change_bmscroll_time = -2000 * this.dbNowBPM / 15000;
-			if (this.bOFFSETの値がマイナスである == true)
-				this.nOFFSET = this.nOFFSET * -1; //OFFSETは秒を加算するので、必ず正の数にすること。
+			if (this.isOFFSET_Negative == true)
+				this.msOFFSET_Abs = this.msOFFSET_Abs * -1; //OFFSETは秒を加算するので、必ず正の数にすること。
 												  //tbOFFSET.Text = strCommandParam;
 
 			// Substract global offset
-			this.nOFFSET += ((this.bOFFSETの値がマイナスである == true) ? -OpenTaiko.ConfigIni.nGlobalOffsetMs : OpenTaiko.ConfigIni.nGlobalOffsetMs);
+			this.msOFFSET_Abs += ((this.isOFFSET_Negative == true) ? -OpenTaiko.ConfigIni.nGlobalOffsetMs : OpenTaiko.ConfigIni.nGlobalOffsetMs);
 		} else if (strCommandName.Equals("MOVIEOFFSET")) {
-			this.nMOVIEOFFSET = (int)(Convert.ToDouble(strCommandParam) * 1000);
-			this.bMOVIEOFFSETの値がマイナスである = this.nMOVIEOFFSET < 0 ? true : false;
+			this.msMOVIEOFFSET_Abs = (int)(Convert.ToDouble(strCommandParam) * 1000);
+			this.isMOVIEOFFSET_Negative = this.msMOVIEOFFSET_Abs < 0 ? true : false;
 
-			if (this.bMOVIEOFFSETの値がマイナスである == true)
-				this.nMOVIEOFFSET = this.nMOVIEOFFSET * -1; //OFFSETは秒を加算するので、必ず正の数にすること。
+			if (this.isMOVIEOFFSET_Negative == true)
+				this.msMOVIEOFFSET_Abs = this.msMOVIEOFFSET_Abs * -1; //OFFSETは秒を加算するので、必ず正の数にすること。
 															//tbOFFSET.Text = strCommandParam;
 		}
 		#region[移動→不具合が起こるのでここも一応復活させておく]

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -764,8 +764,8 @@ internal class CTja : CActivity {
 		this.BACKGROUND_GR = "";
 		this.PATH_WAV = "";
 		this.BPM = 120.0;
-		this.msOFFSET_Abs = OpenTaiko.ConfigIni.nGlobalOffsetMs; // When OFFSET isn't called (typically in Dans), it should default to the game's Global Offset to avoid desync.
-		this.isOFFSET_Negative = msOFFSET_Abs < 0;
+		this.msOFFSET_Abs = 0;
+		this.isOFFSET_Negative = false;
 		STDGBVALUE<int> stdgbvalue = new STDGBVALUE<int>();
 		stdgbvalue.Drums = 0;
 		stdgbvalue.Guitar = 0;
@@ -2179,7 +2179,14 @@ internal class CTja : CActivity {
 		#endregion
 
 		if (command == "#START") {
+			// apply global offset
+			var msOFFSET_Signed = this.isOFFSET_Negative ? -this.msOFFSET_Abs : this.msOFFSET_Abs;
+			msOFFSET_Signed += OpenTaiko.ConfigIni.nGlobalOffsetMs;
+			this.msOFFSET_Abs = Math.Abs(msOFFSET_Signed);
+			this.isOFFSET_Negative = (msOFFSET_Signed < 0);
+
 			//#STARTと同時に鳴らすのはどうかと思うけどしゃーなしだな。
+			this.listBPM[0].bpm_change_bmscroll_time = -2000 * this.dbNowBPM / 15000;
 			AddMusicPreTimeMs(); // 音源を鳴らす前に遅延。
 			var chip = new CChip();
 
@@ -5492,16 +5499,11 @@ internal class CTja : CActivity {
 			}
 		} else if (strCommandName.Equals("OFFSET") && !string.IsNullOrEmpty(strCommandParam)) {
 			this.msOFFSET_Abs = (int)(Convert.ToDouble(strCommandParam) * 1000);
-
 			this.isOFFSET_Negative = this.msOFFSET_Abs < 0 ? true : false;
 
-			this.listBPM[0].bpm_change_bmscroll_time = -2000 * this.dbNowBPM / 15000;
 			if (this.isOFFSET_Negative == true)
 				this.msOFFSET_Abs = this.msOFFSET_Abs * -1; //OFFSETは秒を加算するので、必ず正の数にすること。
 												  //tbOFFSET.Text = strCommandParam;
-
-			// Substract global offset
-			this.msOFFSET_Abs += ((this.isOFFSET_Negative == true) ? -OpenTaiko.ConfigIni.nGlobalOffsetMs : OpenTaiko.ConfigIni.nGlobalOffsetMs);
 		} else if (strCommandName.Equals("MOVIEOFFSET")) {
 			this.msMOVIEOFFSET_Abs = (int)(Convert.ToDouble(strCommandParam) * 1000);
 			this.isMOVIEOFFSET_Negative = this.msMOVIEOFFSET_Abs < 0 ? true : false;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -526,7 +526,6 @@ internal class CTja : CActivity {
 		public double dbBMScollTime;
 		public double db移動待機時刻;
 		public double db出現時刻;
-		public double db再生速度;
 		public float fMeasure_s;
 		public float fMeasure_m;
 	}
@@ -553,7 +552,6 @@ internal class CTja : CActivity {
 	public double MaxBPM;
 	public STチップがある bチップがある;
 	public string COMMENT;
-	public double db再生速度;
 	public string GENRE;
 	public string MAKER;
 	public string[] NOTESDESIGNER = new string[(int)Difficulty.Total] { "", "", "", "", "", "", "" };
@@ -770,7 +768,6 @@ internal class CTja : CActivity {
 		stdgbvalue.Bass = 0;
 		this.LEVEL = stdgbvalue;
 		this.bHIDDENBRANCH = false;
-		this.db再生速度 = 1.0;
 		this.bチップがある = new STチップがある();
 		this.bチップがある.Drums = false;
 		this.bチップがある.Guitar = false;
@@ -855,15 +852,15 @@ internal class CTja : CActivity {
 		DanSongs.Number = 0;
 
 	}
-	public CTja(string strファイル名, bool bヘッダのみ, double db再生速度, int nBGMAdjust, int difficulty)
+	public CTja(string strファイル名, bool bヘッダのみ, double db再生速度Unused, int nBGMAdjust, int difficulty)
 		: this() {
 		this.Activate();
-		this.t入力(strファイル名, bヘッダのみ, db再生速度, nBGMAdjust, 0, 0, false, difficulty);
+		this.t入力(strファイル名, bヘッダのみ, db再生速度Unused, nBGMAdjust, 0, 0, false, difficulty);
 	}
-	public CTja(string strファイル名, bool bヘッダのみ, double db再生速度, int nBGMAdjust, int nReadVersionUnused, int nPlayerSide, bool bSession, int difficulty)
+	public CTja(string strファイル名, bool bヘッダのみ, double db再生速度Unused, int nBGMAdjust, int nReadVersionUnused, int nPlayerSide, bool bSession, int difficulty)
 		: this() {
 		this.Activate();
-		this.t入力(strファイル名, bヘッダのみ, db再生速度, nBGMAdjust, nReadVersionUnused, nPlayerSide, bSession, difficulty);
+		this.t入力(strファイル名, bヘッダのみ, db再生速度Unused, nBGMAdjust, nReadVersionUnused, nPlayerSide, bSession, difficulty);
 	}
 
 
@@ -1245,7 +1242,7 @@ internal class CTja : CActivity {
 	}
 	#endregion
 
-	public void t入力(string strファイル名, bool bヘッダのみ, double db再生速度, int nBGMAdjust, int nReadVersionUnused, int nPlayerSide, bool bSession, int difficulty) {
+	public void t入力(string strファイル名, bool bヘッダのみ, double db再生速度Unused, int nBGMAdjust, int nReadVersionUnused, int nPlayerSide, bool bSession, int difficulty) {
 		this.bヘッダのみ = bヘッダのみ;
 		this.strファイル名の絶対パス = Path.GetFullPath(strファイル名);
 		this.strファイル名 = Path.GetFileName(this.strファイル名の絶対パス);
@@ -1261,18 +1258,15 @@ internal class CTja : CActivity {
 			StreamReader reader = new StreamReader(strファイル名, Encoding.GetEncoding(OpenTaiko.sEncType));
 			string str2 = reader.ReadToEnd();
 			reader.Close();
-			this.t入力_全入力文字列から(str2, str2, db再生速度, nBGMAdjust, difficulty);
+			this.t入力_全入力文字列から(str2, str2, db再生速度Unused, nBGMAdjust, difficulty);
 		} catch (Exception ex) {
 			Trace.TraceError("おや?エラーが出たようです。お兄様。");
 			Trace.TraceError(ex.ToString());
 			Trace.TraceError("例外が発生しましたが処理を継続します。 (79ff8639-9b3c-477f-bc4a-f2eea9784860)");
 		}
 	}
-	public void t入力_全入力文字列から(string str全入力文字列, string str1Unused, double db再生速度, int nBGMAdjust, int Difficulty) {
+	public void t入力_全入力文字列から(string str全入力文字列, string str1Unused, double db再生速度Unused, int nBGMAdjust, int Difficulty) {
 		if (!string.IsNullOrEmpty(str全入力文字列)) {
-			#region [ 改行カット ]
-			this.db再生速度 = db再生速度;
-			#endregion
 			#region [ 初期化 ]
 			for (int j = 0; j < 36 * 36; j++) {
 				this.n無限管理WAV[j] = -j;
@@ -1592,14 +1586,6 @@ internal class CTja : CActivity {
 								chip.dbBPM = this.dbNowBPM;
 								continue;
 							}
-					}
-				}
-				if (this.db再生速度 > 0.0) {
-					double _db再生速度 = this.db再生速度;
-					foreach (CChip chip in this.listChip) {
-						chip.n発声時刻ms = (int)(((double)chip.n発声時刻ms) / _db再生速度);
-						chip.db発声時刻ms = (((double)chip.n発声時刻ms) / _db再生速度);
-						chip.nNoteEndTimems = (int)(((double)chip.nNoteEndTimems) / _db再生速度);
 					}
 				}
 				#endregion
@@ -4721,7 +4707,6 @@ internal class CTja : CActivity {
 			cBranchStart.fMeasure_m = this.fNow_Measure_m;
 			cBranchStart.nMeasureCount = this.n現在の小節数;
 			cBranchStart.db移動待機時刻 = this.db移動待機時刻;
-			cBranchStart.db再生速度 = this.db再生速度;
 			cBranchStart.db出現時刻 = this.db出現時刻;
 			#endregion
 		} else {
@@ -4735,7 +4720,6 @@ internal class CTja : CActivity {
 			this.fNow_Measure_m = cBranchStart.fMeasure_m;
 			this.n現在の小節数 = cBranchStart.nMeasureCount;
 			this.db移動待機時刻 = cBranchStart.db移動待機時刻;
-			this.db再生速度 = cBranchStart.db再生速度;
 			this.db出現時刻 = cBranchStart.db出現時刻;
 			#endregion
 		}
@@ -6168,8 +6152,7 @@ internal class CTja : CActivity {
 
 					int duration = 0;
 					if (listWAV.TryGetValue(pChip.n整数値_内部番号, out CTja.CWAV wc)) {
-						double _db再生速度 = this.db再生速度;
-						duration = (wc.rSound[0] == null) ? 0 : (int)(wc.rSound[0].TotalPlayTime / _db再生速度); // #23664 durationに再生速度が加味されておらず、低速再生でBGMが途切れる問題を修正 (発声時刻msは、DTX読み込み時に再生速度加味済)
+						duration = wc.rSound[0]?.TotalPlayTime ?? 0;
 					}
 					int n新RemoveMixer時刻ms, n新RemoveMixer位置;
 					t発声時刻msと発声位置を取得する(pChip.n発声時刻ms + duration + n発音後余裕ms, out n新RemoveMixer時刻ms, out n新RemoveMixer位置);

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -621,7 +621,7 @@ internal class CTja : CActivity {
 	private int[] nNowRollCountBranch = new int[3] { -1, -1, -1 };
 
 	private int[] n連打チップ_temp = new int[3];
-	public int msOFFSET_Abs = 0; // from initial measure to music begin
+	private int msOFFSET_Abs = 0; // from initial measure to music begin
 	private bool isOFFSET_Negative = false;
 	private int msMOVIEOFFSET_Abs = 0; // from music begin to video begin
 	private bool isMOVIEOFFSET_Negative = false;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -594,8 +594,6 @@ internal class CTja : CActivity {
 	private double[] dbNowSCROLL_Expert;
 	private double[] dbNowSCROLL_Master;
 
-	private int nNextSongOffset;
-
 	public Dictionary<int, CDELAY> listDELAY;
 	public Dictionary<int, CBRANCH> listBRANCH;
 	public STLANEINT n可視チップ数;
@@ -2267,7 +2265,7 @@ internal class CTja : CActivity {
 				MinBPM = dbBPM;
 			}
 
-			this.listBPM.Add(this.n内部番号BPM1to - 1, new CBPM() { n内部番号 = this.n内部番号BPM1to - 1, n表記上の番号 = 0, dbBPM値 = dbBPM, bpm_change_time = this.dbNowTime - nNextSongOffset, bpm_change_bmscroll_time = this.dbNowBMScollTime, bpm_change_course = this.n現在のコース });
+			this.listBPM.Add(this.n内部番号BPM1to - 1, new CBPM() { n内部番号 = this.n内部番号BPM1to - 1, n表記上の番号 = 0, dbBPM値 = dbBPM, bpm_change_time = this.dbNowTime, bpm_change_bmscroll_time = this.dbNowBMScollTime, bpm_change_course = this.n現在のコース });
 
 
 			//チップ追加して割り込んでみる。
@@ -4570,9 +4568,6 @@ internal class CTja : CActivity {
 			FixSENote = int.Parse(argument);
 			IsEnabledFixSENote = true;
 		} else if (command == "#NEXTSONG") {
-			nNextSongOffset += msOFFSET_Abs;
-			var delayTime = msDanNextSongDelay + msOFFSET_Abs; // 6.2秒ディレイ
-											  //チップ追加して割り込んでみる。
 			var chip = new CChip();
 
 			chip.nChannelNo = 0x9B;
@@ -4580,13 +4575,15 @@ internal class CTja : CActivity {
 			chip.n発声時刻ms = (int)this.dbNowTime;
 			chip.fNow_Measure_m = this.fNow_Measure_m;
 			chip.fNow_Measure_s = this.fNow_Measure_s;
-			this.dbNowTime += delayTime;
-			this.dbNowBMScollTime += (delayTime - msOFFSET_Abs) * this.dbNowBPM / 15000;
 			chip.n整数値_内部番号 = 0;
 			chip.nBranch = this.n現在のコース;
 
 			// チップを配置。
 			this.listChip.Add(chip);
+
+			// 6.2秒ディレイ
+			this.dbNowTime += msDanNextSongDelay;
+			this.dbNowBMScollTime += msDanNextSongDelay * this.dbNowBPM / 15000;
 
 			AddMusicPreTimeMs(); // 段位の幕が開いてからの遅延。
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2023,10 +2023,6 @@ internal class CTja : CActivity {
 			strSplitした後の譜面 = this.tコマンド行を削除したTJAを返す(strSplitした後の譜面, 1);
 			this.n現在の小節数 = 1;
 			try {
-				#region[ 最初の処理 ]
-				//1小節の時間を挿入して開始時間を調節。
-				this.dbNowTime += ((15000.0 / 120.0 * (4.0 / 4.0)) * 16.0);
-				#endregion
 				for (int i = 0; strSplitした後の譜面.Length > i; i++) {
 					nNowReadLine++;
 					str = strSplitした後の譜面[i];
@@ -2186,7 +2182,6 @@ internal class CTja : CActivity {
 			this.isOFFSET_Negative = (msOFFSET_Signed < 0);
 
 			//#STARTと同時に鳴らすのはどうかと思うけどしゃーなしだな。
-			this.listBPM[0].bpm_change_bmscroll_time = -2000 * this.dbNowBPM / 15000;
 			AddMusicPreTimeMs(); // 音源を鳴らす前に遅延。
 			var chip = new CChip();
 
@@ -6530,9 +6525,9 @@ internal class CTja : CActivity {
 	// RawTjaTime is time for chip.n発声時刻ms just before the post-processing of tja.t入力_V4().
 	// * RawTjaTime is DefTime with additional initial padding time
 	public static double DefTimeToRawTjaTime(double msTime)
-		=> msTime + (((15000.0 / 120.0 * (4.0 / 4.0)) * 16.0) + OpenTaiko.ConfigIni.MusicPreTimeMs);
+		=> msTime + OpenTaiko.ConfigIni.MusicPreTimeMs;
 	public static double RawTjaTimeToDefTime(double msTime)
-		=> msTime - (((15000.0 / 120.0 * (4.0 / 4.0)) * 16.0) + OpenTaiko.ConfigIni.MusicPreTimeMs);
+		=> msTime - OpenTaiko.ConfigIni.MusicPreTimeMs;
 
 	// TjaTime is the time for chip.n発声時刻ms after the post-processing of tja.t入力_V4().
 	// * For positive msOFFSET, all and only music-time-relative events are delayed by msOFFSET_Abs.

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -6520,4 +6520,39 @@ internal class CTja : CActivity {
 	}
 	//-----------------
 	#endregion
+
+	// Time coordination converters
+
+	// DefTime is the time relative to the initial measure of the first song.
+	// RawTjaTime is time for chip.n発声時刻ms just before the post-processing of tja.t入力_V4().
+	// * RawTjaTime is DefTime with additional initial padding time
+	public static double DefTimeToRawTjaTime(double msTime)
+		=> msTime + (((15000.0 / 120.0 * (4.0 / 4.0)) * 16.0) + OpenTaiko.ConfigIni.MusicPreTimeMs);
+	public static double RawTjaTimeToDefTime(double msTime)
+		=> msTime - (((15000.0 / 120.0 * (4.0 / 4.0)) * 16.0) + OpenTaiko.ConfigIni.MusicPreTimeMs);
+
+	// TjaTime is the time for chip.n発声時刻ms after the post-processing of tja.t入力_V4().
+	// * For positive msOFFSET, all and only music-time-relative events are delayed by msOFFSET_Abs.
+	// * For negative msOFFSET, all and only note-time-relative events are delayed by msOFFSET_Abs.
+	public static double RawTjaTimeToTjaTimeMusic(double msTime, CTja tja)
+		=> msTime + (!tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
+	public static double TjaTimeToRawTjaTimeMusic(double msTime, CTja tja)
+		=> msTime - (!tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
+	public static double RawTjaTimeToTjaTimeNote(double msTime, CTja tja)
+		=> msTime + (tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
+	public static double TjaTimeToRawTjaTimeNote(double msTime, CTja tja)
+		=> msTime - (tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
+
+	// GameTime is the real elapsed time of gameplay.
+	// SongPlaybackSpeed scales the GameTime into the corresponding TjaTime
+	// These converters are unit-independent.
+	public static double GameTimeToTjaTime(double time)
+		=> time * OpenTaiko.ConfigIni.SongPlaybackSpeed;
+	public static double TjaTimeToGameTime(double time)
+		=> time / OpenTaiko.ConfigIni.SongPlaybackSpeed;
+	// BeatSpeed (including BPM) is the reciprocal of time duration per beat.
+	public static double GameBeatSpeedToTjaBeatSpeed(double beatSpeed)
+		=> beatSpeed / OpenTaiko.ConfigIni.SongPlaybackSpeed;
+	public static double TjaBeatSpeedToGameBeatSpeed(double beatSpeed)
+		=> beatSpeed * OpenTaiko.ConfigIni.SongPlaybackSpeed;
 }

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -601,6 +601,7 @@ internal class CTja : CActivity {
 	public STLANEINT n可視チップ数;
 	public const int n最大音数 = 4;
 	public const int n小節の解像度 = 384;
+	public const double msDanNextSongDelay = 6200.0;
 	public string PANEL;
 	public string PATH_WAV;
 	public string PREIMAGE;
@@ -4568,7 +4569,7 @@ internal class CTja : CActivity {
 			IsEnabledFixSENote = true;
 		} else if (command == "#NEXTSONG") {
 			nNextSongOffset += msOFFSET_Abs;
-			var delayTime = 6200.0 + msOFFSET_Abs; // 6.2秒ディレイ
+			var delayTime = msDanNextSongDelay + msOFFSET_Abs; // 6.2秒ディレイ
 											  //チップ追加して割り込んでみる。
 			var chip = new CChip();
 

--- a/OpenTaiko/src/Songs/TJA/CChip.cs
+++ b/OpenTaiko/src/Songs/TJA/CChip.cs
@@ -291,8 +291,7 @@ internal class CChip : IComparable<CChip>, ICloneable {
 			}
 		}
 
-		double _db再生速度 = OpenTaiko.TJA.db再生速度;
-		return (int)(nDuration / _db再生速度);
+		return nDuration;
 	}
 
 	#region [ IComparable 実装 ]

--- a/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
@@ -1145,7 +1145,7 @@ internal class CActConfigList : CActivity {
 		#region [ 初めての進行描画 ]
 		//-----------------
 		if (base.IsFirstDraw) {
-			this.nスクロール用タイマ値 = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.nスクロール用タイマ値 = OpenTaiko.Timer.NowTimeMs;
 			this.ct三角矢印アニメ.Start(0, 9, 50, OpenTaiko.Timer);
 			base.IsFirstDraw = false;
 		}

--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -2977,9 +2977,9 @@ internal class CActSelect曲リスト : CActivity {
 		var _speed = OpenTaiko.ConfigIni.SongPlaybackSpeed;
 
 		double[] bpms = new double[3] {
-			_score.BaseBpm * _speed,
-			_score.MinBpm * _speed,
-			_score.MaxBpm * _speed
+			CTja.TjaBeatSpeedToGameBeatSpeed(_score.BaseBpm),
+			CTja.TjaBeatSpeedToGameBeatSpeed(_score.MinBpm),
+			CTja.TjaBeatSpeedToGameBeatSpeed(_score.MaxBpm),
 		};
 
 		string bpm_str = CLangManager.LangInstance.GetString("SONGSELECT_INFO_BPM", bpms[0]);

--- a/OpenTaiko/src/Stages/07.Game/CActTaikoScrollSpeed.cs
+++ b/OpenTaiko/src/Stages/07.Game/CActTaikoScrollSpeed.cs
@@ -31,7 +31,7 @@ internal class CActTaikoScrollSpeed : CActivity {
 		if (!base.IsDeActivated) {
 			if (base.IsFirstDraw) {
 				for (int i = 0; i < 5; i++) {
-					this.nScrollExclusiveTimer[i] = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+					this.nScrollExclusiveTimer[i] = SoundManager.PlayTimer.NowTimeMs;
 
 				}
 

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
@@ -49,7 +49,7 @@ internal class CAct演奏演奏情報 : CActivity {
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Song/G. Offset:{0:####0}/{1:####0} ms", OpenTaiko.TJA.nBGMAdjust, OpenTaiko.ConfigIni.nGlobalOffsetMs));
 			y -= dy;
 			int num = (OpenTaiko.TJA.listChip.Count > 0) ? OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms : 0;
-			string str = "Time:          " + ((((double)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0)).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
+			string str = "Time:          " + (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) / 1000.0).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, str);
 			y -= dy;
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Part:          {0:####0}/{1:####0}", NowMeasure[0], NowMeasure[1]));

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
@@ -49,7 +49,7 @@ internal class CAct演奏演奏情報 : CActivity {
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Song/G. Offset:{0:####0}/{1:####0} ms", OpenTaiko.TJA.nBGMAdjust, OpenTaiko.ConfigIni.nGlobalOffsetMs));
 			y -= dy;
 			int num = (OpenTaiko.TJA.listChip.Count > 0) ? OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms : 0;
-			string str = "Time:          " + (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) / 1000.0).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
+			string str = "Time:          " + (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.TJA) / 1000.0).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, str);
 			y -= dy;
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Part:          {0:####0}/{1:####0}", NowMeasure[0], NowMeasure[1]));

--- a/OpenTaiko/src/Stages/07.Game/CFloorManagement.cs
+++ b/OpenTaiko/src/Stages/07.Game/CFloorManagement.cs
@@ -50,7 +50,7 @@ static internal class CFloorManagement {
 
 	// prevents one from playing in 7.65x or so speed and passing the life challenge easily.
 	public static double InvincibilityDurationSpeedDependent {
-		get => CTja.TjaTimeToGameTime(InvincibilityDuration);
+		get => CTja.TjaDurationToGameDuration(InvincibilityDuration);
 	}
 
 	// ms

--- a/OpenTaiko/src/Stages/07.Game/CFloorManagement.cs
+++ b/OpenTaiko/src/Stages/07.Game/CFloorManagement.cs
@@ -48,8 +48,9 @@ static internal class CFloorManagement {
 	public static int MaxNumberOfLives = 5;
 	public static int CurrentNumberOfLives = 5;
 
+	// prevents one from playing in 7.65x or so speed and passing the life challenge easily.
 	public static double InvincibilityDurationSpeedDependent {
-		get => ((double)InvincibilityDuration) / OpenTaiko.ConfigIni.SongPlaybackSpeed;
+		get => CTja.TjaTimeToGameTime(InvincibilityDuration);
 	}
 
 	// ms

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4287,7 +4287,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		float bpm_time = 0;
 		int last_input = 0;
 		float last_bpm_change_time;
-		play_time = (float)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) - tja.msOFFSET_Abs;
+		play_time = (float)CTja.TjaTimeToRawTjaTimeNote(CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), tja);
 
 		for (int i = 1; ; i++) {
 			//BPMCHANGEの数越えた

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -1442,9 +1442,9 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 					if (this.bPAUSE == false && rollSpeed > 0) // && TJAPlayer3.ConfigIni.bAuto先生の連打)
 					{
-						double rollSpeedScaled = rollSpeed / OpenTaiko.ConfigIni.SongPlaybackSpeed;
+						double msPerRollTja = 1000.0 / rollSpeed * OpenTaiko.ConfigIni.SongPlaybackSpeed;
 						if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)
-							> (pChip.n発声時刻ms + (1000.0 / rollSpeedScaled) * pChip.nRollCount)) {
+							> (pChip.n発声時刻ms + msPerRollTja * pChip.nRollCount)) {
 							EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(nPlayer)];
 							int nLane = 0;
 

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -869,10 +869,10 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 	private void UpdateCharaCounter(int nPlayer) {
 		for (int i = 0; i < 5; i++) {
-			ctChipAnime[i] = new CCounter(0, 3, 60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i] * 1 / 4 / OpenTaiko.ConfigIni.SongPlaybackSpeed, SoundManager.PlayTimer);
+			ctChipAnime[i] = new CCounter(0, 3, CTja.TjaTimeToGameTime(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i] * 1 / 4), SoundManager.PlayTimer);
 		}
 
-		OpenTaiko.stageGameScreen.PuchiChara.ChangeBPM(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer] / OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		OpenTaiko.stageGameScreen.PuchiChara.ChangeBPM(CTja.TjaTimeToGameTime(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer]));
 	}
 
 	public void AddMixer(CSound cs, bool _b演奏終了後も再生が続くチップである) {
@@ -975,11 +975,11 @@ internal abstract class CStage演奏画面共通 : CStage {
 			int nDeltaTime = Math.Abs(pChip.nLag);
 			//Debug.WriteLine("nAbsTime=" + (nTime - pChip.n発声時刻ms) + ", nDeltaTime=" + (nTime - pChip.n発声時刻ms));
 			if (NotesManager.IsRoll(pChip) || NotesManager.IsFuzeRoll(pChip)) {
-				if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) > pChip.n発声時刻ms && (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) < pChip.nNoteEndTimems) {
+				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) > pChip.n発声時刻ms && CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) < pChip.nNoteEndTimems) {
 					return ENoteJudge.Perfect;
 				}
 			} else if (NotesManager.IsGenericBalloon(pChip)) {
-				if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) >= pChip.n発声時刻ms - 17 && (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) < pChip.nNoteEndTimems) {
+				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) >= pChip.n発声時刻ms - 17 && CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) < pChip.nNoteEndTimems) {
 					return ENoteJudge.Perfect;
 				}
 			}
@@ -987,17 +987,17 @@ internal abstract class CStage演奏画面共通 : CStage {
 			int actual = OpenTaiko.GetActualPlayer(player);
 			CConfigIni.CTimingZones tz = GetTimingZones(actual);
 
-			if (nDeltaTime <= tz.nGoodZone * OpenTaiko.ConfigIni.SongPlaybackSpeed) {
+			if (nDeltaTime <= CTja.GameTimeToTjaTime(tz.nGoodZone)) {
 				return ENoteJudge.Perfect;
 			}
-			if (nDeltaTime <= tz.nOkZone * OpenTaiko.ConfigIni.SongPlaybackSpeed) {
+			if (nDeltaTime <= CTja.GameTimeToTjaTime(tz.nOkZone)) {
 				if (OpenTaiko.ConfigIni.bJust[actual] == 1 && NotesManager.IsMissableNote(pChip)) // Just
 					return ENoteJudge.Poor;
 				return ENoteJudge.Good;
 			}
 
 
-			if (nDeltaTime <= tz.nBadZone * OpenTaiko.ConfigIni.SongPlaybackSpeed) {
+			if (nDeltaTime <= CTja.GameTimeToTjaTime(tz.nBadZone)) {
 				if (OpenTaiko.ConfigIni.bJust[actual] == 2 || !NotesManager.IsMissableNote(pChip)) // Safe
 					return ENoteJudge.Good;
 				return ENoteJudge.Poor;
@@ -1234,7 +1234,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 	protected bool tBalloonProcess(CChip pChip, double dbProcess_time, int player) {
 		//if( dbProcess_time >= pChip.n発声時刻ms && dbProcess_time < pChip.nノーツ終了時刻ms )
-		long nowTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		long nowTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		bool IsKusudama = NotesManager.IsKusudama(pChip);
 		bool IsFuze = NotesManager.IsFuzeRoll(pChip);
 
@@ -1442,8 +1442,8 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 					if (this.bPAUSE == false && rollSpeed > 0) // && TJAPlayer3.ConfigIni.bAuto先生の連打)
 					{
-						double msPerRollTja = 1000.0 / rollSpeed * OpenTaiko.ConfigIni.SongPlaybackSpeed;
-						if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)
+						double msPerRollTja = CTja.GameTimeToTjaTime(1000.0 / rollSpeed);
+						if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)
 							> (pChip.n発声時刻ms + msPerRollTja * pChip.nRollCount)) {
 							EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(nPlayer)];
 							int nLane = 0;
@@ -1465,13 +1465,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 							if (pChip.nChannelNo == 0x20 && _gt == EGameType.Konga) nLane = 4;
 							else if (pChip.nChannelNo == 0x21 && _gt == EGameType.Konga) nLane = 1;
 
-							this.tRollProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 1, nLane, 0, nPlayer);
+							this.tRollProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 1, nLane, 0, nPlayer);
 						}
 					}
 				}
 				if (!bAutoPlay && !rollEffectHit) {
 					this.eRollState = ERollState.Roll;
-					this.tRollProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 1, nNowInput, 0, nPlayer);
+					this.tRollProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 1, nNowInput, 0, nPlayer);
 				}
 				//---------------------------
 				#endregion
@@ -1525,7 +1525,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 						int balloonDuration = bAutoPlay ? (pChip.nNoteEndTimems - pChip.n発声時刻ms) : 1000;
 
-						if ((SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) >
+						if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) >
 							(pChip.n発声時刻ms + (balloonDuration / (double)rollSpeed) * rollCount)) {
 							if (this.nHand[nPlayer] == 0)
 								this.nHand[nPlayer]++;
@@ -1535,18 +1535,18 @@ internal abstract class CStage演奏画面共通 : CStage {
 							OpenTaiko.stageGameScreen.actTaikoLaneFlash.PlayerLane[nPlayer].Start(PlayerLane.FlashType.Red);
 							OpenTaiko.stageGameScreen.actMtaiko.tMtaikoEvent(pChip.nChannelNo, this.nHand[nPlayer], nPlayer);
 
-							this.tBalloonProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), nPlayer);
+							this.tBalloonProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), nPlayer);
 						}
 					}
 				}
 				if (!bAutoPlay && !rollEffectHit) {
 					if (!IsKusudama || nCurrentKusudamaCount > 0) {
-						this.tBalloonProcess(pChip, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), nPlayer);
+						this.tBalloonProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), nPlayer);
 					}
 				}
 				#endregion
 			} else if (NotesManager.IsRollEnd(pChip)) {
-				if (pChip.nNoteEndTimems <= (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+				if (pChip.nNoteEndTimems <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 					if (NotesManager.IsKusudama(pChip)) {
 						for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 							chip現在処理中の連打チップ[i].bHit = true;
@@ -2614,12 +2614,12 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
 
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 0);
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eNormal, 0, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eNormal, 0, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eNormal, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eNormal, 0);
@@ -2639,13 +2639,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 				//rc演奏用タイマ.n現在時刻msから引っ張ることに
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 0);
 
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eExpert, 0, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eExpert, 0, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eExpert, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eExpert, 0);
@@ -2665,13 +2665,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 				//rc演奏用タイマ.n現在時刻msから引っ張ることに
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 0);
 
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eMaster, 0, (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eMaster, 0, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eMaster, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eMaster, 0);
@@ -2814,7 +2814,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 			return true;
 		}
 
-		var n現在時刻ms = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		var n現在時刻ms = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		NowAIBattleSectionTime = (int)n現在時刻ms - NowAIBattleSection.StartTime;
 
@@ -2940,7 +2940,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!pChip.bHit && time < 0) {
 						pChip.bHit = true;
 						if (configIni.bBGMPlayVoiceSound) {
-							dTX.tチップの再生(pChip, SoundManager.PlayTimer.PrevResetTimeMs + (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed));
+							dTX.tチップの再生(pChip, SoundManager.PlayTimer.PrevResetTimeMs + (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms));
 						}
 					}
 					break;
@@ -4059,7 +4059,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				break;
 		}
 
-		var n現在時刻ms = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		var n現在時刻ms = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		//for ( int nCurrentTopChip = this.n現在のトップChip; nCurrentTopChip < dTX.listChip.Count; nCurrentTopChip++ )
 		for (int nCurrentTopChip = dTX.listChip.Count - 1; nCurrentTopChip > 0; nCurrentTopChip--) {
@@ -4287,7 +4287,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		float bpm_time = 0;
 		int last_input = 0;
 		float last_bpm_change_time;
-		play_time = SoundManager.PlayTimer.NowTimeMs * (float)OpenTaiko.ConfigIni.SongPlaybackSpeed - tja.msOFFSET_Abs;
+		play_time = (float)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) - tja.msOFFSET_Abs;
 
 		for (int i = 1; ; i++) {
 			//BPMCHANGEの数越えた
@@ -4544,7 +4544,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		}
 		#endregion
 		#region [ 演奏開始の発声時刻msを取得し、タイマに設定 ]
-		int nStartTime = (int)(dTX.listChip[this.nCurrentTopChip].n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		int nStartTime = (int)CTja.TjaTimeToGameTime(dTX.listChip[this.nCurrentTopChip].n発声時刻ms);
 
 		SoundManager.PlayTimer.Reset(); // これでPAUSE解除されるので、次のPAUSEチェックは不要
 										//if ( !this.bPAUSE )
@@ -4560,7 +4560,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		for (int i = this.nCurrentTopChip; i >= 0; i--) {
 			CChip pChip = dTX.listChip[i];
 			int nDuration = pChip.GetDuration();
-			long n発声時刻ms = (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			long n発声時刻ms = (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms);
 
 			if ((n発声時刻ms + nDuration > 0) && (n発声時刻ms <= nStartTime) && (nStartTime <= n発声時刻ms + nDuration)) {
 				if (pChip.nChannelNo == 0x01 && (pChip.nChannelNo >> 4) != 0xB) // wav系チャンネル、且つ、空打ちチップではない
@@ -4570,7 +4570,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!b) continue;
 
 					if ((wc.bIsBGMSound && OpenTaiko.ConfigIni.bBGMPlayVoiceSound) || (!wc.bIsBGMSound)) {
-						OpenTaiko.TJA.tチップの再生(pChip, (long)(SoundManager.PlayTimer.PrevResetTimeMs) + (long)(pChip.n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed));
+						OpenTaiko.TJA.tチップの再生(pChip, (long)(SoundManager.PlayTimer.PrevResetTimeMs) + (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms));
 						#region [ PAUSEする ]
 						int j = wc.n現在再生中のサウンド番号;
 						if (wc.rSound[j] != null) {

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4287,7 +4287,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		float bpm_time = 0;
 		int last_input = 0;
 		float last_bpm_change_time;
-		play_time = SoundManager.PlayTimer.NowTimeMs * (float)OpenTaiko.ConfigIni.SongPlaybackSpeed - tja.nOFFSET;
+		play_time = SoundManager.PlayTimer.NowTimeMs * (float)OpenTaiko.ConfigIni.SongPlaybackSpeed - tja.msOFFSET_Abs;
 
 		for (int i = 1; ; i++) {
 			//BPMCHANGEの数越えた

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4565,7 +4565,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		#region [ BGMやギターなど、演奏開始のタイミングで再生がかかっているサウンドのの途中再生開始 ] // (CDTXのt入力_行解析_チップ配置()で小節番号が+1されているのを削っておくこと)
 		for (int i = this.nCurrentTopChip; i >= 0; i--) {
 			CChip pChip = dTX.listChip[i];
-			int nDuration = pChip.GetDuration();
+			int nDuration = (int)CTja.TjaDurationToGameDuration(pChip.GetDuration());
 			long n発声時刻ms = (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, dTX);
 
 			if ((n発声時刻ms + nDuration > 0) && (n発声時刻ms <= nStartTime) && (nStartTime <= n発声時刻ms + nDuration)) {

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBackground.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBackground.cs
@@ -154,7 +154,7 @@ internal class CActImplBackground : CActivity {
 
 		this.ctSlideAnimation = new CCounter();
 		this.ctClimbDuration = new CCounter();
-		this.ctStandingAnimation = new CCounter(0, 1000, (60000f / (float)(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] * OpenTaiko.ConfigIni.SongPlaybackSpeed)) * OpenTaiko.Skin.Characters_Beat_Tower_Standing[currentCharacter] / OpenTaiko.Skin.Characters_Tower_Standing_Ptn[currentCharacter], OpenTaiko.Timer);
+		this.ctStandingAnimation = new CCounter(0, 1000, (60000f / (float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0])) * OpenTaiko.Skin.Characters_Beat_Tower_Standing[currentCharacter] / OpenTaiko.Skin.Characters_Tower_Standing_Ptn[currentCharacter], OpenTaiko.Timer);
 		this.ctClimbingAnimation = new CCounter();
 		this.ctRunningAnimation = new CCounter();
 		this.ctClearAnimation = new CCounter();
@@ -332,7 +332,7 @@ internal class CActImplBackground : CActivity {
 			float nextPositionMax140 = Math.Min((OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] + 1) / (float)nightTime, 1f);
 
 			if (bFloorChanged == true)
-				ctSlideAnimation.Start(0, 1000, 120f / ((float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] * OpenTaiko.ConfigIni.SongPlaybackSpeed), OpenTaiko.Timer);
+				ctSlideAnimation.Start(0, 1000, 120f / CTja.TjaBeatSpeedToGameBeatSpeed((float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]), OpenTaiko.Timer);
 
 			float progressFactor = (nextPositionMax140 - currentFloorPositionMax140) * (ctSlideAnimation.CurrentValue / 1000f);
 
@@ -419,7 +419,7 @@ internal class CActImplBackground : CActivity {
 			bool stageEnded = OpenTaiko.stageGameScreen.ePhaseID == CStage.EPhase.Game_EndStage || OpenTaiko.stageGameScreen.ePhaseID == CStage.EPhase.Game_STAGE_CLEAR_FadeOut || CFloorManagement.CurrentNumberOfLives == 0;
 
 			if (bFloorChanged == true) {
-				float floorBPM = (float)(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				float floorBPM = (float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]);
 				ctClimbDuration.Start(0, 1500, 120f / floorBPM, OpenTaiko.Timer);
 				ctStandingAnimation.Start(0, 1000, (60000f / floorBPM) * OpenTaiko.Skin.Characters_Beat_Tower_Standing[currentCharacter] / OpenTaiko.Skin.Characters_Tower_Standing_Ptn[currentCharacter], OpenTaiko.Timer);
 				ctClimbingAnimation.Start(0, 1000, (120000f / floorBPM) / OpenTaiko.Skin.Characters_Tower_Climbing_Ptn[currentCharacter], OpenTaiko.Timer);
@@ -432,7 +432,7 @@ internal class CActImplBackground : CActivity {
 			bool isClimbing = ctClimbDuration.CurrentValue > 0 && ctClimbDuration.CurrentValue < 1500;
 
 			if (stageEnded && !TowerFinished && !isClimbing) {
-				float floorBPM = (float)(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				float floorBPM = (float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]);
 				ctClearAnimation.Start(0, 20000, (60000f / floorBPM) * OpenTaiko.Skin.Characters_Beat_Tower_Clear[currentCharacter] / OpenTaiko.Skin.Characters_Tower_Clear_Ptn[currentCharacter], OpenTaiko.Timer);
 				ctClearTiredAnimation.Start(0, 20000, (60000f / floorBPM) * OpenTaiko.Skin.Characters_Beat_Tower_Clear_Tired[currentCharacter] / OpenTaiko.Skin.Characters_Tower_Clear_Tired_Ptn[currentCharacter], OpenTaiko.Timer);
 				ctFailAnimation.Start(0, 20000, (60000f / floorBPM) * OpenTaiko.Skin.Characters_Beat_Tower_Fail[currentCharacter] / OpenTaiko.Skin.Characters_Tower_Fail_Ptn[currentCharacter], OpenTaiko.Timer);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -53,7 +53,7 @@ internal class CActImplLaneTaiko : CActivity {
 	public override int Draw() {
 		if (base.IsFirstDraw) {
 			for (int i = 0; i < 5; i++)
-				this.stBranch[i].nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				this.stBranch[i].nフラッシュ制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			base.IsFirstDraw = false;
 		}
 
@@ -581,7 +581,7 @@ internal class CActImplLaneTaiko : CActivity {
             }
             */
 		}
-		var nTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		var nTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			if (this.n総移動時間[i] != -1) {
@@ -791,7 +791,7 @@ internal class CActImplLaneTaiko : CActivity {
 	}
 
 	public void t判定枠移動(double db移動時間, int n移動px, int n移動方向, int nPlayer, int vJs) {
-		this.n移動開始時刻[nPlayer] = (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		this.n移動開始時刻[nPlayer] = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		this.n移動開始X[nPlayer] = OpenTaiko.stageGameScreen.JPOSCROLLX[nPlayer];
 		this.n移動開始Y[nPlayer] = OpenTaiko.stageGameScreen.JPOSCROLLY[nPlayer];
 		this.n総移動時間[nPlayer] = (int)(db移動時間 * 1000);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -53,7 +53,7 @@ internal class CActImplLaneTaiko : CActivity {
 	public override int Draw() {
 		if (base.IsFirstDraw) {
 			for (int i = 0; i < 5; i++)
-				this.stBranch[i].nフラッシュ制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+				this.stBranch[i].nフラッシュ制御タイマ = SoundManager.PlayTimer.NowTimeMs;
 			base.IsFirstDraw = false;
 		}
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -581,9 +581,9 @@ internal class CActImplLaneTaiko : CActivity {
             }
             */
 		}
-		var nTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
+			var nTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.GetTJA(i)!);
 			if (this.n総移動時間[i] != -1) {
 				if (n移動方向[i] == 1) {
 					OpenTaiko.stageGameScreen.JPOSCROLLX[i] = this.n移動開始X[i] + (int)((((int)nTime - this.n移動開始時刻[i]) / (double)(this.n総移動時間[i])) * this.n移動距離px[i]);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMtaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMtaiko.cs
@@ -48,11 +48,11 @@ internal class CActImplMtaiko : CActivity {
 
 	public override int Draw() {
 		if (base.IsFirstDraw) {
-			this.nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.nフラッシュ制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			base.IsFirstDraw = false;
 		}
 
-		long num = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		long num = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		if (num < this.nフラッシュ制御タイマ) {
 			this.nフラッシュ制御タイマ = num;
 		}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMtaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMtaiko.cs
@@ -48,11 +48,11 @@ internal class CActImplMtaiko : CActivity {
 
 	public override int Draw() {
 		if (base.IsFirstDraw) {
-			this.nフラッシュ制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+			this.nフラッシュ制御タイマ = SoundManager.PlayTimer.NowTimeMs;
 			base.IsFirstDraw = false;
 		}
 
-		long num = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+		long num = SoundManager.PlayTimer.NowTimeMs;
 		if (num < this.nフラッシュ制御タイマ) {
 			this.nフラッシュ制御タイマ = num;
 		}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplPad.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplPad.cs
@@ -43,11 +43,11 @@ internal class CActImplPad : CActivity {
 	public override int Draw() {
 		if (!base.IsDeActivated) {
 			if (base.IsFirstDraw) {
-				this.nフラッシュ制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
-				this.nY座標制御タイマ = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				this.nフラッシュ制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+				this.nY座標制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				base.IsFirstDraw = false;
 			}
-			long num = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			long num = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			if (num < this.nフラッシュ制御タイマ) {
 				this.nフラッシュ制御タイマ = num;
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplPad.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplPad.cs
@@ -43,11 +43,11 @@ internal class CActImplPad : CActivity {
 	public override int Draw() {
 		if (!base.IsDeActivated) {
 			if (base.IsFirstDraw) {
-				this.nフラッシュ制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
-				this.nY座標制御タイマ = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+				this.nフラッシュ制御タイマ = SoundManager.PlayTimer.NowTimeMs;
+				this.nY座標制御タイマ = SoundManager.PlayTimer.NowTimeMs;
 				base.IsFirstDraw = false;
 			}
-			long num = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+			long num = SoundManager.PlayTimer.NowTimeMs;
 			if (num < this.nフラッシュ制御タイマ) {
 				this.nフラッシュ制御タイマ = num;
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -84,6 +84,8 @@ class CActImplTrainingMode : CActivity {
 	}
 
 	public override int Draw() {
+		CTja tja = OpenTaiko.TJA!;
+
 		if (!base.IsDeActivated) {
 			if (base.IsFirstDraw) {
 				base.IsFirstDraw = false;
@@ -135,7 +137,7 @@ class CActImplTrainingMode : CActivity {
 					}
 					if (t配列の値interval以下か(ref this.RBlue, SoundManager.PlayTimer.SystemTimeMs, OpenTaiko.ConfigIni.TokkunMashInterval)) {
 						for (int index = 0; index < this.JumpPointList.Count; index++) {
-							if (this.JumpPointList[index].Time >= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
+							if (this.JumpPointList[index].Time >= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
 								this.nCurrentMeasure = this.JumpPointList[index].Measure;
 								OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = this.nCurrentMeasure;
 								OpenTaiko.Skin.soundSkip.tPlay();
@@ -158,7 +160,7 @@ class CActImplTrainingMode : CActivity {
 					}
 					if (t配列の値interval以下か(ref this.LBlue, SoundManager.PlayTimer.SystemTimeMs, OpenTaiko.ConfigIni.TokkunMashInterval)) {
 						for (int index = this.JumpPointList.Count - 1; index >= 0; index--) {
-							if (this.JumpPointList[index].Time <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
+							if (this.JumpPointList[index].Time <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
 								this.nCurrentMeasure = this.JumpPointList[index].Measure;
 								OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = this.nCurrentMeasure;
 								OpenTaiko.Skin.sound特訓スキップ音.tPlay();
@@ -225,14 +227,14 @@ class CActImplTrainingMode : CActivity {
 					this.nCurrentMeasure = OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0];
 				}
 
-				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) > this.n最終演奏位置ms) {
-					this.n最終演奏位置ms = (long)(CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs));
+				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) > this.n最終演奏位置ms) {
+					this.n最終演奏位置ms = (long)(CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja));
 				}
 			}
 
 		}
 
-		var current = CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+		var current = CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
 		var percentage = current / length;
 
 		var currentWhite = (double)(this.n最終演奏位置ms);
@@ -425,19 +427,20 @@ class CActImplTrainingMode : CActivity {
 		}
 
 		if (doScroll) {
-			this.nスクロール後ms = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms);
+			this.nスクロール後ms = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms, dTX);
 			this.bCurrentlyScrolling = true;
 
 			this.ctScrollCounter = new CCounter(0, OpenTaiko.Skin.Game_Training_ScrollTime, 1, OpenTaiko.Timer);
 		} else {
-			SoundManager.PlayTimer.NowTimeMs = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms);
+			SoundManager.PlayTimer.NowTimeMs = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms, dTX);
 			this.nスクロール後ms = SoundManager.PlayTimer.NowTimeMs;
 		}
 	}
 
 	public void tToggleBookmarkAtTheCurrentPosition() {
 		if (!this.bCurrentlyScrolling && this.bTrainingPAUSE) {
-			STJUMPP _JumpPoint = new STJUMPP() { Time = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), Measure = this.nCurrentMeasure };
+			CTja tja = OpenTaiko.TJA!;
+			STJUMPP _JumpPoint = new STJUMPP() { Time = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), Measure = this.nCurrentMeasure };
 
 			if (!JumpPointList.Contains(_JumpPoint))
 				JumpPointList.Add(_JumpPoint);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -49,7 +49,7 @@ class CActImplTrainingMode : CActivity {
 			if (pChip.nChannelNo == 0x9E && !bIsInGoGo) {
 				bIsInGoGo = true;
 
-				var current = ((double)(pChip.db発声時刻ms * OpenTaiko.ConfigIni.SongPlaybackSpeed));
+				var current = pChip.db発声時刻ms;
 				var width = 0;
 				if (OpenTaiko.Tx.Tokkun_ProgressBar != null) width = OpenTaiko.Tx.Tokkun_ProgressBar.szTextureSize.Width;
 
@@ -471,7 +471,7 @@ class CActImplTrainingMode : CActivity {
 	private CCounter ctScrollCounter;
 	private CCounter ctBackgroundScrollTimer;
 	private Easing easing = new Easing();
-	private long length = 1;
+	private long length = 1; // chart length in TJA time
 
 	private List<int> gogoXList;
 	private List<STJUMPP> JumpPointList;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -135,7 +135,7 @@ class CActImplTrainingMode : CActivity {
 					}
 					if (t配列の値interval以下か(ref this.RBlue, SoundManager.PlayTimer.SystemTimeMs, OpenTaiko.ConfigIni.TokkunMashInterval)) {
 						for (int index = 0; index < this.JumpPointList.Count; index++) {
-							if (this.JumpPointList[index].Time >= SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) {
+							if (this.JumpPointList[index].Time >= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 								this.nCurrentMeasure = this.JumpPointList[index].Measure;
 								OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = this.nCurrentMeasure;
 								OpenTaiko.Skin.soundSkip.tPlay();
@@ -158,7 +158,7 @@ class CActImplTrainingMode : CActivity {
 					}
 					if (t配列の値interval以下か(ref this.LBlue, SoundManager.PlayTimer.SystemTimeMs, OpenTaiko.ConfigIni.TokkunMashInterval)) {
 						for (int index = this.JumpPointList.Count - 1; index >= 0; index--) {
-							if (this.JumpPointList[index].Time <= SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed) {
+							if (this.JumpPointList[index].Time <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 								this.nCurrentMeasure = this.JumpPointList[index].Measure;
 								OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = this.nCurrentMeasure;
 								OpenTaiko.Skin.sound特訓スキップ音.tPlay();
@@ -225,14 +225,14 @@ class CActImplTrainingMode : CActivity {
 					this.nCurrentMeasure = OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0];
 				}
 
-				if (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed > this.n最終演奏位置ms) {
-					this.n最終演奏位置ms = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) > this.n最終演奏位置ms) {
+					this.n最終演奏位置ms = (long)(CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs));
 				}
 			}
 
 		}
 
-		var current = (double)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		var current = CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		var percentage = current / length;
 
 		var currentWhite = (double)(this.n最終演奏位置ms);
@@ -425,19 +425,19 @@ class CActImplTrainingMode : CActivity {
 		}
 
 		if (doScroll) {
-			this.nスクロール後ms = (long)(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.nスクロール後ms = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms);
 			this.bCurrentlyScrolling = true;
 
 			this.ctScrollCounter = new CCounter(0, OpenTaiko.Skin.Game_Training_ScrollTime, 1, OpenTaiko.Timer);
 		} else {
-			SoundManager.PlayTimer.NowTimeMs = (long)(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			SoundManager.PlayTimer.NowTimeMs = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms);
 			this.nスクロール後ms = SoundManager.PlayTimer.NowTimeMs;
 		}
 	}
 
 	public void tToggleBookmarkAtTheCurrentPosition() {
 		if (!this.bCurrentlyScrolling && this.bTrainingPAUSE) {
-			STJUMPP _JumpPoint = new STJUMPP() { Time = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), Measure = this.nCurrentMeasure };
+			STJUMPP _JumpPoint = new STJUMPP() { Time = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), Measure = this.nCurrentMeasure };
 
 			if (!JumpPointList.Contains(_JumpPoint))
 				JumpPointList.Add(_JumpPoint);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -388,7 +388,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			if (this.st叩ききりまショー.bタイマー使用中) {
 				if (!this.st叩ききりまショー.ct残り時間.IsStoped || this.st叩ききりまショー.b加算アニメ中 == true) {
 					this.st叩ききりまショー.ct残り時間.Tick();
-					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
+					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
 						this.st叩ききりまショー.bタイマー使用中 = false;
 						this.st叩ききりまショー.ct残り時間.Stop();
 					}
@@ -498,7 +498,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 		double n延長する時間 = 0;
 
 		//最後に延長した時刻から11秒経過していなければ延長を行わない。
-		if (this.n最後に時間延長した時刻 + 11000 <= (SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+		if (this.n最後に時間延長した時刻 + 11000 <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 			//1項目につき5秒
 			//-精度
 			if (this.st叩ききりまショー.nヒット数_PERFECT != 0 || this.st叩ききりまショー.nヒット数_GREAT != 0) {
@@ -590,7 +590,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			#endregion
 
 
-			this.n最後に時間延長した時刻 = (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 			if (this.st叩ききりまショー.n区間ノート数 == 0)
@@ -651,7 +651,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			}
 
 
-			this.n最後に時間延長した時刻 = (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -375,6 +375,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 
 	public override int Draw() {
 		if (OpenTaiko.ConfigIni.eGameMode == EGame.Survival || OpenTaiko.ConfigIni.eGameMode == EGame.SurvivalHard) {
+			CTja tja = OpenTaiko.TJA!; // 1P-only mode (?)
 			//if( this.st叩ききりまショー.b最初のチップが叩かれた == true )//&&
 			//CDTXMania.stage演奏ドラム画面.r検索範囲内にチップがあるか調べる( CSound管理.rc演奏用タイマ.n現在時刻ms, 0, 3000 ) )
 			//this.st叩ききりまショー.ct残り時間.t進行();
@@ -388,7 +389,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			if (this.st叩ききりまショー.bタイマー使用中) {
 				if (!this.st叩ききりまショー.ct残り時間.IsStoped || this.st叩ききりまショー.b加算アニメ中 == true) {
 					this.st叩ききりまショー.ct残り時間.Tick();
-					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
+					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
 						this.st叩ききりまショー.bタイマー使用中 = false;
 						this.st叩ききりまショー.ct残り時間.Stop();
 					}
@@ -497,8 +498,10 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 	private void t叩ききりまショー_評価をして残り時間を延長する() {
 		double n延長する時間 = 0;
 
+		CTja tja = OpenTaiko.TJA!; // 1P-only mode (?)
+
 		//最後に延長した時刻から11秒経過していなければ延長を行わない。
-		if (this.n最後に時間延長した時刻 + 11000 <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
+		if (this.n最後に時間延長した時刻 + 11000 <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
 			//1項目につき5秒
 			//-精度
 			if (this.st叩ききりまショー.nヒット数_PERFECT != 0 || this.st叩ききりまショー.nヒット数_GREAT != 0) {
@@ -590,7 +593,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			#endregion
 
 
-			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 			if (this.st叩ききりまショー.n区間ノート数 == 0)
@@ -651,7 +654,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			}
 
 
-			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
+			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -269,7 +269,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		OpenTaiko.DiscordClient?.SetPresence(new RichPresence() {
 			Details = details,
 			State = "Playing" + (OpenTaiko.ConfigIni.bAutoPlay[0] == true ? " (Auto)" : ""),
-			Timestamps = new Timestamps(DateTime.UtcNow, DateTime.UtcNow.AddMilliseconds(OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms / OpenTaiko.ConfigIni.SongPlaybackSpeed)),
+			Timestamps = new Timestamps(DateTime.UtcNow, DateTime.UtcNow.AddMilliseconds(CTja.TjaTimeToGameTime(OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms))),
 			Assets = new Assets() {
 				SmallImageKey = OpenTaiko.ConfigIni.SendDiscordPlayingInformation ? difficultyName.ToLower() : "",
 				SmallImageText = OpenTaiko.ConfigIni.SendDiscordPlayingInformation ? String.Format("COURSE:{0} ({1})", difficultyName, OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0]) : "",
@@ -490,7 +490,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			this.t進行描画_演奏情報();
 
-			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 				this.actPanel.t歌詞テクスチャを生成する(OpenTaiko.TJA.listLyric2[ShownLyric2++].TextTex);
 			}
 
@@ -802,7 +802,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 				// convert input time (mixer space) to note time
 				long msInputMixer = inputEvent.nTimeStamp - SoundManager.PlayTimer.PrevResetTimeMs;
-				long nTime = (long)((msInputMixer + nInputAdjustTimeMs) * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				long nTime = (long)CTja.GameTimeToTjaTime(msInputMixer + nInputAdjustTimeMs);
 				//int nPad09 = ( nPad == (int) Eパッド.HP ) ? (int) Eパッド.BD : nPad;		// #27029 2012.1.5 yyagi
 
 				bool bHitted = false;
@@ -1206,15 +1206,14 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 							// Process big notes (judge big notes on)
 							if (e判定 != ENoteJudge.Miss && ((_isBigNoteTaiko && OpenTaiko.ConfigIni.bJudgeBigNotes) || _isPinkKonga)) {
 								CConfigIni.CTimingZones tz = this.GetTimingZones(nUsePlayer);
-								double divided_songspeed = OpenTaiko.ConfigIni.SongPlaybackSpeed;
-								float time = chipNoHit.n発声時刻ms - (float)(SoundManager.PlayTimer.NowTimeMs * divided_songspeed);
+								float time = chipNoHit.n発声時刻ms - (float)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 								int nWaitTime = OpenTaiko.ConfigIni.nBigNoteWaitTimems;
 
 								bool _timeBadOrLater = time <= tz.nBadZone;
 
 								if (chipNoHit.eNoteState == ENoteState.None) {
 									if (_timeBadOrLater) {
-										chipNoHit.nProcessTime = (int)(SoundManager.PlayTimer.NowTimeMs * divided_songspeed);
+										chipNoHit.nProcessTime = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 										chipNoHit.eNoteState = ENoteState.Wait;
 										//this.nWaitButton = waitInstr;
 										this.nStoredHit[nUsePlayer] = (int)_pad;
@@ -1225,7 +1224,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 									// Double tap success
 									if (_isExpected && _timeBadOrLater && chipNoHit.nProcessTime
-										+ nWaitTime > (int)(SoundManager.PlayTimer.NowTimeMs * divided_songspeed)) {
+										+ nWaitTime > (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 										this.tドラムヒット処理(nTime, _pad, chipNoHit, true, nUsePlayer);
 										bHitted = true;
 										//this.nWaitButton = 0;
@@ -1234,7 +1233,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 									// Double tap failure
 									else if (!_isExpected || (_timeBadOrLater && chipNoHit.nProcessTime
-												 + nWaitTime < (int)(SoundManager.PlayTimer.NowTimeMs * divided_songspeed))) {
+												 + nWaitTime < (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs))) {
 										if (!_isPinkKonga) {
 											this.tドラムヒット処理(nTime, _pad, chipNoHit, false, nUsePlayer);
 											bHitted = true;
@@ -1344,7 +1343,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		if (pChip.bVisible) {
 			if (!pChip.bHit) {
-				long nPlayTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				long nPlayTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				if ((!pChip.bHit) && (pChip.n発声時刻ms <= nPlayTime)) {
 					bool bAutoPlay = OpenTaiko.ConfigIni.bAutoPlay[nPlayer];
 					switch (nPlayer) {
@@ -1451,7 +1450,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				}
 				#endregion
 
-				long __dbt = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				long __dbt = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				long time = pChip.n発声時刻ms - __dbt;
 
 				if (pChip.dbSCROLL_Y != 0.0) {
@@ -1615,7 +1614,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 	protected override void t進行描画_チップ_Taiko連打(CConfigIni configIni, ref CTja dTX, ref CChip pChip, int nPlayer) {
 		int nSenotesX = 0;
 		int nSenotesY = 0;
-		long nowTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+		long nowTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		switch (OpenTaiko.ConfigIni.nPlayerCount) {
 			case 1:
@@ -1954,7 +1953,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		if (pChip.dbSCROLL_Y != 0.0) {
 			double _scrollSpeed = pChip.dbSCROLL_Y * (this.actScrollSpeed.dbConfigScrollSpeed[nPlayer] + 1.0) / 10.0;
-			long __dbt = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+			long __dbt = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			long msDTime = pChip.n発声時刻ms - __dbt;
 			float play_bpm_time = this.GetNowPBMTime(dTX, 0);
 			double th16DBeat = pChip.fBMSCROLLTime - play_bpm_time;
@@ -1988,7 +1987,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			var chkChip = this.chip現在処理中の連打チップ[i];
 			if (chkChip != null) {
-				long nowTime = (long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				long nowTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				//int n = this.chip現在処理中の連打チップ[i].nチャンネル番号;
 				if ((NotesManager.IsGenericBalloon(chkChip) || NotesManager.IsKusudama(chkChip)) && (this.bCurrentlyDrumRoll[i] == true)) {
 					//if (this.chip現在処理中の連打チップ.n発声時刻ms <= (int)CSound管理.rc演奏用タイマ.n現在時刻ms && this.chip現在処理中の連打チップ.nノーツ終了時刻ms >= (int)CSound管理.rc演奏用タイマ.n現在時刻ms)
@@ -2017,7 +2016,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		//常時イベントが発生しているメソッドのほうがいいんじゃないかという予想。
 		//CDTX.CChip chipNoHit = this.r指定時刻に一番近い未ヒットChip((int)CSound管理.rc演奏用タイマ.n現在時刻ms, 0);
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
-			CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed), i);
+			CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), i);
 
 			EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(i)];
 			bool _isBigKaTaiko = NotesManager.IsBigKaTaiko(chipNoHit, _gt);
@@ -2026,10 +2025,10 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			if (chipNoHit != null && (_isBigDonTaiko || _isBigKaTaiko)) {
 				CConfigIni.CTimingZones tz = this.GetTimingZones(i);
-				float timeC = chipNoHit.n発声時刻ms - (float)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed);
+				float timeC = chipNoHit.n発声時刻ms - (float)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				int nWaitTime = OpenTaiko.ConfigIni.nBigNoteWaitTimems;
 				if (chipNoHit.eNoteState == ENoteState.Wait && timeC <= tz.nBadZone
-															&& chipNoHit.nProcessTime + nWaitTime <= (int)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) {
+															&& chipNoHit.nProcessTime + nWaitTime <= (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 					if (!_isSwapNote) {
 						this.tドラムヒット処理(chipNoHit.nProcessTime, EPad.RRed, chipNoHit, false, i);
 						//this.nWaitButton = 0;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -257,7 +257,7 @@ class ScriptBG : IDisposable {
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
 				timestamp = (((double)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0) +
-							(-(OpenTaiko.ConfigIni.MusicPreTimeMs + OpenTaiko.TJA.nOFFSET) / 1000.0) +
+							(-(OpenTaiko.ConfigIni.MusicPreTimeMs + OpenTaiko.TJA.msOFFSET_Abs) / 1000.0) +
 							timeoffset;
 			}
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -256,10 +256,12 @@ class ScriptBG : IDisposable {
 				double msTimeOffset = OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? 0 : -CTja.msDanNextSongDelay;
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
-				timestamp = (CTja.RawTjaTimeToDefTime(CTja.TjaTimeToRawTjaTimeNote(
-					CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs),
+				timestamp = (CTja.RawTjaTimeToDefTime(
+					CTja.TjaTimeToRawTjaTimeNote(
+						CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.TJA),
+						OpenTaiko.TJA),
 					OpenTaiko.TJA
-				)) + msTimeOffset) / 1000.0;
+				) + msTimeOffset) / 1000.0;
 			}
 
 			LuaUpdateValues.Call(OpenTaiko.FPS.DeltaTime,

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -256,7 +256,7 @@ class ScriptBG : IDisposable {
 				double timeoffset = OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? -2.0 : -8.2;
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
-				timestamp = (((double)(SoundManager.PlayTimer.NowTimeMs * OpenTaiko.ConfigIni.SongPlaybackSpeed)) / 1000.0) +
+				timestamp = (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) / 1000.0) +
 							(-(OpenTaiko.ConfigIni.MusicPreTimeMs + OpenTaiko.TJA.msOFFSET_Abs) / 1000.0) +
 							timeoffset;
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -253,7 +253,7 @@ class ScriptBG : IDisposable {
 			double timestamp = -1.0;
 
 			if (OpenTaiko.TJA != null) {
-				double timeoffset = OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? -2.0 : -8.2;
+				double timeoffset = -2.0 + (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? 0 : -CTja.msDanNextSongDelay / 1000.0);
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
 				timestamp = (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) / 1000.0) +

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -253,12 +253,13 @@ class ScriptBG : IDisposable {
 			double timestamp = -1.0;
 
 			if (OpenTaiko.TJA != null) {
-				double timeoffset = -2.0 + (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? 0 : -CTja.msDanNextSongDelay / 1000.0);
+				double msTimeOffset = OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? 0 : -CTja.msDanNextSongDelay;
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
-				timestamp = (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) / 1000.0) +
-							(-(OpenTaiko.ConfigIni.MusicPreTimeMs + OpenTaiko.TJA.msOFFSET_Abs) / 1000.0) +
-							timeoffset;
+				timestamp = (CTja.RawTjaTimeToDefTime(CTja.TjaTimeToRawTjaTimeNote(
+					CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs),
+					OpenTaiko.TJA
+				)) + msTimeOffset) / 1000.0;
 			}
 
 			LuaUpdateValues.Call(OpenTaiko.FPS.DeltaTime,


### PR DESCRIPTION
~~I have not tested the Dan-i offset cases. It might work by the code logic but please test it.~~ tested

## Fixed Issues

* fix `SongPlaybackSpeed` misused to initialize speed-independent animation values
* fix entering training mode in non-1x play speed distorted displayed go-go time position
* fix `GetNowPBMTime()` (notes' and bar lines' position variable in HB/BMScroll) returned wrong beat position for charts with positive `OFFSET:`
* fix `ScriptBG` Lua API gave wrong timestamp for charts with positive `OFFSET:`
* fix global offset bug completely by moving `OFFSET` handling to `#START`, including:
    * fix global offset was treated as positive when `OFFSET:` is not given in TJA
    * fix wrong HB/BMScroll position before the initial measure when `OFFSET:` is not given in TJA or is given before `BPM:`
* fix TJA+global offset wrongly re-applied on each dan song
* remove static extra (2 / PlaySpeed)-second delay beyond the song playback buffer
* remove redundant initial song playback buffer for Dans
    * Save 3 seconds for retrying a Dan!
* fix Mini-Taiko input highlight fade-out animation speed varied by play speed
* fix: make initial song playback buffer play-speed-independent for non-Dans
    * Temporarily not for Dans for technical reason.
* fix music silenced when resumed from x+% of the song at x% song speed [0auBSQ/OpenTaiko#676]

## Fixed Development Issues

* refactor: replace usage of `SongPlaybackSpeed` with `CTja` GameTime <-> TjaTime converters
* refactor: replace hardcoded 6.2s with `CTja.msDanNextSongDelay` (`6200.0`)
* refactor: drop unused prebaked `CTja.db再生速度` [dbPlaySpeed]
* refactor: add public getter/setter for `TJA` obj with variable player number

## Test Cases

[Metal.Dan.zip](https://github.com/user-attachments/files/18657290/Metal.Dan.zip)

:o: `Metal Dan-set.tja` (use one chart-wise `OFFSET:` and `#DELAY`s to adjust song offset)
:o: `Metal Dan-lay.tja` (no `OFFSET:` specified; use only `#DELAY`s to adjust song offset)
