### PR TITLE
fix video playback issues (multiplayer crash, decoder resource release crash, `#BGAOFF` not resuming main BGA)

### DIFF
--- a/FDK/src/04.Graphics/CFrameConverter.cs
+++ b/FDK/src/04.Graphics/CFrameConverter.cs
@@ -49,14 +49,20 @@ public unsafe class CFrameConverter : IDisposable {
 	}
 
 	public void Dispose() {
-		Marshal.FreeHGlobal(_convertedFrameBufferPtr);
-		ffmpeg.sws_freeContext(convert_context);
+		if (_convertedFrameBufferPtr != 0) {
+			Marshal.FreeHGlobal(_convertedFrameBufferPtr);
+			_convertedFrameBufferPtr = 0;
+		}
+		if (convert_context != null) {
+			ffmpeg.sws_freeContext(convert_context);
+			this.convert_context = null;
+		}
 	}
 
 	private SwsContext* convert_context;
 	private readonly byte_ptrArray4 _dstData;
 	private readonly int_array4 _dstLinesize;
-	private readonly IntPtr _convertedFrameBufferPtr;
+	private IntPtr _convertedFrameBufferPtr;
 	private const AVPixelFormat CVPxfmt = AVPixelFormat.AV_PIX_FMT_RGBA;
 	private bool IsConvert = false;
 	private Size FrameSize;

--- a/FDK/src/04.Graphics/CVideoDecoder.cs
+++ b/FDK/src/04.Graphics/CVideoDecoder.cs
@@ -15,7 +15,6 @@ public unsafe class CVideoDecoder : IDisposable {
 		if (!File.Exists(filename))
 			throw new FileNotFoundException(filename + " not found...");
 
-		format_context = ffmpeg.avformat_alloc_context();
 		fixed (AVFormatContext** format_contexttmp = &format_context) {
 			if (ffmpeg.avformat_open_input(format_contexttmp, filename, null, null) != 0)
 				throw new FileLoadException("avformat_open_input failed\n");
@@ -262,7 +261,7 @@ public unsafe class CVideoDecoder : IDisposable {
 	//for read & decode
 	private bool close = false;
 	private double _dbPlaySpeed = 1.0;
-	private static AVFormatContext* format_context;
+	private AVFormatContext* format_context;
 	private AVStream* video_stream;
 	private AVCodecContext* codec_context;
 	private ConcurrentQueue<CDecodedFrame> decodedframes;

--- a/FDK/src/04.Graphics/CVideoDecoder.cs
+++ b/FDK/src/04.Graphics/CVideoDecoder.cs
@@ -62,6 +62,9 @@ public unsafe class CVideoDecoder : IDisposable {
 	}
 
 	public void Dispose() {
+		if (this.close)
+			return;
+
 		bDrawing = false;
 		close = true;
 		cts?.Cancel();

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
@@ -12,8 +12,8 @@ internal class CAct演奏AVI : CActivity {
 
 	// メソッド
 
-	public void Start(int nチャンネル番号, CVideoDecoder rVD) {
-		if (nチャンネル番号 == 0x54 && OpenTaiko.ConfigIni.bEnableAVI) {
+	public void Start(CVideoDecoder rVD) {
+		if (OpenTaiko.ConfigIni.bEnableAVI) {
 			this.rVD = rVD;
 			if (this.rVD != null) {
 				this.ratio1 = Math.Min((float)GameWindowSize.Height / ((float)this.rVD.FrameSize.Height), (float)GameWindowSize.Width / ((float)this.rVD.FrameSize.Height));

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -2822,7 +2822,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 							if ((dTX.listVD.TryGetValue(pChip.n整数値_内部番号, out CVideoDecoder vd))) {
 								ShowVideo = true;
 								if (OpenTaiko.ConfigIni.bEnableAVI && vd != null) {
-									this.actAVI.Start(pChip.nChannelNo, vd);
+									this.actAVI.Start(vd);
 									this.actAVI.Seek(pChip.VideoStartTimeMs);
 								}
 							}
@@ -2843,7 +2843,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 							if ((dTX.listVD.TryGetValue(1, out CVideoDecoder vd2))) {
 								ShowVideo = true;
 								if (OpenTaiko.ConfigIni.bEnableAVI && vd != null) {
-									this.actAVI.Start(pChip.nChannelNo, vd);
+									this.actAVI.Start(vd);
 								}
 							}
 						}
@@ -4430,7 +4430,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 						if (chip.n発声時刻ms <= nStartTime) {
 							chip.bHit = true;
 							this.actAVI.Seek(nStartTime - chip.n発声時刻ms);
-							this.actAVI.Start(0x54, this.actAVI.rVD);
+							this.actAVI.Start(this.actAVI.rVD);
 							break;
 						} else {
 							this.actAVI.Seek(0);


### PR DESCRIPTION
* fix: prevent crash due to video resource double-free access violation
* fix multiplayer video crash due to wrongly reusing `AVFormatContext`; fix 0auBSQ/OpenTaiko#636
* fix TJA `#BGMOFF` did not resume main video playback







