### PR TITLE
feat: initial support of story-mode cutscene

### DIFF
--- a/FDK/src/04.Graphics/CVideoDecoder.cs
+++ b/FDK/src/04.Graphics/CVideoDecoder.cs
@@ -246,6 +246,8 @@ public unsafe class CVideoDecoder : IDisposable {
 		return null;
 	}
 
+	public double msPlayPosition => CTimer.NowTimeMs * _dbPlaySpeed;
+
 	public Size FrameSize {
 		get;
 		private set;

--- a/FDK/src/04.Graphics/CVideoDecoder.cs
+++ b/FDK/src/04.Graphics/CVideoDecoder.cs
@@ -105,6 +105,7 @@ public unsafe class CVideoDecoder : IDisposable {
 		CTimer.Pause();
 		this.bPlaying = false;
 		bDrawing = false;
+		this.bFinishPlaying = true;
 	}
 
 	public void InitRead() {
@@ -116,6 +117,7 @@ public unsafe class CVideoDecoder : IDisposable {
 	}
 
 	public void Seek(long timestampms) {
+		this.bFinishPlaying = false;
 		cts?.Cancel();
 		while (DS != DecodingState.Stopped) ;
 		if (ffmpeg.av_seek_frame(format_context, video_stream->index, timestampms, ffmpeg.AVSEEK_FLAG_BACKWARD) < 0)
@@ -208,6 +210,7 @@ public unsafe class CVideoDecoder : IDisposable {
 						//2020/10/27 Mr-Ojii packetが解放されない周回があった問題を修正。
 						ffmpeg.av_packet_unref(packet);
 					} else if (error == ffmpeg.AVERROR_EOF) {
+						this.bFinishPlaying = true;
 						return;
 					}
 				} else {
@@ -276,6 +279,7 @@ public unsafe class CVideoDecoder : IDisposable {
 	//for play
 	public bool bPlaying { get; private set; } = false;
 	public bool bDrawing { get; private set; } = false;
+	public bool bFinishPlaying { get; private set; } = false;
 	private CTimer CTimer;
 	private AVRational Framerate;
 	private CTexture lastTexture;

--- a/FDK/src/04.Graphics/CVideoDecoder.cs
+++ b/FDK/src/04.Graphics/CVideoDecoder.cs
@@ -91,13 +91,21 @@ public unsafe class CVideoDecoder : IDisposable {
 
 	}
 
-	public void PauseControl() {
+	public void Pause() {
+		CTimer.Pause();
+		this.bPlaying = false;
+	}
+
+	public void Resume() {
+		CTimer.Resume();
+		this.bPlaying = true;
+	}
+
+	public void TogglePause() {
 		if (this.bPlaying) {
-			CTimer.Pause();
-			this.bPlaying = false;
+			this.Pause();
 		} else {
-			CTimer.Resume();
-			this.bPlaying = true;
+			this.Resume();
 		}
 	}
 

--- a/OpenTaiko/Lang/de/lang.json
+++ b/OpenTaiko/Lang/de/lang.json
@@ -557,6 +557,7 @@
 		"PAUSE_TITLE": "Pause",
 		"PAUSE_RESUME": "Fortsetzen",
 		"PAUSE_RESTART": "Neustart",
+		"PAUSE_SKIP": "Überspringen",
 		"PAUSE_EXIT": "Beenden",
 
 		// AI Info

--- a/OpenTaiko/Lang/en/lang.json
+++ b/OpenTaiko/Lang/en/lang.json
@@ -557,6 +557,7 @@
 		"PAUSE_TITLE": "Pause",
 		"PAUSE_RESUME": "Resume",
 		"PAUSE_RESTART": "Restart",
+		"PAUSE_SKIP": "Skip",
 		"PAUSE_EXIT": "Quit",
 
 		// AI Info

--- a/OpenTaiko/Lang/es/lang.json
+++ b/OpenTaiko/Lang/es/lang.json
@@ -560,6 +560,7 @@
 		"PAUSE_TITLE": "Pause",
 		"PAUSE_RESUME": "Reanudar",
 		"PAUSE_RESTART": "Reiniciar",
+		"PAUSE_SKIP": "Saltar",
 		"PAUSE_EXIT": "Salir",
 
 		// AI Info

--- a/OpenTaiko/Lang/fr/lang.json
+++ b/OpenTaiko/Lang/fr/lang.json
@@ -559,6 +559,7 @@
 		"PAUSE_TITLE": "Pause",
 		"PAUSE_RESUME": "Reprendre",
 		"PAUSE_RESTART": "Recommencer",
+		"PAUSE_SKIP": "Sauter",
 		"PAUSE_EXIT": "Quitter",
 
 		// AI Info

--- a/OpenTaiko/Lang/ja/lang.json
+++ b/OpenTaiko/Lang/ja/lang.json
@@ -559,6 +559,7 @@
 		"PAUSE_TITLE": "ポーズ",
 		"PAUSE_RESUME": "もどる",
 		"PAUSE_RESTART": "やりなおす",
+		"PAUSE_SKIP": "スキップする",
 		"PAUSE_EXIT": "演奏中止",
 
 		// AI Info

--- a/OpenTaiko/Lang/ko/lang.json
+++ b/OpenTaiko/Lang/ko/lang.json
@@ -559,6 +559,7 @@
 		"PAUSE_TITLE": "일시정지",
 		"PAUSE_RESUME": "재생",
 		"PAUSE_RESTART": "다시 시작",
+		"PAUSE_SKIP": "건너뛰기",
 		"PAUSE_EXIT": "나가기",
 
 		// AI Info

--- a/OpenTaiko/Lang/nl/lang.json
+++ b/OpenTaiko/Lang/nl/lang.json
@@ -557,6 +557,7 @@
 		"PAUSE_TITLE": "Pauze",
 		"PAUSE_RESUME": "Hervatten",
 		"PAUSE_RESTART": "Opnieuw starten",
+		"PAUSE_SKIP": "Overslaan",
 		"PAUSE_EXIT": "Stoppen",
 
 		// AI Info

--- a/OpenTaiko/Lang/ru/lang.json
+++ b/OpenTaiko/Lang/ru/lang.json
@@ -557,6 +557,7 @@
 		"PAUSE_TITLE": "Пауза",
 		"PAUSE_RESUME": "Продолжить",
 		"PAUSE_RESTART": "Переиграть",
+		"PAUSE_SKIP": "Пропускать",
 		"PAUSE_EXIT": "Выход",
 
 		// AI Info

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -557,6 +557,7 @@
 		"PAUSE_TITLE": "暂停",
 		"PAUSE_RESUME": "继续",
 		"PAUSE_RESTART": "重新开始",
+		"PAUSE_SKIP": "跳过",
 		"PAUSE_EXIT": "退出",
 
 		// AI Info

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -1071,7 +1071,7 @@ internal class OpenTaiko : Game {
 					case CStage.EStage.TaikoTowers:
 						#region [ *** ]
 						switch (this.nDrawLoopReturnValue) {
-							case (int)EReturnValue.ReturnToTitle:
+							case (int)CStageSongSelect.EReturnValue.BackToTitle:
 								#region [ *** ]
 								//-----------------------------
 								ChangeStage(stageTitle);
@@ -1086,7 +1086,7 @@ internal class OpenTaiko : Game {
 							//-----------------------------
 							#endregion
 
-							case (int)EReturnValue.SongChoosen:
+							case (int)CStageSongSelect.EReturnValue.SongSelected:
 								#region [ *** ]
 								//-----------------------------
 								ChangeStage(stageSongLoading);

--- a/OpenTaiko/src/Databases/DBSaves.cs
+++ b/OpenTaiko/src/Databases/DBSaves.cs
@@ -290,9 +290,10 @@ internal class DBSaves {
 		return _bestPlays;
 	}
 
-	public static void RegisterPlay(int player, int clearStatus, int scoreRank) {
+	// return whether the score is valid and registered successfully
+	public static bool RegisterPlay(int player, int clearStatus, int scoreRank) {
 		SqliteConnection? connection = GetSavesDBConnection();
-		if (connection == null) return;
+		if (connection == null) return false;
 
 		SaveFile.Data saveData = OpenTaiko.SaveFileInstances[OpenTaiko.GetActualPlayer(player)].data;
 		BestPlayRecords.CBestPlayRecord currentPlay = new BestPlayRecords.CBestPlayRecord();
@@ -302,7 +303,7 @@ internal class DBSaves {
 		List<int>[] danResults = new List<int>[7] { new List<int>(), new List<int>(), new List<int>(), new List<int>(), new List<int>(), new List<int>(), new List<int>() };
 
 		// Do not register the play if Dan/Tower and any mod is ON
-		if ((choosenDifficulty == (int)Difficulty.Tower || choosenDifficulty == (int)Difficulty.Dan) && !ModIcons.tPlayIsStock(player)) return;
+		if ((choosenDifficulty == (int)Difficulty.Tower || choosenDifficulty == (int)Difficulty.Dan) && !ModIcons.tPlayIsStock(player)) return false;
 
 		// 1st step: Init best play record class
 
@@ -474,6 +475,8 @@ internal class DBSaves {
                 ";
 			cmd.ExecuteNonQuery();
 		}
+
+		return true;
 	}
 
 	#endregion

--- a/OpenTaiko/src/Songs/CSongListNode.cs
+++ b/OpenTaiko/src/Songs/CSongListNode.cs
@@ -88,6 +88,13 @@ internal class CSongListNode {
 
 	public string strScenePreset = null;
 
+	#region [ OpenTaiko-Exclusive TJA Extension Data ]
+
+	public CTja.CutSceneDef? CutSceneIntro = null;
+	public List<CTja.CutSceneDef> CutSceneOutros = [];
+
+	#endregion
+
 	public string tGetUniqueId() {
 		return uniqueId?.data.id ?? "";
 	}

--- a/OpenTaiko/src/Songs/CSong管理.cs
+++ b/OpenTaiko/src/Songs/CSong管理.cs
@@ -306,6 +306,9 @@ internal class CSongs管理 {
 								c曲リストノード.nLevelIcon = dtx.LEVELtaikoIcon;
 								c曲リストノード.uniqueId = dtx.uniqueID;
 
+								c曲リストノード.CutSceneIntro = dtx.CutSceneIntro;
+								c曲リストノード.CutSceneOutros = dtx.CutSceneOutros;
+
 								CSongDict.tAddSongNode(c曲リストノード.uniqueId, c曲リストノード);
 
 								c曲リストノード.score[n] = new CScore();

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -3525,6 +3525,7 @@ internal class CTja : CActivity {
 						});
 					}
 				}
+				this.CutSceneOutros = outros;
 			} catch (Exception ex) {
 				this.AddError($"Invalid {strCommandName} argument: {strCommandParam}: {ex.ToString()}");
 			}

--- a/OpenTaiko/src/Stages/05.SongSelect/CActCutScenePauseMenu.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActCutScenePauseMenu.cs
@@ -1,0 +1,109 @@
+﻿using System.Diagnostics;
+using FDK;
+
+namespace OpenTaiko;
+
+internal class CActCutScenePauseMenu : CActSelectPopupMenu {
+	// コンストラクタ
+
+	public CActCutScenePauseMenu() {
+		CActCutScenePauseMenuMain();
+	}
+
+	private void CActCutScenePauseMenuMain() {
+		this.bEsc有効 = false;
+		lci = new List<List<List<CItemBase>>>();                                    // この画面に来る度に、メニューを作り直す。
+		for (int nConfSet = 0; nConfSet < 2; nConfSet++) {
+			lci.Add(new List<List<CItemBase>>());                                   // ConfSet用の3つ分の枠。
+			for (int nInst = 0; nInst < 3; nInst++) {
+				lci[nConfSet].Add(null);                                        // Drum/Guitar/Bassで3つ分、枠を作っておく
+				lci[nConfSet][nInst] = MakeListCItemBase(nConfSet, nInst);
+			}
+		}
+		base.Initialize(lci[nCurrentConfigSet][0], true, CLangManager.LangInstance.GetString("PAUSE_TITLE"), 0);    // ConfSet=0, nInst=Drums
+	}
+
+	private List<CItemBase> MakeListCItemBase(int nConfigSet, int nInst) {
+		List<CItemBase> l = new List<CItemBase>();
+
+		#region [ 共通 SET切り替え/More/Return ]
+		l.Add(new CSwitchItemList(CLangManager.LangInstance.GetString("PAUSE_RESUME"), CItemBase.EPanelType.Normal, 0, "", "", new string[] { "" }));
+		l.Add(new CSwitchItemList(CLangManager.LangInstance.GetString("PAUSE_SKIP"), CItemBase.EPanelType.Normal, 0, "", "", new string[] { "", "" }));
+		#endregion
+
+		return l;
+	}
+
+	// メソッド
+	public override void tActivatePopupMenu(EInstrumentPad einst) {
+		this.CActCutScenePauseMenuMain();
+		CActSelectPopupMenu.b選択した = false;
+		base.tActivatePopupMenu(einst);
+	}
+	//public void tDeativatePopupMenu()
+	//{
+	//	base.tDeativatePopupMenu();
+	//}
+
+	public override void tEnter押下Main(int nSortOrder) {
+		switch (n現在の選択行) {
+			case (int)EOrder.Continue:
+				OpenTaiko.stageCutScene.Resume();
+				CActSelectPopupMenu.b選択した = true;
+				this.tDeativatePopupMenu();
+				break;
+
+			case (int)EOrder.Skip:
+				OpenTaiko.stageCutScene.Skip();
+				CActSelectPopupMenu.b選択した = true;
+				this.tDeativatePopupMenu();
+				break;
+			default:
+				break;
+		}
+	}
+
+	public override void tCancel() {
+	}
+
+	// CActivity 実装
+
+	public override void Activate() {
+		base.Activate();
+		this.bGotoDetailConfig = false;
+	}
+	public override void DeActivate() {
+		base.DeActivate();
+	}
+	public override void CreateManagedResource() {
+		string pathパネル本体 = CSkin.Path(@$"Graphics{Path.DirectorySeparatorChar}ScreenSelect popup auto settings.png");
+		if (File.Exists(pathパネル本体)) {
+			this.txパネル本体 = OpenTaiko.tテクスチャの生成(pathパネル本体, true);
+		}
+
+		base.CreateManagedResource();
+	}
+	public override void ReleaseManagedResource() {
+		OpenTaiko.tテクスチャの解放(ref this.txパネル本体);
+		OpenTaiko.tテクスチャの解放(ref this.tx文字列パネル);
+		base.ReleaseManagedResource();
+	}
+
+	#region [ private ]
+	//-----------------
+	private int nCurrentTarget = 0;
+	private int nCurrentConfigSet = 0;
+	private List<List<List<CItemBase>>> lci;
+	private enum EOrder : int {
+		Continue,
+		Skip,
+		END,
+		Default = 99,
+	};
+
+	private bool b選択した;
+	private CTexture txパネル本体;
+	private CTexture tx文字列パネル;
+	//-----------------
+	#endregion
+}

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
@@ -111,6 +111,7 @@ class CStageCutScene : CStage {
 
 	public override void DeActivate() {
 		// On de-activation
+		this.rVD?.Dispose();
 
 		this.cutScenes?.Clear();
 		this.cutScenes = null;
@@ -143,7 +144,6 @@ class CStageCutScene : CStage {
 		this.KeyInput();
 
 		if ((this.rVD == null || this.rVD.bFinishPlaying) && this.iCutScene < this.cutScenes!.Count) {
-			this.rVD?.Dispose();
 			while (++this.iCutScene < this.cutScenes!.Count) {
 				var cutScene = this.cutScenes[this.iCutScene];
 				if (this.LoadCutSceneAVI(cutScene)) {
@@ -190,6 +190,7 @@ class CStageCutScene : CStage {
 
 	private bool LoadCutSceneAVI(CTja.CutSceneDef cutScene) {
 		try {
+			this.rVD?.Dispose();
 			this.rVD = new CVideoDecoder(cutScene.FullPath);
 			this.rVD.InitRead();
 			this.rVD.dbPlaySpeed = 1;

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
@@ -1,0 +1,201 @@
+﻿using System.Diagnostics;
+using FDK;
+
+namespace OpenTaiko;
+
+class CStageCutScene : CStage {
+	public CStageCutScene() {
+		base.eStageID = EStage.CutScene;
+		base.ePhaseID = CStage.EPhase.Common_NORMAL;
+
+		// Load CActivity objects here
+		// base.list子Activities.Add(this.act = new CAct());
+
+		base.ChildActivities.Add(this.actAVI = new());
+		base.ChildActivities.Add(this.actFOIntro = new());
+		base.ChildActivities.Add(this.actFOOutro = new());
+	}
+
+	public override void Activate() {
+		// On activation
+
+		if (base.IsActivated)
+			return;
+
+		if (this.cutScenes == null)
+			this.LoadCutScenes(OpenTaiko.rPreviousStage);
+
+		this.iCutScene = -1;
+
+		base.ePhaseID = CStage.EPhase.Common_NORMAL;
+		this.ReturnValueAfterFadingOut = EReturnValue.Continue;
+
+		base.Activate();
+	}
+
+	public bool LoadCutScenes(CStage stageLast) {
+		var selectedSong = OpenTaiko.stageSongSelect.rChoosenSong;
+		if (stageLast == OpenTaiko.stageSongSelect
+			|| stageLast == OpenTaiko.stageDanSongSelect
+			|| stageLast == OpenTaiko.stageTowerSelect
+			) {
+			this.mode = ECutSceneMode.Intro;
+			this.cutScenes = (selectedSong.CutSceneIntro != null) ? [selectedSong.CutSceneIntro] : [];
+		} else {
+			this.mode = ECutSceneMode.Outro;
+			this.cutScenes = [..selectedSong.CutSceneOutros];
+		}
+		this.cutScenes.RemoveAll(x => !this.JudgeRequirement(x));
+		return this.cutScenes.Count > 0;
+	}
+
+	private bool JudgeRequirement(CTja.CutSceneDef cutScene) {
+		if (OpenTaiko.ConfigIni.bAutoPlay[0]) {
+			return false; // no human player, no cut scene, no repeat status
+		}
+		if (this.mode != ECutSceneMode.Intro) {
+			if (!OpenTaiko.stageResults.IsScoreValid[0]) {
+				return false; // no score register, no cut scene, no repeat status
+			}
+			int clearstatus = (int)(OpenTaiko.stageResults.ClearStatusesSaved[0] + 1); // was -1 to 3
+			int clearRequirement = (int)cutScene.ClearRequirement; // 0 to 4
+			bool met = (cutScene.RequirementRange) switch {
+				"l" => clearstatus < clearRequirement,
+				"le" => clearstatus <= clearRequirement,
+				"e" => clearstatus == clearRequirement,
+				"m" => clearstatus > clearRequirement,
+				"d" => clearstatus != clearRequirement,
+				"me" or _ => clearstatus >= clearRequirement,
+			};
+			if (!met) {
+				// TODO: Update repeat status
+				return false;
+			}
+		}
+
+		// TODO: Judge by repeat status and update repeat status
+		return true;
+	}
+
+	public override void DeActivate() {
+		// On de-activation
+
+		this.cutScenes?.Clear();
+		this.cutScenes = null;
+
+		base.DeActivate();
+	}
+
+	public override void CreateManagedResource() {
+		// Ressource allocation
+
+		base.CreateManagedResource();
+	}
+
+	public override void ReleaseManagedResource() {
+		// Ressource freeing
+
+		base.ReleaseManagedResource();
+	}
+
+	public override int Draw() {
+		if (!base.IsActivated)
+			return 0;
+
+		#region [ First draw (unused) ]
+		if (base.IsFirstDraw) {
+			base.IsFirstDraw = false;
+		}
+		#endregion
+
+		this.KeyInput();
+
+		if ((this.rVD == null || this.rVD.bFinishPlaying) && this.iCutScene < this.cutScenes!.Count) {
+			this.rVD?.Dispose();
+			while (++this.iCutScene < this.cutScenes!.Count) {
+				var cutScene = this.cutScenes[this.iCutScene];
+				if (this.LoadCutSceneAVI(cutScene)) {
+					this.actAVI.Start(this.rVD!, true);
+					break;
+				}
+			}
+		}
+
+		this.actAVI.Draw();
+
+		if (base.ePhaseID == EPhase.Common_NORMAL && !(this.iCutScene < this.cutScenes!.Count)) {
+			base.ePhaseID = EPhase.Common_FADEOUT;
+			switch (this.mode) {
+				case ECutSceneMode.Intro:
+					this.actFOIntro.tフェードアウト開始();
+					this.ReturnValueAfterFadingOut = EReturnValue.IntroFinished;
+					break;
+
+				case ECutSceneMode.Outro:
+					this.actFOOutro.tフェードアウト開始();
+					this.ReturnValueAfterFadingOut = EReturnValue.OutroFinished;
+					break;
+			}
+		}
+
+		#region [ Fading in/out transition ]
+		switch (base.ePhaseID) {
+			case CStage.EPhase.Common_FADEOUT:
+				int fadeOutDrawResult = this.mode switch {
+					ECutSceneMode.Intro => this.actFOIntro.Draw(),
+					ECutSceneMode.Outro or _ => this.actFOOutro.Draw(),
+				};
+				if (fadeOutDrawResult == 0) {
+					break;
+				}
+				return (int)this.ReturnValueAfterFadingOut;
+		}
+		#endregion
+
+		return 0;
+	}
+
+	private bool LoadCutSceneAVI(CTja.CutSceneDef cutScene) {
+		try {
+			this.rVD = new CVideoDecoder(cutScene.FullPath);
+			this.rVD.InitRead();
+			this.rVD.dbPlaySpeed = 1;
+			return true;
+		} catch (Exception e) {
+			Trace.TraceWarning(e.ToString() + "\n"
+				+ $"Failed to load cutscene video: {cutScene.FullPath}; skipped.");
+			return false;
+		}
+	}
+
+	private void KeyInput() {
+		IInputDevice keyboard = OpenTaiko.InputManager.Keyboard;
+		// TODO: Pause menu
+	}
+
+	public enum EReturnValue : int {
+		Continue,
+		IntroFinished,
+		OutroFinished,
+	}
+
+	#region [Private]
+
+	private enum ECutSceneMode {
+		Intro,
+		Outro,
+	}
+
+	private ECutSceneMode mode;
+	private EReturnValue ReturnValueAfterFadingOut;
+
+	private CAct演奏AVI actAVI;
+	private CActFIFOStart actFOIntro;
+	private CActFIFOBlack actFOOutro;
+
+	private List<CTja.CutSceneDef>? cutScenes;
+	private int iCutScene;
+	private CVideoDecoder? rVD;
+
+	#endregion
+}

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
@@ -160,7 +160,7 @@ class CStageCutScene : CStage {
 			base.ePhaseID = EPhase.Common_FADEOUT;
 			switch (this.mode) {
 				case ECutSceneMode.Intro:
-					this.actFOIntro.tフェードアウト開始();
+					this.actFOIntro.tフェードアウト開始(true);
 					this.ReturnValueAfterFadingOut = EReturnValue.IntroFinished;
 					break;
 

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
@@ -1575,23 +1575,9 @@ internal class CStageSongSelect : CStage {
 		tNotifySelectedSongChange();
 	}
 	private void t曲を選択する() {
-		// First assignation
-		this.rChoosenSong = this.actSongList.rCurrentlySelectedSong;
-		this.r確定されたスコア = this.actSongList.r現在選択中のスコア;
-
-		this.nChoosenSongDifficulty[0] = this.actSongList.n現在選択中の曲の現在の難易度レベル;
-		this.str確定された曲のジャンル = this.rChoosenSong.songGenre;
-
-		if ((this.rChoosenSong != null) && (this.r確定されたスコア != null)) {
-			this.eフェードアウト完了時の戻り値 = EReturnValue.SongSelected;
-			this.actFOtoNowLoading.tフェードアウト開始();                // #27787 2012.3.10 yyagi 曲決定時の画面フェードアウトの省略
-			base.ePhaseID = CStage.EPhase.SongSelect_FadeOutToNowLoading;
-		}
-		// TJAPlayer3.Skin.bgm選曲画面.t停止する();
-		CSongSelectSongManager.stopSong();
+		this.t曲を選択する(this.actSongList.n現在選択中の曲の現在の難易度レベル, 0);
 	}
 	public void t曲を選択する(int nCurrentLevel, int player) {
-		// Second assignation
 		this.rChoosenSong = this.actSongList.rCurrentlySelectedSong;
 		this.r確定されたスコア = this.actSongList.r現在選択中のスコア;
 

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
@@ -1185,6 +1185,7 @@ internal class CStageSongSelect : CStage {
 	public enum EReturnValue : int {
 		継続,
 		BackToTitle,
+		PlayCutSceneIntro,
 		SongSelected,
 		オプション呼び出し,
 		ConfigMenuOpened,
@@ -1585,13 +1586,27 @@ internal class CStageSongSelect : CStage {
 		this.str確定された曲のジャンル = this.rChoosenSong.songGenre;
 
 		if ((this.rChoosenSong != null) && (this.r確定されたスコア != null)) {
-			this.eフェードアウト完了時の戻り値 = EReturnValue.SongSelected;
-			this.actFOtoNowLoading.tフェードアウト開始();                // #27787 2012.3.10 yyagi 曲決定時の画面フェードアウトの省略
-			base.ePhaseID = CStage.EPhase.SongSelect_FadeOutToNowLoading;
+			if (OpenTaiko.stageCutScene.LoadCutScenes(this)) {
+				this.FadeToCutSceneIntro();
+			} else {
+				this.FadeOutToNowLoading();
+			}
 		}
 
 		// TJAPlayer3.Skin.bgm選曲画面.t停止する();
 		CSongSelectSongManager.stopSong();
+	}
+
+	private void FadeToCutSceneIntro() {
+		this.eフェードアウト完了時の戻り値 = EReturnValue.PlayCutSceneIntro;
+		this.actFIFO.tフェードアウト開始();                // #27787 2012.3.10 yyagi 曲決定時の画面フェードアウトの省略
+		base.ePhaseID = CStage.EPhase.Common_FADEOUT;
+	}
+
+	private void FadeOutToNowLoading() {
+		this.eフェードアウト完了時の戻り値 = EReturnValue.SongSelected;
+		this.actFOtoNowLoading.tフェードアウト開始();                // #27787 2012.3.10 yyagi 曲決定時の画面フェードアウトの省略
+		base.ePhaseID = CStage.EPhase.SongSelect_FadeOutToNowLoading;
 	}
 
 	// Foreach randomly selectable songs

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
@@ -7,13 +7,18 @@ internal class CAct演奏AVI : CActivity {
 
 	public CAct演奏AVI() {
 		base.IsDeActivated = true;
+		this.isCutScene = false;
 	}
 
 
 	// メソッド
 
 	public void Start(CVideoDecoder rVD) {
-		if (OpenTaiko.ConfigIni.bEnableAVI) {
+		this.Start(rVD, false);
+	}
+	public void Start(CVideoDecoder rVD, bool isCutScene) {
+		this.isCutScene = isCutScene;
+		if (this.isCutScene || OpenTaiko.ConfigIni.bEnableAVI) {
 			this.rVD = rVD;
 			if (this.rVD != null) {
 				this.ratio1 = Math.Min((float)GameWindowSize.Height / ((float)this.rVD.FrameSize.Height), (float)GameWindowSize.Width / ((float)this.rVD.FrameSize.Height));
@@ -38,7 +43,7 @@ internal class CAct演奏AVI : CActivity {
 			this.tx描画用.vcScaleRatio.X = this.ratio1;
 			this.tx描画用.vcScaleRatio.Y = this.ratio1;
 
-			if (OpenTaiko.ConfigIni.eClipDispType.HasFlag(EClipDispType.BackgroundOnly)) {
+			if (this.isCutScene || OpenTaiko.ConfigIni.eClipDispType.HasFlag(EClipDispType.BackgroundOnly)) {
 				this.tx描画用.t2D拡大率考慮描画(CTexture.RefPnt.Center, GameWindowSize.Width / 2, GameWindowSize.Height / 2);
 			}
 		}
@@ -82,6 +87,8 @@ internal class CAct演奏AVI : CActivity {
 
 	#region [ private ]
 	//-----------------
+	private bool isCutScene;
+
 	private float ratio1;
 
 	private CTexture tx描画用;

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
@@ -31,7 +31,9 @@ internal class CAct演奏AVI : CActivity {
 
 	public void Stop() => this.rVD?.Stop();
 
-	public void tPauseControl() => this.rVD?.PauseControl();
+	public void Pause() => this.rVD?.Pause();
+	public void Resume() => this.rVD?.Resume();
+	public void TogglePause() => this.rVD?.TogglePause();
 
 	public override unsafe int Draw() {
 		if (!base.IsDeActivated) {

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
@@ -37,7 +37,7 @@ internal class CAct演奏AVI : CActivity {
 
 	public override unsafe int Draw() {
 		if (!base.IsDeActivated) {
-			if (this.rVD == null || !rVD.bDrawing)
+			if (this.rVD == null || !(this.isCutScene || this.rVD.bDrawing))
 				return 0;
 
 			this.rVD.GetNowFrame(ref this.tx描画用);

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏PauseMenu.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏PauseMenu.cs
@@ -69,7 +69,7 @@ internal class CAct演奏PauseMenu : CActSelectPopupMenu {
 				SoundManager.PlayTimer.Resume();
 				OpenTaiko.Timer.Resume();
 				OpenTaiko.TJA.t全チップの再生再開();
-				OpenTaiko.stageGameScreen.actAVI.tPauseControl();
+				OpenTaiko.stageGameScreen.actAVI.Resume();
 				CActSelectPopupMenu.b選択した = true;
 				this.tDeativatePopupMenu();
 				break;

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -2356,7 +2356,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 					SoundManager.PlayTimer.Pause();
 					OpenTaiko.Timer.Pause();
 					OpenTaiko.TJA.t全チップの再生一時停止();
-					this.actAVI.tPauseControl();
+					this.actAVI.Pause();
 
 					this.bPAUSE = true;
 					this.actPauseMenu.tActivatePopupMenu(0);

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -2040,7 +2040,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				SoundManager.PlayTimer.Pause();
 				OpenTaiko.Timer.Pause();
 				OpenTaiko.TJA.t全チップの再生一時停止();
-				this.actAVI.tPauseControl();
+				this.actAVI.Pause();
 
 				this.bPAUSE = true;
 				this.actPauseMenu.tActivatePopupMenu(0);

--- a/OpenTaiko/src/Stages/08.Result/CStage結果.cs
+++ b/OpenTaiko/src/Stages/08.Result/CStage結果.cs
@@ -43,7 +43,7 @@ internal class CStage結果 : CStage {
 		base.ChildActivities.Add(this.actParameterPanel = new CActResultParameterPanel());
 		base.ChildActivities.Add(this.actSongBar = new CActResultSongBar());
 		base.ChildActivities.Add(this.actOption = new CActオプションパネル());
-		base.ChildActivities.Add(this.actFI = new CActFIFOResult());
+		base.ChildActivities.Add(this.actFIFO = new CActFIFOResult());
 		base.ChildActivities.Add(this.actFO = new CActFIFOBlack());
 	}
 
@@ -699,7 +699,7 @@ internal class CStage結果 : CStage {
 
 			if (base.IsFirstDraw) {
 				this.ct登場用 = new CCounter(0, 100, 5, OpenTaiko.Timer);
-				this.actFI.tフェードイン開始();
+				this.actFIFO.tフェードイン開始();
 				base.ePhaseID = CStage.EPhase.Common_FADEIN;
 
 				if (this.rResultSound != null) {
@@ -1335,12 +1335,17 @@ internal class CStage結果 : CStage {
 			#endregion
 
 			if (base.ePhaseID == CStage.EPhase.Common_FADEIN) {
-				if (this.actFI.Draw() != 0) {
+				if (this.actFIFO.Draw() != 0) {
 					base.ePhaseID = CStage.EPhase.Common_NORMAL;
 				}
 			} else if ((base.ePhaseID == CStage.EPhase.Common_FADEOUT))         //&& ( this.actFO.On進行描画() != 0 ) )
 			{
-				return (int)this.eフェードアウト完了時の戻り値;
+				if (this.actFIFO.Draw() != 0) {
+					bgmResultLoop.tStop();
+					OpenTaiko.Skin.bgmDanResult.tStop();
+					OpenTaiko.Skin.bgmTowerResult.tStop();
+					return (int)this.eフェードアウト完了時の戻り値;
+				}
 			}
 
 			#region [ #24609 2011.3.14 yyagi ランク更新or演奏型スキル更新時、リザルト画像をpngで保存する ]
@@ -1362,11 +1367,8 @@ internal class CStage結果 : CStage {
 				if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape)) {
 					#region [ Return to song select screen (Faster method) ]
 
-					bgmResultLoop.tStop();
-					OpenTaiko.Skin.bgmDanResult.tStop();
-					OpenTaiko.Skin.bgmTowerResult.tStop();
 					OpenTaiko.Skin.soundDecideSFX.tPlay();
-					actFI.tフェードアウト開始();
+					actFIFO.tフェードアウト開始();
 
 					if (OpenTaiko.latestSongSelect == OpenTaiko.stageSongSelect)// TJAPlayer3.stage選曲.n確定された曲の難易度[0] != (int)Difficulty.Dan)
 						if (OpenTaiko.stageSongSelect.rNowSelectedSong.rParentNode != null)
@@ -1406,16 +1408,13 @@ internal class CStage結果 : CStage {
 						if (_modalsProcessed == true) {
 							#region [ Return to song select screen ]
 
-							actFI.tフェードアウト開始();
+							actFIFO.tフェードアウト開始();
 
 							tPostprocessing();
 
 							{
 								base.ePhaseID = CStage.EPhase.Common_FADEOUT;
 								this.eフェードアウト完了時の戻り値 = E戻り値.完了;
-								bgmResultLoop.tStop();
-								OpenTaiko.Skin.bgmDanResult.tStop();
-								OpenTaiko.Skin.bgmTowerResult.tStop();
 							}
 
 							#endregion
@@ -1607,7 +1606,7 @@ internal class CStage結果 : CStage {
 
 	private CCounter ct登場用;
 	private E戻り値 eフェードアウト完了時の戻り値;
-	private CActFIFOResult actFI;
+	private CActFIFOResult actFIFO;
 	private CActFIFOBlack actFO;
 	private CActオプションパネル actOption;
 	private CActResultParameterPanel actParameterPanel;

--- a/OpenTaiko/src/Stages/08.Result/CStage結果.cs
+++ b/OpenTaiko/src/Stages/08.Result/CStage結果.cs
@@ -26,6 +26,9 @@ internal class CStage結果 : CStage {
 	public int[] nクリア = { 0, 0, 0, 0, 0 };        //0:未クリア 1:クリア 2:フルコンボ 3:ドンダフルコンボ
 	public int[] nスコアランク = { 0, 0, 0, 0, 0 };  //0:未取得 1:白粋 2:銅粋 3:銀粋 4:金雅 5:桃雅 6:紫雅 7:虹極
 	public int[] nHighScore = { 0, 0, 0, 0, 0 };
+	public bool[] IsScoreValid = [false, false, false, false, false];
+	public int[] ClearStatusesSaved = [0, 0, 0, 0, 0];
+	public int[] ScoreRanksSaved = [0, 0, 0, 0, 0];
 
 	public CChip[] r空うちドラムチップ;
 	public STDGBVALUE<CScoreIni.C演奏記録> st演奏記録;
@@ -124,6 +127,10 @@ internal class CStage結果 : CStage {
 				(OpenTaiko.stageSongSelect.actPlayOption.tGetModMultiplier(CActPlayOption.EBalancingType.SCORE, false, 3) < 1f),
 				(OpenTaiko.stageSongSelect.actPlayOption.tGetModMultiplier(CActPlayOption.EBalancingType.SCORE, false, 4) < 1f)
 			};
+
+			this.IsScoreValid = [false, false, false, false, false];
+			this.ClearStatusesSaved = [0, 0, 0, 0, 0];
+			this.ScoreRanksSaved = [0, 0, 0, 0, 0];
 
 			{
 				#region [ 初期化 ]
@@ -533,7 +540,11 @@ internal class CStage結果 : CStage {
 					}
 
 					// Unsafe function, it is the only appropriate place to call it
-					DBSaves.RegisterPlay(i, clearStatuses[i], scoreRanks[i]);
+					if (DBSaves.RegisterPlay(i, clearStatuses[i], scoreRanks[i])) {
+						this.IsScoreValid[i] = true;
+						this.ClearStatusesSaved[i] = clearStatuses[i];
+						this.ScoreRanksSaved[i] = scoreRanks[i];
+					}
 				}
 			}
 

--- a/OpenTaiko/src/Stages/13.TowerSelect/CStageTowerSelect.cs
+++ b/OpenTaiko/src/Stages/13.TowerSelect/CStageTowerSelect.cs
@@ -26,7 +26,7 @@ class CStageTowerSelect : CStage {
 			return;
 
 		base.ePhaseID = CStage.EPhase.Common_NORMAL;
-		this.eフェードアウト完了時の戻り値 = EReturnValue.Continuation;
+		this.eフェードアウト完了時の戻り値 = CStageSongSelect.EReturnValue.継続;
 
 		if (listSongs == null)
 			listSongs = OpenTaiko.Songs管理.list曲ルート_Tower;
@@ -81,10 +81,10 @@ class CStageTowerSelect : CStage {
 
 		#region [Input]
 
-		if (this.eフェードアウト完了時の戻り値 == EReturnValue.Continuation) {
+		if (this.eフェードアウト完了時の戻り値 == CStageSongSelect.EReturnValue.継続) {
 			int returnTitle() {
 				OpenTaiko.Skin.soundCancelSFX.tPlay();
-				this.eフェードアウト完了時の戻り値 = EReturnValue.ReturnToTitle;
+				this.eフェードアウト完了時の戻り値 = CStageSongSelect.EReturnValue.BackToTitle;
 				this.actFOtoTitle.tフェードアウト開始();
 				base.ePhaseID = CStage.EPhase.Common_FADEOUT;
 				return 0;
@@ -183,7 +183,7 @@ class CStageTowerSelect : CStage {
 		OpenTaiko.stageSongSelect.str確定された曲のジャンル = listSongs[nCurrentSongIndex].songGenre;
 		if ((OpenTaiko.stageSongSelect.rChoosenSong != null) && (OpenTaiko.stageSongSelect.r確定されたスコア != null)) {
 			CFloorManagement.reinitialize(OpenTaiko.stageSongSelect.rChoosenSong.score[(int)Difficulty.Tower].譜面情報.nLife);
-			this.eフェードアウト完了時の戻り値 = EReturnValue.SongChoosen;
+			this.eフェードアウト完了時の戻り値 = CStageSongSelect.EReturnValue.SongSelected;
 			this.actFOtoNowLoading.tフェードアウト開始();                // #27787 2012.3.10 yyagi 曲決定時の画面フェードアウトの省略
 			base.ePhaseID = CStage.EPhase.SongSelect_FadeOutToNowLoading;
 		}
@@ -223,7 +223,7 @@ class CStageTowerSelect : CStage {
 
 		//TJAPlayer3.Skin.sound曲決定音.t再生する();
 
-		this.eフェードアウト完了時の戻り値 = EReturnValue.SongChoosen;
+		this.eフェードアウト完了時の戻り値 = CStageSongSelect.EReturnValue.SongSelected;
 		this.actFOtoNowLoading.tフェードアウト開始();                    // #27787 2012.3.10 yyagi 曲決定時の画面フェードアウトの省略
 		base.ePhaseID = CStage.EPhase.SongSelect_FadeOutToNowLoading;
 
@@ -292,7 +292,7 @@ class CStageTowerSelect : CStage {
 	private CCachedFontRenderer pfTitleFont;
 	private CCachedFontRenderer pfSubTitleFont;
 
-	public EReturnValue eフェードアウト完了時の戻り値;
+	public CStageSongSelect.EReturnValue eフェードアウト完了時の戻り値;
 	public CActFIFOStart actFOtoNowLoading;
 	public CActFIFOBlack actFOtoTitle;
 

--- a/OpenTaiko/src/Stages/CActFIFOStart.cs
+++ b/OpenTaiko/src/Stages/CActFIFOStart.cs
@@ -6,16 +6,19 @@ namespace OpenTaiko;
 internal class CActFIFOStart : CActivity {
 	// メソッド
 
-	public void tフェードアウト開始() {
+	public void tフェードアウト開始() => tフェードアウト開始(false);
+	public void tフェードアウト開始(bool skipDelay) {
 		this.mode = EFIFOMode.FadeOut;
 
 		OpenTaiko.Skin.soundDanSelectBGM.tStop();
 		if (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] == (int)Difficulty.Dan)
-			this.counter = new CCounter(0, 1255, 1, OpenTaiko.Timer);
+			this.counter = new CCounter(skipDelay ? 1000 : 0, 1255, 1, OpenTaiko.Timer);
 		else if (OpenTaiko.ConfigIni.bAIBattleMode) {
-			this.counter = new CCounter(0, 5500, 1, OpenTaiko.Timer);
+			this.counter = new CCounter(skipDelay ? 2000 : 0, 5500, 1, OpenTaiko.Timer);
+		} else if (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] >= (int)Difficulty.Tower) {
+			this.counter = new CCounter(skipDelay ? 1000 : 0, 3580, 1, OpenTaiko.Timer);
 		} else {
-			this.counter = new CCounter(0, 3580, 1, OpenTaiko.Timer);
+			this.counter = new CCounter(skipDelay ? 2580 : 0, 3580, 1, OpenTaiko.Timer);
 		}
 	}
 	public void tフェードイン開始() {

--- a/OpenTaiko/src/Stages/CStage.cs
+++ b/OpenTaiko/src/Stages/CStage.cs
@@ -26,6 +26,7 @@ public class CStage : CActivity {
 		PlayerStats,
 		ChartEditor,
 		Toolbox,
+		CutScene,
 		TEMPLATE,           // No effect, for template class
 		CRASH,              // Special case, for CSystemError
 		CUSTOM,             // For custom stages in the future, generic with lua


### PR DESCRIPTION
~~Notice that this PR is dependent on 0auBSQ/OpenTaiko#800; merging this closes 0auBSQ/OpenTaiko#800.~~ dependencies merged.

~~Notice that this PR is dependent on 0auBSQ/OpenTaiko#804, merging this closes 0auBSQ/OpenTaiko#804.~~ dependencies merged.

## Main Features

Intro cutscene is played before the song loading screen. Outro cutscene is played after result screen.

The cutscene condition judgement is only on player 1. If player 1 uses auto mod, no cutscenes are played. Other players are considered guests

The cutscene can be paused by pressing <kbd>Esc</kbd> or <kbd>F1</kbd> to open the pause menu, which allow skipping one cutscene video at a time.

New TJA decorative headers (OpenTaiko-exclusive; subject to future changes)

* `.CUTSCENE_INTRO:<string-path>,<enum-int-repeat-mode>`
* `.CUTSCENE_OUTRO:<string-path>,<enum-int-clear-status>,<enum-str-clear-status-range>,<enum-int-repeat-mode>,...`

Explanation

* `<enum-int-clear-status>`: 0 for failed, 1 for assistant clear, 2 for clear, 3 for full combo, 4 for perfect (same for unlockable condition)
* `<enum-int-repeat-mode>` (not implemented yet, treated as 1)
    * `-1` &mdash; the cut scene is played until the requirement is first unmet.
    * `0` &mdash; the cut scene is only played when the requirement is first met
    * `1` &mdash; the cut scene is played whenever the requirement is met
* `enum-str-clear-status-range` &mdash; `l` `<`, `le` `<=`, `e` `==`, `me` `>=`, `m` `>`, `d` `!=` (defaults to `me`) (same for unlockable condition)

The last arguments can be omitted for both headers.

Arguments of `.CUTSCENE_OUTRO:` are grouped by 4, with the last group allows argument omission. All outros which can be played will be played in order.

## Behavior Changes

* feat(`CStage結果`): restore result screen fade-out transition
    * The BGM now stops when the screen is done fading out, instead of stopping immediately when the exiting input has just been done.