### PR TITLE
Fix + Improve TJA offset Pt. II

### DIFF
--- a/FDK/src/00.Common/CTimerBase.cs
+++ b/FDK/src/00.Common/CTimerBase.cs
@@ -107,6 +107,18 @@ public abstract class CTimerBase : IDisposable {
 		}
 	}
 
+	// Time coordination converters
+	// GameTime is the real elapsed time of gameplay (excluding pauses).
+	// SystemTime is the real elapsed time, including pauses.
+	public long GameTimeToSystemTime(long msGameTime)
+		=> msGameTime + this.PrevResetTimeMs;
+	public long SystemTimeToGameTime(long msSystemTime)
+		=> msSystemTime - this.PrevResetTimeMs;
+	public double GameTimeToSystemTime(double msGameTime)
+		=> msGameTime + this.PrevResetTimeMs_Double;
+	public double SystemTimeToGameTime(double msSystemTime)
+		=> msSystemTime - this.PrevResetTimeMs_Double;
+
 	#region [ protected ]
 	//-----------------
 	protected long PauseSystemTimeMs = 0;

--- a/OpenTaiko/src/Common/CConfigIni.cs
+++ b/OpenTaiko/src/Common/CConfigIni.cs
@@ -1279,6 +1279,7 @@ internal class CConfigIni : INotifyPropertyChanged {
 	public bool PreAssetsLoading; // 事前画像描画モード
 	public bool SimpleMode; // 事前画像描画モード
 	public int MusicPreTimeMs; // 音源再生前の待機時間ms
+	public const int MusicPreTimeMsOffset = 1500; // Added to the MusicPreTimeMs config for the final interpreted value
 
 	public bool TJAP3FolderMode { get; private set; }
 
@@ -1734,7 +1735,7 @@ internal class CConfigIni : INotifyPropertyChanged {
 		ASyncTextureLoad = true;
 		PreAssetsLoading = true;
 		SimpleMode = false;
-		MusicPreTimeMs = 1000; // 一秒
+		MusicPreTimeMs = 2500; // 2.5 seconds
 		SendDiscordPlayingInformation = true;
 
 		#region[ Ver.K追加 ]
@@ -2119,9 +2120,9 @@ internal class CConfigIni : INotifyPropertyChanged {
 		sw.WriteLine(
 			$"; Keyboard sound level increment ({MinimumKeyboardSoundLevelIncrement}-{MaximumKeyboardSoundLevelIncrement})");
 		sw.WriteLine("{0}={1}", nameof(KeyboardSoundLevelIncrement), KeyboardSoundLevelIncrement);
-		sw.WriteLine($"; 音源再生前の空白時間 (ms)");
-		sw.WriteLine($"; Blank time before music source to play. (ms)");
-		sw.WriteLine("{0}={1}", nameof(MusicPreTimeMs), MusicPreTimeMs);
+		sw.WriteLine($"; 音源再生前の空白時間 (ms) (最終値はこの値 + {MusicPreTimeMsOffset}ms)");
+		sw.WriteLine($"; Blank time before music source to play. (ms) (Final value is this value + {MusicPreTimeMsOffset}ms");
+		sw.WriteLine("{0}={1}", nameof(MusicPreTimeMs), MusicPreTimeMs - MusicPreTimeMsOffset);
 		sw.WriteLine();
 		sw.WriteLine("; バッファ入力モード(0:OFF, 1:ON)");
 		sw.WriteLine("; Using Buffered input (0:OFF, 1:ON)");
@@ -2893,7 +2894,7 @@ internal class CConfigIni : INotifyPropertyChanged {
 					this.KeyboardSoundLevelIncrement);
 				break;
 			case nameof(this.MusicPreTimeMs):
-				this.MusicPreTimeMs = int.Parse(value);
+				this.MusicPreTimeMs = int.Parse(value) + MusicPreTimeMsOffset;
 				break;
 			case "AutoResultCapture":
 				this.bIsAutoResultCapture = CConversion.bONorOFF(value[0]);

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1391,7 +1391,7 @@ internal class CTja : CActivity {
 				this.n内部番号BRANCH1to = 0;
 				this.n内部番号JSCROLL1to = 0;
 				#region [ 発声時刻の計算 ]
-				double bpm = 120.0;
+				double bpm = this.BASEBPM;
 				int n発声位置 = 0;
 				int ms = 0;
 				int nBar = 0;
@@ -1400,6 +1400,11 @@ internal class CTja : CActivity {
 				List<STLYRIC> tmplistlyric = new List<STLYRIC>();
 				int BGM番号 = 0;
 
+
+				// Chip post-process:
+				// * Offset chips from RawTjaTime To TjaTime; see RawTjaTimeToTjaTimeMusic()
+				// * TaikoJiro 1 behavior: Notes' scrolling BPM and HBScroll beat (but not time) are re-adjusted to the active timing
+				//   (also affect notes' time in TaikoJiro 2 (?))
 				foreach (CChip chip in this.listChip) {
 					switch (chip.nChannelNo) {
 						case 0x02 or 0x01 or 0x08:
@@ -1452,14 +1457,13 @@ internal class CTja : CActivity {
 								dbBarLength = chip.db実数値;
 								continue;
 							}
-						case 0x03:  // BPM
+						case 0x03:  // Initial BPM
 						{
 								n発声位置 = chip.n発声位置;
 								if (this.isOFFSET_Negative == false)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
 								ms = chip.n発声時刻ms;
-								bpm = this.BASEBPM + chip.n整数値;
-								this.dbNowBPM = bpm;
+								// this.dbNowBPM has already been initialized
 								continue;
 							}
 						case 0x04:  // BGA (レイヤBGA1)

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -6460,35 +6460,35 @@ internal class CTja : CActivity {
 	// RawTjaTime is time for chip.n発声時刻ms just before the post-processing of tja.t入力_V4().
 	// * RawTjaTime is DefTime with additional initial padding time
 	// MusicPreTimeMs is pre-baked to only Dan
-	public static double DefTimeToRawTjaTime(double msTime, CTja tja)
-		=> (tja.n参照中の難易度 != (int)Difficulty.Dan) ? msTime
+	public double DefTimeToRawTjaTime(double msTime)
+		=> (this.n参照中の難易度 != (int)Difficulty.Dan) ? msTime
 			: msTime + OpenTaiko.ConfigIni.MusicPreTimeMs;
-	public static double RawTjaTimeToDefTime(double msTime, CTja tja)
-		=> (tja.n参照中の難易度 != (int)Difficulty.Dan) ? msTime
+	public double RawTjaTimeToDefTime(double msTime)
+		=> (this.n参照中の難易度 != (int)Difficulty.Dan) ? msTime
 			: msTime - OpenTaiko.ConfigIni.MusicPreTimeMs;
 
 	// TjaTime is the time for chip.n発声時刻ms after the post-processing of tja.t入力_V4().
 	// * For positive msOFFSET, all and only music-time-relative events are delayed by msOFFSET_Abs.
 	// * For negative msOFFSET, all and only note-time-relative events are delayed by msOFFSET_Abs.
-	public static double RawTjaTimeToTjaTimeMusic(double msTime, CTja tja)
-		=> msTime + (!tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
-	public static double TjaTimeToRawTjaTimeMusic(double msTime, CTja tja)
-		=> msTime - (!tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
-	public static double RawTjaTimeToTjaTimeNote(double msTime, CTja tja)
-		=> msTime + (tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
-	public static double TjaTimeToRawTjaTimeNote(double msTime, CTja tja)
-		=> msTime - (tja.isOFFSET_Negative ? tja.msOFFSET_Abs : 0);
+	public double RawTjaTimeToTjaTimeMusic(double msTime)
+		=> msTime + (!this.isOFFSET_Negative ? this.msOFFSET_Abs : 0);
+	public double TjaTimeToRawTjaTimeMusic(double msTime)
+		=> msTime - (!this.isOFFSET_Negative ? this.msOFFSET_Abs : 0);
+	public double RawTjaTimeToTjaTimeNote(double msTime)
+		=> msTime + (this.isOFFSET_Negative ? this.msOFFSET_Abs : 0);
+	public double TjaTimeToRawTjaTimeNote(double msTime)
+		=> msTime - (this.isOFFSET_Negative ? this.msOFFSET_Abs : 0);
 
 	// GameTime is the real elapsed time of gameplay.
 	// SongPlaybackSpeed scales the GameTime into the corresponding TjaTime
 	// MusicPreTimeMs is applied in real time to non-Dan
-	public static double GameTimeToTjaTime(double msTime, CTja tja)
-		=> GameDurationToTjaDuration((tja.n参照中の難易度 == (int)Difficulty.Dan) ?
+	public double GameTimeToTjaTime(double msTime)
+		=> GameDurationToTjaDuration((this.n参照中の難易度 == (int)Difficulty.Dan) ?
 			msTime
 			: msTime - OpenTaiko.ConfigIni.MusicPreTimeMs);
-	public static double TjaTimeToGameTime(double msTime, CTja tja) {
+	public double TjaTimeToGameTime(double msTime) {
 		msTime = TjaDurationToGameDuration(msTime);
-		return (tja.n参照中の難易度 == (int)Difficulty.Dan) ? msTime
+		return (this.n参照中の難易度 == (int)Difficulty.Dan) ? msTime
 			: msTime + OpenTaiko.ConfigIni.MusicPreTimeMs;
 	}
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1478,10 +1478,6 @@ internal class CTja : CActivity {
 						{
 								if (this.isOFFSET_Negative == false)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
-								if (this.isMOVIEOFFSET_Negative == false)
-									chip.n発声時刻ms += this.msMOVIEOFFSET_Abs;
-								else
-									chip.n発声時刻ms -= this.msMOVIEOFFSET_Abs;
 								continue;
 							}
 						case 0x97:
@@ -4674,10 +4670,7 @@ internal class CTja : CActivity {
 		var chipMovie = new CChip();
 		chipMovie.nChannelNo = 0x54;
 		chipMovie.n発声位置 = 384;
-		if (this.msMOVIEOFFSET_Abs == 0)
-			chipMovie.n発声時刻ms = (int)this.dbNowTime;
-		else
-			chipMovie.n発声時刻ms = (int)this.msMOVIEOFFSET_Abs;
+		chipMovie.n発声時刻ms = (int)this.dbNowTime + (this.isMOVIEOFFSET_Negative ? -this.msMOVIEOFFSET_Abs : this.msMOVIEOFFSET_Abs);
 		chipMovie.dbBPM = this.dbNowBPM;
 		chipMovie.fNow_Measure_m = this.fNow_Measure_m;
 		chipMovie.fNow_Measure_s = this.fNow_Measure_s;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1401,10 +1401,19 @@ internal class CTja : CActivity {
 				int BGM番号 = 0;
 
 				foreach (CChip chip in this.listChip) {
-					if (chip.nChannelNo == 0x02) { } else if (chip.nChannelNo == 0x01) { } else if (chip.nChannelNo == 0x08) { } else if (chip.nChannelNo >= 0x11 && chip.nChannelNo <= 0x1F) { } else if (chip.nChannelNo == 0x50) { } else if (chip.nChannelNo == 0x54) { } else if (chip.nChannelNo == 0x08) { } else if (chip.nChannelNo == 0xF1) { } else if (chip.nChannelNo == 0xF2) { } else if (chip.nChannelNo == 0xFF) { } else if (chip.nChannelNo == 0xDD) { chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm)); } else if (chip.nChannelNo == 0xDF) { chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm)); } else if (chip.nChannelNo < 0x93)
-						chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
-					else if ((chip.nChannelNo > 0x9F && chip.nChannelNo < 0xA0) || (chip.nChannelNo >= 0xF0 && chip.nChannelNo < 0xFE))
-						chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
+					switch (chip.nChannelNo) {
+						case 0x02 or 0x01 or 0x08:
+						case >= 0x11 and <= 0x1F:
+						case 0x50 or 0x54:
+						case 0xF1 or 0xF2 or 0xFF:
+							break;
+						case 0xDD or 0xDF:
+						case < 0x93:
+						// case > 0x9F and < 0xA0: // impossible case
+						case >= 0xF0 and < 0xFE:
+							chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
+							break;
+					}
 					nBar = chip.n発声位置 / 384;
 					ch = chip.nChannelNo;
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1376,13 +1376,6 @@ internal class CTja : CActivity {
 				// * TaikoJiro 1 behavior: Notes' scrolling BPM and HBScroll beat (but not time) are re-adjusted to the active timing
 				//   (also affect notes' time in TaikoJiro 2 (?))
 				foreach (CChip chip in this.listChip) {
-					// reassign the timing of measure-position-based chips
-					// TODO: remove this process completely for 0xDD (#SECTION)
-					switch (chip.nChannelNo) {
-						case 0xDD:
-							chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
-							break;
-					}
 					nBar = chip.n発声位置 / 384;
 					int ch = chip.nChannelNo;
 
@@ -4235,12 +4228,11 @@ internal class CTja : CActivity {
 			var chip = new CChip();
 
 			chip.nChannelNo = 0xDD;
-			chip.n発声位置 = ((this.n現在の小節数 - 1) * 384);
+			chip.n発声位置 = (this.n現在の小節数 * 384);
 			chip.n発声時刻ms = (int)this.dbNowTime;
 			chip.fNow_Measure_m = this.fNow_Measure_m;
 			chip.fNow_Measure_s = this.fNow_Measure_s;
 			chip.n整数値_内部番号 = 1;
-			chip.db発声時刻ms = this.dbNowTime;
 			// チップを配置。
 			this.listChip.Add(chip);
 		} else if (command == "#BRANCHSTART") {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1396,13 +1396,13 @@ internal class CTja : CActivity {
 							}
 						case 0x02:  // BarLength
 						{
-								if (this.isOFFSET_Negative == false)
+								if (this.isOFFSET_Negative)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
 								continue;
 							}
 						case 0x03:  // Initial BPM
 						{
-								if (this.isOFFSET_Negative == false)
+								if (this.isOFFSET_Negative)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
 								// this.dbNowBPM has already been initialized
 								continue;
@@ -1466,7 +1466,7 @@ internal class CTja : CActivity {
 							}
 						case 0x08:  // 拡張BPM
 						{
-								if (this.isOFFSET_Negative == false)
+								if (this.isOFFSET_Negative)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
 								if (this.listBPM.TryGetValue(chip.n整数値_内部番号, out CBPM cBPM)) {
 									bpm = (cBPM.n表記上の番号 == 0 ? 0.0 : this.BASEBPM) + cBPM.dbBPM値;
@@ -4620,7 +4620,7 @@ internal class CTja : CActivity {
 		var chipInitScroll = new CChip();
 
 		chipInitScroll.nChannelNo = 0x9D;
-		chipInitScroll.n発声位置 = ((this.n現在の小節数 - 2) * 384);
+		chipInitScroll.n発声位置 = (this.n現在の小節数 * 384);
 		chipInitScroll.n整数値 = 0x00;
 		chipInitScroll.n整数値_内部番号 = this.n内部番号SCROLL1to;
 		chipInitScroll.dbSCROLL = this.dbScrollSpeed;
@@ -4637,7 +4637,7 @@ internal class CTja : CActivity {
 		var chipInitBpm = new CChip();
 
 		chipInitBpm.nChannelNo = 0x03;
-		chipInitBpm.n発声位置 = ((this.n現在の小節数 - 1) * 384);
+		chipInitBpm.n発声位置 = (this.n現在の小節数 * 384);
 		chipInitBpm.n整数値 = 0x00;
 		chipInitBpm.n整数値_内部番号 = 1;
 
@@ -4649,7 +4649,7 @@ internal class CTja : CActivity {
 		// and HBScroll gimmicks regarding `BPM:` are also supported in TaikoJiro,
 		// so it is now handled here for simplicity.
 		CChip chipInitBpmChange = new CChip();
-		chipInitBpmChange.n発声位置 = 0;
+		chipInitBpmChange.n発声位置 = (this.n現在の小節数 * 384);
 		chipInitBpmChange.nChannelNo = 8;      // 拡張BPM
 		chipInitBpmChange.n整数値 = 0;
 		chipInitBpmChange.n整数値_内部番号 = bpmInit.n内部番号;
@@ -4673,6 +4673,7 @@ internal class CTja : CActivity {
 		// add movie start chip
 		var chipMovie = new CChip();
 		chipMovie.nChannelNo = 0x54;
+		chipMovie.n発声位置 = 384;
 		if (this.msMOVIEOFFSET_Abs == 0)
 			chipMovie.n発声時刻ms = (int)this.dbNowTime;
 		else

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -652,7 +652,6 @@ internal class CTja : CActivity {
 	public int[] nScoreDiff = new int[(int)Difficulty.Total]; //[y]
 	public bool[,] b配点が指定されている = new bool[3, (int)Difficulty.Total]; //2017.06.04 kairera0467 [ x, y ] x=通常(Init)or真打orDiff y=コース
 
-	private double dbBarLength;
 	public float fNow_Measure_s = 4.0f;
 	public float fNow_Measure_m = 4.0f;
 	public double dbNowTime = 0.0;
@@ -830,8 +829,6 @@ internal class CTja : CActivity {
 			this.b配点が指定されている[1, y] = false;
 			this.b配点が指定されている[2, y] = false;
 		}
-
-		this.dbBarLength = 1.0;
 
 		this.b最初の分岐である = true;
 
@@ -1362,10 +1359,7 @@ internal class CTja : CActivity {
 				this.n内部番号JSCROLL1to = 0;
 				#region [ 発声時刻の計算 ]
 				double bpm = this.BASEBPM;
-				int n発声位置 = 0;
-				int ms = 0;
 				int nBar = 0;
-				int nCount = 0;
 
 				List<STLYRIC> tmplistlyric = new List<STLYRIC>();
 				int BGM番号 = 0;
@@ -1379,15 +1373,10 @@ internal class CTja : CActivity {
 					nBar = chip.n発声位置 / 384;
 					int ch = chip.nChannelNo;
 
-					nCount++;
-
 					switch (ch) {
 						case 0x01: {
-								n発声位置 = chip.n発声位置;
-
 								if (this.isOFFSET_Negative == false)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
-								ms = chip.n発声時刻ms;
 
 								#region[listlyric2の時間合わせ]
 								for (int ind = 0; ind < listLyric2.Count; ind++) {
@@ -1407,19 +1396,14 @@ internal class CTja : CActivity {
 							}
 						case 0x02:  // BarLength
 						{
-								n発声位置 = chip.n発声位置;
 								if (this.isOFFSET_Negative == false)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
-								ms = chip.n発声時刻ms;
-								dbBarLength = chip.db実数値;
 								continue;
 							}
 						case 0x03:  // Initial BPM
 						{
-								n発声位置 = chip.n発声位置;
 								if (this.isOFFSET_Negative == false)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
-								ms = chip.n発声時刻ms;
 								// this.dbNowBPM has already been initialized
 								continue;
 							}
@@ -1482,10 +1466,8 @@ internal class CTja : CActivity {
 							}
 						case 0x08:  // 拡張BPM
 						{
-								n発声位置 = chip.n発声位置;
 								if (this.isOFFSET_Negative == false)
 									chip.n発声時刻ms += this.msOFFSET_Abs;
-								ms = chip.n発声時刻ms;
 								if (this.listBPM.TryGetValue(chip.n整数値_内部番号, out CBPM cBPM)) {
 									bpm = (cBPM.n表記上の番号 == 0 ? 0.0 : this.BASEBPM) + cBPM.dbBPM値;
 									this.dbNowBPM = bpm;
@@ -2328,7 +2310,6 @@ internal class CTja : CActivity {
 			}
 
 			double db小節長倍率 = dbLength[0] / dbLength[1];
-			this.dbBarLength = db小節長倍率;
 			this.fNow_Measure_m = (float)dbLength[1];
 			this.fNow_Measure_s = (float)dbLength[0];
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1301,36 +1301,6 @@ internal class CTja : CActivity {
 			this.n無限管理PAN = null;
 			this.n無限管理SIZE = null;
 			if (!this.bヘッダのみ) {
-				#region [ BPM/BMP初期化 ]
-				int ch;
-				CBPM cbpm = null;
-				foreach (CBPM cbpm2 in this.listBPM.Values) {
-					if (cbpm2.n表記上の番号 == 0) {
-						cbpm = cbpm2;
-						break;
-					}
-				}
-				if (cbpm == null) {
-					cbpm = new CBPM();
-					cbpm.n内部番号 = this.n内部番号BPM1to++;
-					cbpm.n表記上の番号 = 0;
-					cbpm.dbBPM値 = 120.0;
-					this.listBPM.Add(cbpm.n内部番号, cbpm);
-					CChip chip = new CChip();
-					chip.n発声位置 = 0;
-					chip.nChannelNo = 8;      // 拡張BPM
-					chip.n整数値 = 0;
-					chip.n整数値_内部番号 = cbpm.n内部番号;
-					this.listChip.Insert(0, chip);
-				} else {
-					CChip chip = new CChip();
-					chip.n発声位置 = 0;
-					chip.nChannelNo = 8;      // 拡張BPM
-					chip.n整数値 = 0;
-					chip.n整数値_内部番号 = cbpm.n内部番号;
-					this.listChip.Insert(0, chip);
-				}
-				#endregion
 				#region [ CWAV初期化 ]
 				foreach (CWAV cwav in this.listWAV.Values) {
 					if (cwav.nチップサイズ < 0) {
@@ -1420,7 +1390,7 @@ internal class CTja : CActivity {
 							break;
 					}
 					nBar = chip.n発声位置 / 384;
-					ch = chip.nChannelNo;
+					int ch = chip.nChannelNo;
 
 					nCount++;
 
@@ -4692,7 +4662,8 @@ internal class CTja : CActivity {
 		this.n内部番号SCROLL1to++;
 
 		// apply initial BPM
-		this.listBPM.Add(this.n内部番号BPM1to - 1, new CBPM() { n内部番号 = this.n内部番号BPM1to - 1, n表記上の番号 = this.n内部番号BPM1to - 1, dbBPM値 = this.BASEBPM, });
+		CBPM bpmInit = new() { n内部番号 = this.n内部番号BPM1to - 1, n表記上の番号 = this.n内部番号BPM1to - 1, dbBPM値 = this.BASEBPM, };
+		this.listBPM.Add(this.n内部番号BPM1to - 1, bpmInit);
 		this.n内部番号BPM1to++;
 
 		// add initial BPM chip
@@ -4704,6 +4675,18 @@ internal class CTja : CActivity {
 		chipInitBpm.n整数値_内部番号 = 1;
 
 		this.listChip.Add(chipInitBpm);
+
+		// add initial BPMCHANGE chip
+		// Previously this was set up with the first BPMCHANGE during chip post-processing as a part of DTX processing.
+		// However, `BPM:` in TJA is usually used for the actually initial BPM,
+		// and HBScroll gimmicks regarding `BPM:` are also supported in TaikoJiro,
+		// so it is now handled here for simplicity.
+		CChip chipInitBpmChange = new CChip();
+		chipInitBpmChange.n発声位置 = 0;
+		chipInitBpmChange.nChannelNo = 8;      // 拡張BPM
+		chipInitBpmChange.n整数値 = 0;
+		chipInitBpmChange.n整数値_内部番号 = bpmInit.n内部番号;
+		this.listChip.Add(chipInitBpmChange);
 
 		// add music start chip
 		//#STARTと同時に鳴らすのはどうかと思うけどしゃーなしだな。

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1376,16 +1376,10 @@ internal class CTja : CActivity {
 				// * TaikoJiro 1 behavior: Notes' scrolling BPM and HBScroll beat (but not time) are re-adjusted to the active timing
 				//   (also affect notes' time in TaikoJiro 2 (?))
 				foreach (CChip chip in this.listChip) {
+					// reassign the timing of measure-position-based chips
+					// TODO: remove this process completely for 0xDD (#SECTION)
 					switch (chip.nChannelNo) {
-						case 0x02 or 0x01 or 0x08:
-						case >= 0x11 and <= 0x1F:
-						case 0x50 or 0x54:
-						case 0xF1 or 0xF2 or 0xFF:
-							break;
-						case 0xDD or 0xDF:
-						case < 0x93:
-						// case > 0x9F and < 0xA0: // impossible case
-						case >= 0xF0 and < 0xFE:
+						case 0xDD:
 							chip.n発声時刻ms = ms + ((int)(((625 * (chip.n発声位置 - n発声位置)) * this.dbBarLength) / bpm));
 							break;
 					}

--- a/OpenTaiko/src/Songs/TJA/CChip.cs
+++ b/OpenTaiko/src/Songs/TJA/CChip.cs
@@ -51,7 +51,7 @@ internal class CChip : IComparable<CChip>, ICloneable {
 	public double db発声位置;  // 発声時刻を格納していた変数のうちの１つをfloat型からdouble型に変更。(kairera0467)
 	public double fBMSCROLLTime;
 	public double fBMSCROLLTime_end;
-	public int n発声時刻ms;
+	public int n発声時刻ms { get => (int)db発声時刻ms; set => db発声時刻ms = value; }
 	public double n分岐時刻ms;
 
 

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
@@ -49,7 +49,7 @@ internal class CAct演奏演奏情報 : CActivity {
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Song/G. Offset:{0:####0}/{1:####0} ms", OpenTaiko.TJA.nBGMAdjust, OpenTaiko.ConfigIni.nGlobalOffsetMs));
 			y -= dy;
 			int num = (OpenTaiko.TJA.listChip.Count > 0) ? OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms : 0;
-			string str = "Time:          " + (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.TJA) / 1000.0).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
+			string str = "Time:          " + (OpenTaiko.TJA.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) / 1000.0).ToString("####0.00") + " / " + ((((double)num) / 1000.0)).ToString("####0.00");
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, str);
 			y -= dy;
 			OpenTaiko.actTextConsole.Print(x, y, CTextConsole.EFontType.White, string.Format("Part:          {0:####0}/{1:####0}", NowMeasure[0], NowMeasure[1]));

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -3319,11 +3319,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 								this.actPlayInfo.dbBPM[nPlayer] = cBPM.dbBPM値;// + dTX.BASEBPM;
 							}
 
-
-							for (int i = 0; i < 5; i++) {
-								ctChipAnime[i] = new CCounter(0, 3, 60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer] * 1 / 4, SoundManager.PlayTimer);
-							}
-
 							UpdateCharaCounter(nPlayer);
 							//this.actDancer.ct踊り子モーション = new CCounter(0, this.actDancer.ar踊り子モーション番号.Length - 1, (dbUnit * CDTXMania.Skin.Game_Dancer_Beat) / this.actDancer.ar踊り子モーション番号.Length, CSound管理.rc演奏用タイマ);
 							//this.actChara.ctモブモーション = new CCounter(0, this.actChara.arモブモーション番号.Length - 1, (dbUnit) / this.actChara.arモブモーション番号.Length, CSound管理.rc演奏用タイマ);

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -2946,7 +2946,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!this.bPAUSE && !pChip.bHit && time < 0) { // can't play while paused
 						pChip.bHit = true;
 						if (configIni.bBGMPlayVoiceSound) {
-							dTX.tチップの再生(pChip, SoundManager.PlayTimer.PrevResetTimeMs + (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, tja));
+							dTX.tチップの再生(pChip, SoundManager.PlayTimer.GameTimeToSystemTime((long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, tja)));
 						}
 					}
 					break;
@@ -4569,7 +4569,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!b) continue;
 
 					if ((wc.bIsBGMSound && OpenTaiko.ConfigIni.bBGMPlayVoiceSound) || (!wc.bIsBGMSound)) {
-						OpenTaiko.TJA.tチップの再生(pChip, (long)(SoundManager.PlayTimer.PrevResetTimeMs) + (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, dTX));
+						OpenTaiko.TJA.tチップの再生(pChip, SoundManager.PlayTimer.GameTimeToSystemTime((long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, dTX)));
 						#region [ PAUSEする ]
 						int j = wc.n現在再生中のサウンド番号;
 						if (wc.rSound[j] != null) {

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -2952,10 +2952,11 @@ internal abstract class CStage演奏画面共通 : CStage {
 					break;
 				#endregion
 				#region [ 03: BPM変更 ]
-				case 0x03:  // BPM変更
+				case 0x03:  // Initial BPM
 					if (!pChip.bHit && time < 0) {
 						pChip.bHit = true;
-						this.actPlayInfo.dbBPM[nPlayer] = dTX.BASEBPM; //2016.07.10 kairera0467 太鼓の仕様にあわせて修正。(そもそもの仕様が不明&コードミス疑惑)
+						// this.actPlayInfo.dbBPM[nPlayer] has already been initialized
+						// Alternative behavior: Start with 120 BPM chara speed, switch to initial BPM chara speed at this chip?
 					}
 					break;
 				#endregion

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -976,11 +976,11 @@ internal abstract class CStage演奏画面共通 : CStage {
 			int nDeltaTime = Math.Abs(pChip.nLag);
 			//Debug.WriteLine("nAbsTime=" + (nTime - pChip.n発声時刻ms) + ", nDeltaTime=" + (nTime - pChip.n発声時刻ms));
 			if (NotesManager.IsRoll(pChip) || NotesManager.IsFuzeRoll(pChip)) {
-				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) > pChip.n発声時刻ms && CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) < pChip.nNoteEndTimems) {
+				if (tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) > pChip.n発声時刻ms && tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) < pChip.nNoteEndTimems) {
 					return ENoteJudge.Perfect;
 				}
 			} else if (NotesManager.IsGenericBalloon(pChip)) {
-				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) >= pChip.n発声時刻ms - 17 && CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) < pChip.nNoteEndTimems) {
+				if (tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) >= pChip.n発声時刻ms - 17 && tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) < pChip.nNoteEndTimems) {
 					return ENoteJudge.Perfect;
 				}
 			}
@@ -1236,7 +1236,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 	protected bool tBalloonProcess(CChip pChip, double dbProcess_time, int player) {
 		CTja tja = OpenTaiko.GetTJA(player)!;
 		//if( dbProcess_time >= pChip.n発声時刻ms && dbProcess_time < pChip.nノーツ終了時刻ms )
-		long nowTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+		long nowTime = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		bool IsKusudama = NotesManager.IsKusudama(pChip);
 		bool IsFuze = NotesManager.IsFuzeRoll(pChip);
 
@@ -1446,7 +1446,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (this.bPAUSE == false && rollSpeed > 0) // && TJAPlayer3.ConfigIni.bAuto先生の連打)
 					{
 						double msPerRollTja = CTja.GameDurationToTjaDuration(1000.0 / rollSpeed);
-						if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)
+						if (tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)
 							> (pChip.n発声時刻ms + msPerRollTja * pChip.nRollCount)) {
 							EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(nPlayer)];
 							int nLane = 0;
@@ -1468,13 +1468,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 							if (pChip.nChannelNo == 0x20 && _gt == EGameType.Konga) nLane = 4;
 							else if (pChip.nChannelNo == 0x21 && _gt == EGameType.Konga) nLane = 1;
 
-							this.tRollProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 1, nLane, 0, nPlayer);
+							this.tRollProcess(pChip, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 1, nLane, 0, nPlayer);
 						}
 					}
 				}
 				if (!bAutoPlay && !rollEffectHit) {
 					this.eRollState = ERollState.Roll;
-					this.tRollProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 1, nNowInput, 0, nPlayer);
+					this.tRollProcess(pChip, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 1, nNowInput, 0, nPlayer);
 				}
 				//---------------------------
 				#endregion
@@ -1528,7 +1528,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 						int balloonDuration = bAutoPlay ? (pChip.nNoteEndTimems - pChip.n発声時刻ms) : 1000;
 
-						if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) >
+						if (tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) >
 							(pChip.n発声時刻ms + (balloonDuration / (double)rollSpeed) * rollCount)) {
 							if (this.nHand[nPlayer] == 0)
 								this.nHand[nPlayer]++;
@@ -1538,18 +1538,18 @@ internal abstract class CStage演奏画面共通 : CStage {
 							OpenTaiko.stageGameScreen.actTaikoLaneFlash.PlayerLane[nPlayer].Start(PlayerLane.FlashType.Red);
 							OpenTaiko.stageGameScreen.actMtaiko.tMtaikoEvent(pChip.nChannelNo, this.nHand[nPlayer], nPlayer);
 
-							this.tBalloonProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), nPlayer);
+							this.tBalloonProcess(pChip, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), nPlayer);
 						}
 					}
 				}
 				if (!bAutoPlay && !rollEffectHit) {
 					if (!IsKusudama || nCurrentKusudamaCount > 0) {
-						this.tBalloonProcess(pChip, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), nPlayer);
+						this.tBalloonProcess(pChip, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), nPlayer);
 					}
 				}
 				#endregion
 			} else if (NotesManager.IsRollEnd(pChip)) {
-				if (pChip.nNoteEndTimems <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
+				if (pChip.nNoteEndTimems <= tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 					if (NotesManager.IsKusudama(pChip)) {
 						for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 							chip現在処理中の連打チップ[i].bHit = true;
@@ -2618,12 +2618,12 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
 
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 0);
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eNormal, 0, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eNormal, 0, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eNormal, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eNormal, 0);
@@ -2643,13 +2643,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 				//rc演奏用タイマ.n現在時刻msから引っ張ることに
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 0);
 
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eExpert, 0, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eExpert, 0, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eExpert, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eExpert, 0);
@@ -2669,13 +2669,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 				//rc演奏用タイマ.n現在時刻msから引っ張ることに
 
 				//判定枠に一番近いチップの情報を元に一小節分の値を計算する. 2020.04.21 akasoko26
-				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 0);
+				var p判定枠に最も近いチップ = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 0);
 
 				double db一小節後 = 0.0;
 				if (p判定枠に最も近いチップ != null)
 					db一小節後 = ((15000.0 / p判定枠に最も近いチップ.dbBPM * (p判定枠に最も近いチップ.fNow_Measure_s / p判定枠に最も近いチップ.fNow_Measure_m)) * 16.0);
 
-				this.t分岐処理(CTja.ECourse.eMaster, 0, CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) + db一小節後);
+				this.t分岐処理(CTja.ECourse.eMaster, 0, tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) + db一小節後);
 
 				OpenTaiko.stageGameScreen.actLaneTaiko.t分岐レイヤー_コース変化(OpenTaiko.stageGameScreen.actLaneTaiko.stBranch[0].nAfter, CTja.ECourse.eMaster, 0);
 				OpenTaiko.stageGameScreen.actMtaiko.tBranchEvent(OpenTaiko.stageGameScreen.actMtaiko.After[0], CTja.ECourse.eMaster, 0);
@@ -2820,7 +2820,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 		CTja tja = OpenTaiko.GetTJA(nPlayer)!;
 
-		var n現在時刻ms = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+		var n現在時刻ms = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		NowAIBattleSectionTime = (int)n現在時刻ms - NowAIBattleSection.StartTime;
 
@@ -2946,7 +2946,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!this.bPAUSE && !pChip.bHit && time < 0) { // can't play while paused
 						pChip.bHit = true;
 						if (configIni.bBGMPlayVoiceSound) {
-							dTX.tチップの再生(pChip, SoundManager.PlayTimer.GameTimeToSystemTime((long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, tja)));
+							dTX.tチップの再生(pChip, SoundManager.PlayTimer.GameTimeToSystemTime((long)tja.TjaTimeToGameTime(pChip.n発声時刻ms)));
 						}
 					}
 					break;
@@ -4058,7 +4058,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				break;
 		}
 
-		var n現在時刻ms = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, dTX);
+		var n現在時刻ms = (long)dTX.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		//for ( int nCurrentTopChip = this.n現在のトップChip; nCurrentTopChip < dTX.listChip.Count; nCurrentTopChip++ )
 		for (int nCurrentTopChip = dTX.listChip.Count - 1; nCurrentTopChip > 0; nCurrentTopChip--) {
@@ -4286,7 +4286,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		float bpm_time = 0;
 		int last_input = 0;
 		float last_bpm_change_time;
-		play_time = (float)CTja.TjaTimeToRawTjaTimeNote(CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), tja);
+		play_time = (float)tja.TjaTimeToRawTjaTimeNote(tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs));
 
 		for (int i = 1; ; i++) {
 			//BPMCHANGEの数越えた
@@ -4539,7 +4539,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		#endregion
 		#region [ 演奏開始の発声時刻msを取得し、タイマに設定 ]
 		int nStartTime = (nStartBar == 0) ? 0
-			: ((int)CTja.TjaTimeToGameTime(dTX.listChip[this.nCurrentTopChip].n発声時刻ms, dTX) - OpenTaiko.ConfigIni.MusicPreTimeMs);
+			: ((int)dTX.TjaTimeToGameTime(dTX.listChip[this.nCurrentTopChip].n発声時刻ms) - OpenTaiko.ConfigIni.MusicPreTimeMs);
 
 		SoundManager.PlayTimer.Reset(); // これでPAUSE解除されるので、次のPAUSEチェックは不要
 										//if ( !this.bPAUSE )
@@ -4555,7 +4555,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		for (int i = 0; i <= idxCurrentTopMostChip; ++i) {
 			CChip pChip = dTX.listChip[i];
 			int nDuration = (int)CTja.TjaDurationToGameDuration(pChip.GetDuration());
-			long n発声時刻ms = (long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, dTX);
+			long n発声時刻ms = (long)dTX.TjaTimeToGameTime(pChip.n発声時刻ms);
 
 			if (n発声時刻ms <= nStartTime) {
 				if (pChip.nChannelNo == 0x01 && (pChip.nChannelNo >> 4) != 0xB) // wav系チャンネル、且つ、空打ちチップではない
@@ -4569,7 +4569,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!b) continue;
 
 					if ((wc.bIsBGMSound && OpenTaiko.ConfigIni.bBGMPlayVoiceSound) || (!wc.bIsBGMSound)) {
-						OpenTaiko.TJA.tチップの再生(pChip, SoundManager.PlayTimer.GameTimeToSystemTime((long)CTja.TjaTimeToGameTime(pChip.n発声時刻ms, dTX)));
+						OpenTaiko.TJA.tチップの再生(pChip, SoundManager.PlayTimer.GameTimeToSystemTime((long)dTX.TjaTimeToGameTime(pChip.n発声時刻ms)));
 						#region [ PAUSEする ]
 						int j = wc.n現在再生中のサウンド番号;
 						if (wc.rSound[j] != null) {

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -3166,7 +3166,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				case 0x50:  // 小節線
 				{
 
-						if (!pChip.bHit && time < 0) {
+						if (!this.bPAUSE && !pChip.bHit && time < 0) { // can't update while paused
 							//if (nPlayer == 0) TJAPlayer3.BeatScaling = new CCounter(0, 1000, 120.0 / pChip.dbBPM / 2.0, TJAPlayer3.Timer);
 							if (NowAIBattleSectionTime >= NowAIBattleSection.Length && NowAIBattleSection.End == AIBattleSection.EndType.None && nPlayer == 0) {
 								PassAIBattleSection();
@@ -3184,10 +3184,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 							if (this.actPlayInfo.NowMeasure[nPlayer] == 0) {
 								UpdateCharaCounter(nPlayer);
 							}
-							if (!bPAUSE)//2020.07.08 Mr-Ojii KabanFriends氏のコードを参考に
-							{
-								actPlayInfo.NowMeasure[nPlayer] = pChip.n整数値_内部番号;
-							}
+							actPlayInfo.NowMeasure[nPlayer] = pChip.n整数値_内部番号;
 							pChip.bHit = true;
 						}
 						this.t進行描画_チップ_小節線(configIni, ref dTX, ref pChip, nPlayer);

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4518,20 +4518,13 @@ internal abstract class CStage演奏画面共通 : CStage {
 		bool bSuccessSeek = false;
 		for (int i = 0; i < dTX.listChip.Count; i++) {
 			CChip pChip = dTX.listChip[i];
-			if (nStartBar == 0) {
-				if (pChip.n発声位置 < 384 * nStartBar) {
-					continue;
-				} else {
-					bSuccessSeek = true;
-					this.nCurrentTopChip = i;
-					break;
-				}
-			} else {
-				if (pChip.nChannelNo == 0x50 && pChip.n整数値_内部番号 > nStartBar - 1) {
-					bSuccessSeek = true;
-					this.nCurrentTopChip = i;
-					break;
-				}
+			if ((nStartBar == 0) ?
+				pChip.n発声時刻ms >= 0
+				: (pChip.nChannelNo == 0x50 && pChip.n整数値_内部番号 >= nStartBar)
+				) {
+				bSuccessSeek = true;
+				this.nCurrentTopChip = i;
+				break;
 			}
 		}
 		int idxCurrentTopMostChip;
@@ -4545,7 +4538,8 @@ internal abstract class CStage演奏画面共通 : CStage {
 		}
 		#endregion
 		#region [ 演奏開始の発声時刻msを取得し、タイマに設定 ]
-		int nStartTime = (int)CTja.TjaTimeToGameTime(dTX.listChip[this.nCurrentTopChip].n発声時刻ms, dTX);
+		int nStartTime = (nStartBar == 0) ? 0
+			: ((int)CTja.TjaTimeToGameTime(dTX.listChip[this.nCurrentTopChip].n発声時刻ms, dTX) - OpenTaiko.ConfigIni.MusicPreTimeMs);
 
 		SoundManager.PlayTimer.Reset(); // これでPAUSE解除されるので、次のPAUSEチェックは不要
 										//if ( !this.bPAUSE )

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -583,7 +583,7 @@ internal class CActImplLaneTaiko : CActivity {
 		}
 
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
-			var nTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.GetTJA(i)!);
+			var nTime = (long)OpenTaiko.GetTJA(i)!.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			if (this.n総移動時間[i] != -1) {
 				if (n移動方向[i] == 1) {
 					OpenTaiko.stageGameScreen.JPOSCROLLX[i] = this.n移動開始X[i] + (int)((((int)nTime - this.n移動開始時刻[i]) / (double)(this.n総移動時間[i])) * this.n移動距離px[i]);
@@ -792,7 +792,7 @@ internal class CActImplLaneTaiko : CActivity {
 
 	public void t判定枠移動(double db移動時間, int n移動px, int n移動方向, int nPlayer, int vJs) {
 		CTja tja = OpenTaiko.GetTJA(nPlayer)!;
-		this.n移動開始時刻[nPlayer] = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+		this.n移動開始時刻[nPlayer] = (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		this.n移動開始X[nPlayer] = OpenTaiko.stageGameScreen.JPOSCROLLX[nPlayer];
 		this.n移動開始Y[nPlayer] = OpenTaiko.stageGameScreen.JPOSCROLLY[nPlayer];
 		this.n総移動時間[nPlayer] = (int)(db移動時間 * 1000);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -362,7 +362,7 @@ class CActImplTrainingMode : CActivity {
 		int n演奏開始Chip = OpenTaiko.stageGameScreen.nCurrentTopChip;
 		int finalStartBar;
 
-		finalStartBar = this.nCurrentMeasure - 2;
+		finalStartBar = this.nCurrentMeasure;
 		if (finalStartBar < 0) finalStartBar = 0;
 
 		OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = 0;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -235,10 +235,10 @@ class CActImplTrainingMode : CActivity {
 		}
 
 		var current = CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
-		var percentage = current / length;
+		var percentage = double.Clamp(current / length, 0, 1);
 
 		var currentWhite = (double)(this.n最終演奏位置ms);
-		var percentageWhite = currentWhite / length;
+		var percentageWhite = double.Clamp(currentWhite / length, 0, 1);
 
 		if (OpenTaiko.Tx.Tokkun_ProgressBarWhite != null) OpenTaiko.Tx.Tokkun_ProgressBarWhite.t2D描画(OpenTaiko.Skin.Game_Training_ProgressBar_XY[0], OpenTaiko.Skin.Game_Training_ProgressBar_XY[1], new Rectangle(1, 1, (int)(OpenTaiko.Tx.Tokkun_ProgressBarWhite.szTextureSize.Width * percentageWhite), OpenTaiko.Tx.Tokkun_ProgressBarWhite.szTextureSize.Height));
 		if (OpenTaiko.Tx.Tokkun_ProgressBar != null) OpenTaiko.Tx.Tokkun_ProgressBar.t2D描画(OpenTaiko.Skin.Game_Training_ProgressBar_XY[0], OpenTaiko.Skin.Game_Training_ProgressBar_XY[1], new Rectangle(1, 1, (int)(OpenTaiko.Tx.Tokkun_ProgressBar.szTextureSize.Width * percentage), OpenTaiko.Tx.Tokkun_ProgressBar.szTextureSize.Height));

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -384,12 +384,6 @@ class CActImplTrainingMode : CActivity {
 				dTX.listChip[i].bVisible = false;
 				dTX.listChip[i].bShow = false;
 			}
-			if (i < n少し戻ってから演奏開始Chip && dTX.listChip[i].nChannelNo == 0x01) {
-				dTX.listChip[i].bHit = true;
-				dTX.listChip[i].IsHitted = true;
-				dTX.listChip[i].bVisible = false;
-				dTX.listChip[i].bShow = false;
-			}
 			if (dTX.listChip[i].nChannelNo == 0x50 && dTX.listChip[i].n整数値_内部番号 < finalStartBar) {
 				dTX.listChip[i].bHit = true;
 				dTX.listChip[i].IsHitted = true;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -365,12 +365,12 @@ class CActImplTrainingMode : CActivity {
 		finalStartBar = this.nCurrentMeasure - 2;
 		if (finalStartBar < 0) finalStartBar = 0;
 
+		OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = 0;
 		OpenTaiko.stageGameScreen.t演奏位置の変更(finalStartBar, 0);
 
 
 		int n少し戻ってから演奏開始Chip = OpenTaiko.stageGameScreen.nCurrentTopChip;
 
-		OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = 0;
 		OpenTaiko.stageGameScreen.t数値の初期化(true, true);
 		OpenTaiko.stageGameScreen.Activate();
 		if (OpenTaiko.ConfigIni.bTokkunMode && OpenTaiko.stageGameScreen.actBalloon.KusudamaIsActive) OpenTaiko.stageGameScreen.actBalloon.KusuMiss();
@@ -385,6 +385,7 @@ class CActImplTrainingMode : CActivity {
 				dTX.listChip[i].bShow = false;
 			}
 			if (dTX.listChip[i].nChannelNo == 0x50 && dTX.listChip[i].n整数値_内部番号 < finalStartBar) {
+				OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = dTX.listChip[i].n整数値_内部番号;
 				dTX.listChip[i].bHit = true;
 				dTX.listChip[i].IsHitted = true;
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplTrainingMode.cs
@@ -137,7 +137,7 @@ class CActImplTrainingMode : CActivity {
 					}
 					if (t配列の値interval以下か(ref this.RBlue, SoundManager.PlayTimer.SystemTimeMs, OpenTaiko.ConfigIni.TokkunMashInterval)) {
 						for (int index = 0; index < this.JumpPointList.Count; index++) {
-							if (this.JumpPointList[index].Time >= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
+							if (this.JumpPointList[index].Time >= tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 								this.nCurrentMeasure = this.JumpPointList[index].Measure;
 								OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = this.nCurrentMeasure;
 								OpenTaiko.Skin.soundSkip.tPlay();
@@ -160,7 +160,7 @@ class CActImplTrainingMode : CActivity {
 					}
 					if (t配列の値interval以下か(ref this.LBlue, SoundManager.PlayTimer.SystemTimeMs, OpenTaiko.ConfigIni.TokkunMashInterval)) {
 						for (int index = this.JumpPointList.Count - 1; index >= 0; index--) {
-							if (this.JumpPointList[index].Time <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
+							if (this.JumpPointList[index].Time <= tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 								this.nCurrentMeasure = this.JumpPointList[index].Measure;
 								OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0] = this.nCurrentMeasure;
 								OpenTaiko.Skin.sound特訓スキップ音.tPlay();
@@ -227,14 +227,14 @@ class CActImplTrainingMode : CActivity {
 					this.nCurrentMeasure = OpenTaiko.stageGameScreen.actPlayInfo.NowMeasure[0];
 				}
 
-				if (CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja) > this.n最終演奏位置ms) {
-					this.n最終演奏位置ms = (long)(CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja));
+				if (tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) > this.n最終演奏位置ms) {
+					this.n最終演奏位置ms = (long)(tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs));
 				}
 			}
 
 		}
 
-		var current = CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+		var current = tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 		var percentage = double.Clamp(current / length, 0, 1);
 
 		var currentWhite = (double)(this.n最終演奏位置ms);
@@ -422,12 +422,12 @@ class CActImplTrainingMode : CActivity {
 		}
 
 		if (doScroll) {
-			this.nスクロール後ms = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms, dTX);
+			this.nスクロール後ms = (long)dTX.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms);
 			this.bCurrentlyScrolling = true;
 
 			this.ctScrollCounter = new CCounter(0, OpenTaiko.Skin.Game_Training_ScrollTime, 1, OpenTaiko.Timer);
 		} else {
-			SoundManager.PlayTimer.NowTimeMs = (long)CTja.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms, dTX);
+			SoundManager.PlayTimer.NowTimeMs = (long)dTX.TjaTimeToGameTime(dTX.listChip[OpenTaiko.stageGameScreen.nCurrentTopChip].n発声時刻ms);
 			this.nスクロール後ms = SoundManager.PlayTimer.NowTimeMs;
 		}
 	}
@@ -435,7 +435,7 @@ class CActImplTrainingMode : CActivity {
 	public void tToggleBookmarkAtTheCurrentPosition() {
 		if (!this.bCurrentlyScrolling && this.bTrainingPAUSE) {
 			CTja tja = OpenTaiko.TJA!;
-			STJUMPP _JumpPoint = new STJUMPP() { Time = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), Measure = this.nCurrentMeasure };
+			STJUMPP _JumpPoint = new STJUMPP() { Time = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), Measure = this.nCurrentMeasure };
 
 			if (!JumpPointList.Contains(_JumpPoint))
 				JumpPointList.Add(_JumpPoint);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -389,7 +389,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			if (this.st叩ききりまショー.bタイマー使用中) {
 				if (!this.st叩ききりまショー.ct残り時間.IsStoped || this.st叩ききりまショー.b加算アニメ中 == true) {
 					this.st叩ききりまショー.ct残り時間.Tick();
-					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
+					if (!OpenTaiko.stageGameScreen.r検索範囲内にチップがあるか調べる((long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), 5000, 0) || this.st叩ききりまショー.b加算アニメ中 == true) {
 						this.st叩ききりまショー.bタイマー使用中 = false;
 						this.st叩ききりまショー.ct残り時間.Stop();
 					}
@@ -501,7 +501,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 		CTja tja = OpenTaiko.TJA!; // 1P-only mode (?)
 
 		//最後に延長した時刻から11秒経過していなければ延長を行わない。
-		if (this.n最後に時間延長した時刻 + 11000 <= CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
+		if (this.n最後に時間延長した時刻 + 11000 <= tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 			//1項目につき5秒
 			//-精度
 			if (this.st叩ききりまショー.nヒット数_PERFECT != 0 || this.st叩ききりまショー.nヒット数_GREAT != 0) {
@@ -593,7 +593,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			#endregion
 
 
-			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+			this.n最後に時間延長した時刻 = (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 			if (this.st叩ききりまショー.n区間ノート数 == 0)
@@ -654,7 +654,7 @@ internal class CAct演奏Drumsゲームモード : CActivity {
 			}
 
 
-			this.n最後に時間延長した時刻 = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+			this.n最後に時間延長した時刻 = (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			if (n延長する時間 < 0)
 				n延長する時間 = 0;
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -861,7 +861,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				CTja tja = OpenTaiko.GetTJA(nUsePlayer)!;
 
 				// convert input time (mixer space) to note time
-				long msInputMixer = inputEvent.nTimeStamp - SoundManager.PlayTimer.PrevResetTimeMs;
+				long msInputMixer = SoundManager.PlayTimer.SystemTimeToGameTime(inputEvent.nTimeStamp);
 				long nTime = (long)CTja.GameTimeToTjaTime(msInputMixer + nInputAdjustTimeMs, tja);
 				//int nPad09 = ( nPad == (int) Eパッド.HP ) ? (int) Eパッド.BD : nPad;		// #27029 2012.1.5 yyagi
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -269,7 +269,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		OpenTaiko.DiscordClient?.SetPresence(new RichPresence() {
 			Details = details,
 			State = "Playing" + (OpenTaiko.ConfigIni.bAutoPlay[0] == true ? " (Auto)" : ""),
-			Timestamps = new Timestamps(DateTime.UtcNow, DateTime.UtcNow.AddMilliseconds(CTja.TjaTimeToGameTime(OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms, OpenTaiko.TJA))),
+			Timestamps = new Timestamps(DateTime.UtcNow, DateTime.UtcNow.AddMilliseconds(OpenTaiko.TJA.TjaTimeToGameTime(OpenTaiko.TJA.listChip[OpenTaiko.TJA.listChip.Count - 1].n発声時刻ms))),
 			Assets = new Assets() {
 				SmallImageKey = OpenTaiko.ConfigIni.SendDiscordPlayingInformation ? difficultyName.ToLower() : "",
 				SmallImageText = OpenTaiko.ConfigIni.SendDiscordPlayingInformation ? String.Format("COURSE:{0} ({1})", difficultyName, OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0]) : "",
@@ -490,7 +490,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			this.t進行描画_演奏情報();
 
-			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.TJA)) {
+			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)OpenTaiko.TJA.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 				this.actPanel.t歌詞テクスチャを生成する(OpenTaiko.TJA.listLyric2[ShownLyric2++].TextTex);
 			}
 
@@ -862,7 +862,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 				// convert input time (mixer space) to note time
 				long msInputMixer = SoundManager.PlayTimer.SystemTimeToGameTime(inputEvent.nTimeStamp);
-				long nTime = (long)CTja.GameTimeToTjaTime(msInputMixer + nInputAdjustTimeMs, tja);
+				long nTime = (long)tja.GameTimeToTjaTime(msInputMixer + nInputAdjustTimeMs);
 				//int nPad09 = ( nPad == (int) Eパッド.HP ) ? (int) Eパッド.BD : nPad;		// #27029 2012.1.5 yyagi
 
 				CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する(nTime, nUsePlayer);
@@ -1208,14 +1208,14 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 							// Process big notes (judge big notes on)
 							if (e判定 != ENoteJudge.Miss && ((_isBigNoteTaiko && OpenTaiko.ConfigIni.bJudgeBigNotes) || _isPinkKonga)) {
 								CConfigIni.CTimingZones tz = this.GetTimingZones(nUsePlayer);
-								float time = chipNoHit.n発声時刻ms - (float)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+								float time = chipNoHit.n発声時刻ms - (float)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 								int nWaitTime = OpenTaiko.ConfigIni.nBigNoteWaitTimems;
 
 								bool _timeBadOrLater = time <= tz.nBadZone;
 
 								if (chipNoHit.eNoteState == ENoteState.None) {
 									if (_timeBadOrLater) {
-										chipNoHit.nProcessTime = (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+										chipNoHit.nProcessTime = (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 										chipNoHit.eNoteState = ENoteState.Wait;
 										//this.nWaitButton = waitInstr;
 										this.nStoredHit[nUsePlayer] = (int)_pad;
@@ -1226,7 +1226,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 									// Double tap success
 									if (_isExpected && _timeBadOrLater && chipNoHit.nProcessTime
-										+ nWaitTime > (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
+										+ nWaitTime > (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 										this.tドラムヒット処理(nTime, _pad, chipNoHit, true, nUsePlayer);
 										bHitted = true;
 										//this.nWaitButton = 0;
@@ -1235,7 +1235,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 									// Double tap failure
 									else if (!_isExpected || (_timeBadOrLater && chipNoHit.nProcessTime
-												 + nWaitTime < (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja))) {
+												 + nWaitTime < (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs))) {
 										if (!_isPinkKonga) {
 											this.tドラムヒット処理(nTime, _pad, chipNoHit, false, nUsePlayer);
 											bHitted = true;
@@ -1345,7 +1345,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		if (pChip.bVisible) {
 			if (!pChip.bHit) {
-				long nPlayTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+				long nPlayTime = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				if ((!pChip.bHit) && (pChip.n発声時刻ms <= nPlayTime)) {
 					bool bAutoPlay = OpenTaiko.ConfigIni.bAutoPlay[nPlayer];
 					switch (nPlayer) {
@@ -1452,7 +1452,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				}
 				#endregion
 
-				long __dbt = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+				long __dbt = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				long time = pChip.n発声時刻ms - __dbt;
 
 				if (pChip.dbSCROLL_Y != 0.0) {
@@ -1617,7 +1617,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		CTja tja = OpenTaiko.GetTJA(nPlayer)!;
 		int nSenotesX = 0;
 		int nSenotesY = 0;
-		long nowTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+		long nowTime = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 
 		switch (OpenTaiko.ConfigIni.nPlayerCount) {
 			case 1:
@@ -1957,7 +1957,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		if (pChip.dbSCROLL_Y != 0.0) {
 			double _scrollSpeed = pChip.dbSCROLL_Y * (this.actScrollSpeed.dbConfigScrollSpeed[nPlayer] + 1.0) / 10.0;
-			long __dbt = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+			long __dbt = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 			long msDTime = pChip.n発声時刻ms - __dbt;
 			float play_bpm_time = this.GetNowPBMTime(dTX, 0);
 			double th16DBeat = pChip.fBMSCROLLTime - play_bpm_time;
@@ -1992,7 +1992,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			CTja tja = OpenTaiko.GetTJA(i)!;
 			var chkChip = this.chip現在処理中の連打チップ[i];
 			if (chkChip != null) {
-				long nowTime = (long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+				long nowTime = (long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				//int n = this.chip現在処理中の連打チップ[i].nチャンネル番号;
 				if ((NotesManager.IsGenericBalloon(chkChip) || NotesManager.IsKusudama(chkChip)) && (this.bCurrentlyDrumRoll[i] == true)) {
 					//if (this.chip現在処理中の連打チップ.n発声時刻ms <= (int)CSound管理.rc演奏用タイマ.n現在時刻ms && this.chip現在処理中の連打チップ.nノーツ終了時刻ms >= (int)CSound管理.rc演奏用タイマ.n現在時刻ms)
@@ -2022,7 +2022,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		//CDTX.CChip chipNoHit = this.r指定時刻に一番近い未ヒットChip((int)CSound管理.rc演奏用タイマ.n現在時刻ms, 0);
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			CTja tja = OpenTaiko.GetTJA(i)!;
-			CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja), i);
+			CChip chipNoHit = r指定時刻に一番近い未ヒットChipを過去方向優先で検索する((long)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs), i);
 
 			EGameType _gt = OpenTaiko.ConfigIni.nGameType[OpenTaiko.GetActualPlayer(i)];
 			bool _isBigKaTaiko = NotesManager.IsBigKaTaiko(chipNoHit, _gt);
@@ -2031,10 +2031,10 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			if (chipNoHit != null && (_isBigDonTaiko || _isBigKaTaiko)) {
 				CConfigIni.CTimingZones tz = this.GetTimingZones(i);
-				float timeC = chipNoHit.n発声時刻ms - (float)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja);
+				float timeC = chipNoHit.n発声時刻ms - (float)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs);
 				int nWaitTime = OpenTaiko.ConfigIni.nBigNoteWaitTimems;
 				if (chipNoHit.eNoteState == ENoteState.Wait && timeC <= tz.nBadZone
-															&& chipNoHit.nProcessTime + nWaitTime <= (int)CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, tja)) {
+															&& chipNoHit.nProcessTime + nWaitTime <= (int)tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 					if (!_isSwapNote) {
 						this.tドラムヒット処理(chipNoHit.nProcessTime, EPad.RRed, chipNoHit, false, i);
 						//this.nWaitButton = 0;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -256,11 +256,9 @@ class ScriptBG : IDisposable {
 				double msTimeOffset = OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan ? 0 : -CTja.msDanNextSongDelay;
 				// Due to the fact that all Dans use DELAY to offset instead of OFFSET, Dan offset can't be properly synced. ¯\_(ツ)_/¯
 
-				timestamp = (CTja.RawTjaTimeToDefTime(
-					CTja.TjaTimeToRawTjaTimeNote(
-						CTja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs, OpenTaiko.TJA),
-						OpenTaiko.TJA),
-					OpenTaiko.TJA
+				timestamp = (OpenTaiko.TJA.RawTjaTimeToDefTime(
+					OpenTaiko.TJA.TjaTimeToRawTjaTimeNote(
+						OpenTaiko.TJA.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs))
 				) + msTimeOffset) / 1000.0;
 			}
 


### PR DESCRIPTION
## Fixed Issues

* fix wrong notes' scrolling BPM when `#BPMCHANGE` is put at chart start, due to wrong post-process order of 0x03 (initial `BPM:`) and 0x08 (`#BPMCHANGE`)
* fix duplicated or missing initial-state chips at `#START` in case of respecified/omitted/out-of-order headers
* fix inaccurate time of chip `0x55` (`#BGAOFF`) and `0xDD` (`#SECTION`) by stop reassigning chips' time by measure position during TJA post-process
* fix chip `0xDD` (`#SECTION`) had unstable sorting order due to the fraction part of its timestamp
  * → fix indetermined branching behavior of "branch-every-bar" charts likes <ruby>卓球<rt>Takkyuu</rt></ruby>de<ruby>脱臼<rt>Dakkyuu</rt></ruby> Oni
* fix `MOVIEOFFSET:` not applied if negative, applied twice if positive, & wrongly applied to `#BGAON`
* fix wrong chip time of invisible channels 0x02 (measure length), 0x03 (initial BPM), & 0x08 (internal BPM change) (only affects debug info)
* fix issues due to inconsistent usage of `n発声時刻ms` vs. `db発声時刻ms`, triggered by 483f4ab6bfa9c25dc2bf6192300689e2a9ac94d2 (part of 0auBSQ/OpenTaiko#787 : 9924a4f343c901f88fbbf8240d33d2d16c0d11ed):
  * fix Kusudama not converted to Balloon if not encountered almost simultaneously by all players
  * fix all go-go time marks were placed at the very left of the progress bar frame in training mode
* fix training mode progress bars could exceed their frame (from )

## Feature changes

* increase interpreted MusicPreTimeMs (song playback buffer time) by 1.5 seconds from `Config.ini`
  * MusicPreTimeMs now defaults to 2.5 seconds
* gameplay retrying & training mode resuming now respect MusicPreTimeMs
* gameplay retrying now replays from the same time position as entering the gameplay the first time

## Fixed Development Issues

* completely remove the overly long `if`-`else` one-liners for chip post-processing in `CTja.t入力_全入力文字列から()` [`tInput_FromWholeInputTextLines`]
* music & video can now be played even their time position is negative
