### PR TITLE
Revision of some Russian and Chinese Text

### DIFF
--- a/OpenTaiko/Lang/ru/lang.json
+++ b/OpenTaiko/Lang/ru/lang.json
@@ -367,7 +367,7 @@
 		"TITLE_MODE_TAIKO_DESC": "Играйте ваши любимые\nпесни в своём темпе!",
 		"TITLE_MODE_DAN_DESC": "Играйте в несколько партитурах подряд\nследующих сложных экзаменов,\nчтобы получить ранг ПРОПУСКА!",
 		"TITLE_MODE_TOWER_DESC": "Играйте в длинных партитурах с\nограниченным количеством жизней\nи доберитесь до вершины башни!",
-		"TITLE_MODE_SHOP_DESC": "Купите новые музыки,\nпти-персонажей и персонажей\nза монетам полученном из игры!",
+		"TITLE_MODE_SHOP_DESC": "Купите новые песни,\nпти-персонажей и персонажей\nза монетам полученном из игры!",
 		"TITLE_MODE_STORY_DESC": "Преодолевайте различные препятствия и\nоткрывать новый контент и горизонты!",
 		"TITLE_MODE_HEYA_DESC": "Измените вашу информацию\nили визуальные эффекты\nвашего персонажа!",
 		"TITLE_MODE_SETTINGS_DESC": "Измените ваш стиль игры\nили общие настройки!",
@@ -485,7 +485,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "Автоматически <c.#ffff00>дробит</c> со скоростью {0} удар./с",
 		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Разделяет</c> <c.#0088ff>Трассы</c>",
 		// {0}: Coin multiplier
-		"HEYA_DESCRIPTION_COIN_MULTIPLIER": "Множитель монетов: x{0}",
+		"HEYA_DESCRIPTION_COIN_MULTIPLIER": "Множитель монет: x{0}",
 
 		// Unlock requirements & messages (Any Menu)
 		"UNLOCK_CONDITION_INVALID": "[ОШИБКА] Недопустимое условие",
@@ -557,7 +557,7 @@
 		"PAUSE_TITLE": "Пауза",
 		"PAUSE_RESUME": "Продолжить",
 		"PAUSE_RESTART": "Переиграть",
-		"PAUSE_SKIP": "Пропускать",
+		"PAUSE_SKIP": "Пропустить",
 		"PAUSE_EXIT": "Выход",
 
 		// AI Info
@@ -572,7 +572,7 @@
 		"MOD_SWITCH_OFF": "Выкл.",
 		"MOD_SWITCH_ON": "Вкл.",
 		"MOD_SCOREMULTIPLY": "Множитель очков: {0}",
-		"MOD_COINMULTIPLY": "Множитель монетов: {0}",
+		"MOD_COINMULTIPLY": "Множитель монет: {0}",
 
 		"MOD_SPEED": "Скорость",
 

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -47,13 +47,13 @@
 		"SETTINGS_SYSTEM_LANGUAGE_DESC": "更改游戏及菜单的显示语言。",
 		"SETTINGS_SYSTEM_PLAYERCOUNT": "玩家数量",
 		"SETTINGS_SYSTEM_PLAYERCOUNT_DESC": "选择游玩的玩家数量，最多同时可有 5 人游玩。",
-		"SETTINGS_SYSTEM_RELOADSONG": "重新载入歌曲",
-		"SETTINGS_SYSTEM_RELOADSONG_DESC": "重新扫描歌曲文件夹并载入歌曲。",
-		"SETTINGS_SYSTEM_RELOADSONGCACHE": "重新载入歌曲（硬重新加载）",
-		"SETTINGS_SYSTEM_RELOADSONGCACHE_DESC": "清除既有缓存并从空白重新扫描歌曲文件夹并载入歌曲。",
+		"SETTINGS_SYSTEM_RELOADSONG": "重新加载歌曲",
+		"SETTINGS_SYSTEM_RELOADSONG_DESC": "重新扫描歌曲文件夹并加载歌曲。",
+		"SETTINGS_SYSTEM_RELOADSONGCACHE": "重新加载歌曲（硬重新加载）",
+		"SETTINGS_SYSTEM_RELOADSONGCACHE_DESC": "清除既有缓存并从空白重新扫描歌曲文件夹并加载歌曲。",
 
 		"SETTINGS_SYSTEM_IMPORTSCOREINI": "导入 Score.ini 文件",
-		"SETTINGS_SYSTEM_IMPORTSCOREINI_DESC": "导入 Score.ini 文件到数据库中。\n\n<c.#f0ad4e>警告\n下列内容将不会转移：\n— 过关状态\n— 游玩修改器\n— 击打数（良、可、不可、连打等）\n— 段位测验成绩",
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_DESC": "导入 Score.ini 文件到数据库中。\n\n<c.#f0ad4e>警告\n下列内容将不会迁移：\n— 过关状态\n— 游玩修改器\n— 击打数（良、可、不可、连打等）\n— 段位测验成绩",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS1": "正在搜索成绩……",
 		// {0}: Total # of score.ini files to be processed
 		// {1}: # of score.ini files successfully imported
@@ -64,7 +64,7 @@
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "正在处理 {0} 份成绩……\n<c.#0bb000>{1} ／ {2} 已处理</c>（<c.#f0ad4e>{3} 跳过</c> ／ <c.#b00000>{4} 失败</c>）\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "隐藏段位/塔",
-		"SETTINGS_SYSTEM_HIDEDANTOWER_DESC": "在太鼓模式菜单中隐藏段位和塔谱面。\n重新载入歌曲以使此选项生效。",
+		"SETTINGS_SYSTEM_HIDEDANTOWER_DESC": "在太鼓模式菜单中隐藏段位和塔谱面。\n重新加载歌曲以使此选项生效。",
 
 		// Settings - System - Graphics
 		"SETTINGS_SYSTEM_FULLSCREEN": "全屏模式",

--- a/OpenTaiko/Lang/zh/lang.json
+++ b/OpenTaiko/Lang/zh/lang.json
@@ -47,10 +47,10 @@
 		"SETTINGS_SYSTEM_LANGUAGE_DESC": "更改游戏及菜单的显示语言。",
 		"SETTINGS_SYSTEM_PLAYERCOUNT": "玩家数量",
 		"SETTINGS_SYSTEM_PLAYERCOUNT_DESC": "选择游玩的玩家数量，最多同时可有 5 人游玩。",
-		"SETTINGS_SYSTEM_RELOADSONG": "重新载入曲目",
-		"SETTINGS_SYSTEM_RELOADSONG_DESC": "重新扫描曲目文件夹并载入曲目。",
-		"SETTINGS_SYSTEM_RELOADSONGCACHE": "重新载入曲目（硬重新加载）",
-		"SETTINGS_SYSTEM_RELOADSONGCACHE_DESC": "删除既有数据库并从空白重新扫描曲目文件夹并载入曲目。",
+		"SETTINGS_SYSTEM_RELOADSONG": "重新载入歌曲",
+		"SETTINGS_SYSTEM_RELOADSONG_DESC": "重新扫描歌曲文件夹并载入歌曲。",
+		"SETTINGS_SYSTEM_RELOADSONGCACHE": "重新载入歌曲（硬重新加载）",
+		"SETTINGS_SYSTEM_RELOADSONGCACHE_DESC": "清除既有缓存并从空白重新扫描歌曲文件夹并载入歌曲。",
 
 		"SETTINGS_SYSTEM_IMPORTSCOREINI": "导入 Score.ini 文件",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_DESC": "导入 Score.ini 文件到数据库中。\n\n<c.#f0ad4e>警告\n下列内容将不会转移：\n— 过关状态\n— 游玩修改器\n— 击打数（良、可、不可、连打等）\n— 段位测验成绩",
@@ -64,14 +64,14 @@
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS2": "正在处理 {0} 份成绩……\n<c.#0bb000>{1} ／ {2} 已处理</c>（<c.#f0ad4e>{3} 跳过</c> ／ <c.#b00000>{4} 失败</c>）\n\n{5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "隐藏段位/塔",
-		"SETTINGS_SYSTEM_HIDEDANTOWER_DESC": "在太鼓模式菜单中隐藏段位和塔谱面。\n重新载入曲目以使此选项生效。",
+		"SETTINGS_SYSTEM_HIDEDANTOWER_DESC": "在太鼓模式菜单中隐藏段位和塔谱面。\n重新载入歌曲以使此选项生效。",
 
 		// Settings - System - Graphics
 		"SETTINGS_SYSTEM_FULLSCREEN": "全屏模式",
 		"SETTINGS_SYSTEM_FULLSCREEN_DESC": "切换全屏/窗口模式。",
 		"SETTINGS_SYSTEM_VSYNC": "垂直同步",
-		"SETTINGS_SYSTEM_VSYNC_DESC": "选择是否开启垂直同步。打开后帧率会上限为 60 FPS，\n音符滚动会更加顺畅，但输入延迟会增加。",
-		"SETTINGS_SYSTEM_GRAPHICSAPI": "画面渲染 API",
+		"SETTINGS_SYSTEM_VSYNC_DESC": "选择是否开启垂直同步。打开后帧率将上限为 60 FPS，\n音符卷动会更加顺畅，但输入延迟会增加。\n关闭后帧率将没有上限，减少输入延迟，但会使音符卷动\n更加不稳定。",
+		"SETTINGS_SYSTEM_GRAPHICSAPI": "图像 API",
 		"SETTINGS_SYSTEM_GRAPHICSAPI_DESC": "绘制方式：\n从 OpenGL、DirectX11、Vulkan，或 Metal 中选择。\nOpenGL 速度较慢，但稳定性和兼容性较好。\nDirectX11 较快且稳定，但只能在 Windows 上使用。\nVulkan 在 Linux 上速度最快。\nMetal 只能在 MacOS 上使用。\n\n该项设置将在重启 OpenTaiko 后生效。",
 		"SETTINGS_SYSTEM_TEXTUREASYNC": "异步贴图加载",
 		"SETTINGS_SYSTEM_TEXTUREASYNC_DESC": "贴图加载方式：\n启动画面消失时冻结。\n如果有些贴图变黑，请关闭这项设置。\n该项设置将在重启 OpenTaiko 后生效。",
@@ -108,7 +108,7 @@
 		"SETTINGS_SYSTEM_SKIN_DESC": "从 System 文件夹中选择皮肤。（安装皮肤时请将皮肤\n文件夹放入 System 文件夹中，重启游戏并在此选择）",
 
 		// Settings - System - Audio
-		"SETTINGS_SYSTEM_SONGPLAYBACK": "播放背景音乐",
+		"SETTINGS_SYSTEM_SONGPLAYBACK": "播放歌曲",
 		"SETTINGS_SYSTEM_SONGPLAYBACK_DESC": "选择是否播放音乐。",
 		"SETTINGS_SYSTEM_USESONGVOL": "应用音量（SONGVOL）元信息",
 		"SETTINGS_SYSTEM_USESONGVOL_DESC": "切换是否使用 SONGVOL 元数据的部分无效选项。\n— 0—99：降低音量\n— 100+：没有任何作用",
@@ -116,41 +116,41 @@
 		"SETTINGS_SYSTEM_SEVOL_DESC": "调整“咚”“咔”音量。\n— 0：关闭敲击音效\n你必须在调整完成该项设置后重启游戏才能应用更改。",
 		"SETTINGS_SYSTEM_VOICEVOL": "语音音量",
 		"SETTINGS_SYSTEM_VOICEVOL_DESC": "调整角色的语音音量。\n你必须在调整完成该项设置后重启游戏才能应用更改。",
-		"SETTINGS_SYSTEM_SONGVOL": "背景音乐音量",
-		"SETTINGS_SYSTEM_SONGVOL_DESC": "调整背景音乐音量。\n你必须在调整完成该项设置后重启游戏才能应用更改。",
-		"SETTINGS_SYSTEM_SONGPREVIEWVOL": "曲目预览音量",
-		"SETTINGS_SYSTEM_SONGPREVIEWVOL_DESC": "调整曲目预览音量。\n必须在调整完成该项设置后重启游戏才能应用更改。",
-		"SETTINGS_SYSTEM_VOLINCREMENT": "键盘音量更改幅度",
-		"SETTINGS_SYSTEM_VOLINCREMENT_DESC": "控制每次按下调整音量按键时音量的更改幅度。\n更改范围：1—20",
+		"SETTINGS_SYSTEM_SONGVOL": "歌曲播放音量",
+		"SETTINGS_SYSTEM_SONGVOL_DESC": "调整歌曲播放音量。\n你必须在调整完成该项设置后重启游戏才能应用更改。",
+		"SETTINGS_SYSTEM_SONGPREVIEWVOL": "歌曲预览音量",
+		"SETTINGS_SYSTEM_SONGPREVIEWVOL_DESC": "调整歌曲预览音量。\n必须在调整完成该项设置后重启游戏才能应用更改。",
+		"SETTINGS_SYSTEM_VOLINCREMENT": "键盘音量增减幅度",
+		"SETTINGS_SYSTEM_VOLINCREMENT_DESC": "控制每次按下调整音量按键时音量的增减幅度。\n更改范围：1—20",
 
-		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER": "曲目播放缓冲",
-		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER_DESC": "游戏开始前的等待时间。\n降低该值可能会导致曲目过早开始播放。",
-		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER": "曲目预览缓冲",
-		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER_DESC": "曲目预览等待时间。\n降低该值或将导致预览在滚动曲目列表时就开始播放。\n范围：0—10000ms",
+		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER": "歌曲播放缓冲",
+		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER_DESC": "歌曲播放开始前的等待时间。\n减小该值可能会导致歌曲过早开始播放。",
+		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER": "歌曲预览缓冲",
+		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER_DESC": "歌曲预览等待时间。\n减小该值或将导致预览在卷动歌曲列表时就开始播放。\n范围：0—10000ms",
 
 		"SETTINGS_SYSTEM_AUDIOPLAYBACK": "声音播放模式",
 		"SETTINGS_SYSTEM_AUDIOPLAYBACK_DESC": "ASIO：\n— 只在支持 ASIO 的音频设备上生效\n— 输入延迟最低\nWASAPI：\n— 仅与 Windows 兼容\n— 输入延迟次低\nBASS：\n— 支持所有平台\n退出设置界面以使此选项生效。",
 		"SETTINGS_SYSTEM_ASIOPLAYBACK": "ASIO 播放设备",
 		"SETTINGS_SYSTEM_ASIOPLAYBACK_DESC": "选择播放模式为 ASIO 时合适的设备。\n退出设置界面以使此选项生效。",
 		"SETTINGS_SYSTEM_WASAPIBUFFER": "WASAPI 缓冲区大小",
-		"SETTINGS_SYSTEM_WASAPIBUFFER_DESC": "调整声音播放模式为 WASAPI 时的声音缓冲。\n没有出现如曲目冻结或时间错误的声音问题时，该项设置\n越小越好。\n建议设为 0 以使用估计值或通过不断尝试进行调整。\n退出设置界面以使此选项生效。",
+		"SETTINGS_SYSTEM_WASAPIBUFFER_DESC": "调整声音播放模式为 WASAPI 时的声音缓冲。\n没有出现如歌曲冻结或时间错误的声音问题时，该项设置\n越小越好。\n建议设为 0 以使用估计值或通过不断尝试进行调整。\n退出设置界面以使此选项生效。",
 		"SETTINGS_SYSTEM_BASSBUFFER": "Bass 模式缓冲区大小",
 		"SETTINGS_SYSTEM_BASSBUFFER_DESC": "当使用 Bass 模式时的缓冲区大小：\n— 范围： 0-99999 ms\n— 0：系统决定该值的大小\n该值越小，音频卡顿/延迟会更小，但或导致声音异常或\n爆音。\n退出设置界面以使此选项生效。",
 		"SETTINGS_SYSTEM_OSTIMER": "使用系统计时器",
 		"SETTINGS_SYSTEM_OSTIMER_DESC": "开启后，音符卷动会更加流畅，但可能导致谱面与歌曲\n不同步。\n关闭会确保谱面与歌曲同步，但音符卷动会较为不流畅。",
 
 		// Settings - System - Misc.
-		"SETTINGS_SYSTEM_LOG": "创建报错记录",
+		"SETTINGS_SYSTEM_LOG": "创建日志文件",
 		"SETTINGS_SYSTEM_LOG_DESC": "选择游戏关闭时是否生成 TJAPlayer3.log 文件。\n该文件用于追踪游戏的性能并记录报错信息。",
 		"SETTINGS_SYSTEM_RANDOMSUBFOLDER": "随机选曲时访问子文件夹",
 		"SETTINGS_SYSTEM_RANDOMSUBFOLDER_DESC": "选择随机选曲时是否访问子文件夹。",
 		"SETTINGS_SYSTEM_DEBUGMODE": "调试模式",
-		"SETTINGS_SYSTEM_DEBUGMODE_DESC": "选择是否开启 Debug 模式。\n开启后右下角会显示额外信息。\n敲击音效关闭时会显示延迟校准。",
+		"SETTINGS_SYSTEM_DEBUGMODE_DESC": "选择是否开启调试模式。\n开启后右下角会显示附加信息。\n敲击音效关闭时会显示延迟校准。",
 		"SETTINGS_SYSTEM_AUTOSCREENSHOT": "自动截屏",
-		"SETTINGS_SYSTEM_AUTOSCREENSHOT_DESC": "选择是否自动保存结果自动截屏。\n只有当获得新高分时才会截屏，但最高分并不一定是最佳\n演奏。",
+		"SETTINGS_SYSTEM_AUTOSCREENSHOT_DESC": "选择是否自动截屏结果。\n只有当获得新高分时才会截屏，但最高分并不一定是最佳\n演奏。",
 		"SETTINGS_SYSTEM_DISCORDRPC": "Discord 状态显示",
-		"SETTINGS_SYSTEM_DISCORDRPC_DESC": "选择是否在 Discord 上共享曲目信息。",
-		"SETTINGS_SYSTEM_BUFFEREDINPUT": "输入缓冲模式",
+		"SETTINGS_SYSTEM_DISCORDRPC_DESC": "选择是否在 Discord 上共享歌曲信息。",
+		"SETTINGS_SYSTEM_BUFFEREDINPUT": "缓冲输入模式",
 		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "开启后，判定时间精度将不受帧率限制，且所有输入都不\n会被忽略。\n关闭后，判定时间精度将受帧率限制，且部分输入可能\n会被忽略。",
 
 		// Settings - Gameplay
@@ -162,7 +162,7 @@
 		"SETTINGS_GAME_CALIBRATION_OFFSET": "偏移量：{0}",
 
 		"SETTINGS_GAME_CONTROLLERDEADZONE": "控制器死区",
-		"SETTINGS_GAME_CONTROLLERDEADZONE_DESC": "调整所有已连接控制器的拇指杆死区。\n可以在10%到90%之间。\n\n保存后，重新连接控制器或重新启动游戏以应用更改。",
+		"SETTINGS_GAME_CONTROLLERDEADZONE_DESC": "调整所有已连接控制器的拇指杆死区。\n设定范围：10—90%\n\n保存后，重新连接控制器或重新启动游戏以应用更改。",
 
 		"SETTINGS_GAME_BADCOUNT": "完美模式",
 		"SETTINGS_GAME_BADCOUNT_DESC": "选择打出多少个“不可”时会导致演奏失败。\n— 0：禁用此选项",
@@ -178,10 +178,10 @@
 		"SETTINGS_GAME_AUTOP2": "玩家 2 自动演奏",
 		"SETTINGS_GAME_AUTOP2_DESC": "切换玩家 2 是否自动演奏。",
 		"SETTINGS_GAME_AUTOROLL": "连打速度",
-		"SETTINGS_GAME_AUTOROLL_DESC": "设置自动演奏时连打的每秒敲击次数。\n不对气球生效。\n0 关闭自动滚奏，最快每帧一次。",
+		"SETTINGS_GAME_AUTOROLL_DESC": "设置自动演奏时连打的每秒敲击次数。\n不对气球生效。\n0 关闭自动连打，最快每帧一次。",
 
 		"SETTINGS_GAME_NOINFO": "无信息模式",
-		"SETTINGS_GAME_NOINFO_DESC": "打开会关闭曲目信息显示，\n关闭会打开曲目信息显示。",
+		"SETTINGS_GAME_NOINFO_DESC": "打开会关闭歌曲信息显示，\n关闭会打开歌曲信息显示。",
 		"SETTINGS_GAME_COMBODISPLAY": "最小连击显示",
 		"SETTINGS_GAME_COMBODISPLAY_DESC": "选择开始显示连击的数量。\n范围：1—99999",
 		"SETTINGS_GAME_SCOREDISPLAY": "显示判定情况",
@@ -191,7 +191,7 @@
 
 		"SETTINGS_GAME_DEFAULTDIFF": "默认难度",
 		"SETTINGS_GAME_DEFAULTDIFF_DESC": "除非该选项被设为魔王（里）或在选择难度时\n在魔王（表）上按右方向键，魔王（里）难度不会显示。",
-		"SETTINGS_GAME_EXEXTRAANIME": "表里谱面切换动画效果",
+		"SETTINGS_GAME_EXEXTRAANIME": "表里谱面过渡效果",
 		"SETTINGS_GAME_EXEXTRAANIME_DESC": "播放由皮肤定义的表里谱面切换动画效果。",
 
 		// Settings - Gameplay - Training Mode
@@ -209,16 +209,16 @@
 		"SETTINGS_SYSTEM_IMAGEPREVIEWBUFFER": "图片预览缓冲",
 		"SETTINGS_SYSTEM_IMAGEPREVIEWBUFFER_DESC": "移植 DTXMania 导致的无效设置，没有任何作用。",
 		"SETTINGS_SYSTEM_TIMESTRETCH": "时间拉伸模式",
-		"SETTINGS_SYSTEM_TIMESTRETCH_DESC": "此选项作用不明，会导致 CPU 占用增加，\n并且当曲目播放速度低于 0.9 倍时可能会出现问题。",
+		"SETTINGS_SYSTEM_TIMESTRETCH_DESC": "此选项作用不明。\n增加 CPU 占用，且当歌曲播放速度低于 0.9 倍时可能会出\n现问题。",
 		"SETTINGS_SYSTEM_FASTRENDER": "快速渲染",
-		"SETTINGS_SYSTEM_FASTRENDER_DESC": "选择是否在加载曲目时就开始渲染图片。",
-		"SETTINGS_GAME_BRANCHGUIDE": "谱面分歧提示",
-		"SETTINGS_GAME_BRANCHGUIDE_DESC": "切换是否打开谱面分歧条件显示。\n自动演奏模式下此项不起作用。",
+		"SETTINGS_SYSTEM_FASTRENDER_DESC": "选择是否在加载歌曲时就开始渲染图片。",
+		"SETTINGS_GAME_BRANCHGUIDE": "谱面分歧导引",
+		"SETTINGS_GAME_BRANCHGUIDE_DESC": "切换是否显示谱面分歧条件数值导引。\n自动演奏模式下此项不起作用。",
 		"SETTINGS_GAME_BIGNOTEJUDGE": "大音符判断",
-		"SETTINGS_GAME_BIGNOTEJUDGE_DESC": "切换双击大音符时是否获得奖励。\n开启时单击大音符会导致音符消失前出现视觉延迟，\n双击会获得双倍分数。\n关闭时单击与敲击普通音符效果一致并会获得双倍分数。\n尝试双击或将导致下个音符被敲击。",
+		"SETTINGS_GAME_BIGNOTEJUDGE_DESC": "切换双击大音符时是否获得奖励。\n开启时单击大音符会导致音符消失前出现视觉延迟，\n双击会获得双倍得分。\n关闭时单击与敲击普通音符效果一致并会获得双倍得分。\n尝试双击或将导致下个音符被敲击。",
 		"SETTINGS_GAME_SURVIVAL": "生存模式",
 		"SETTINGS_GAME_SURVIVAL_DESC": "此模式不可用。\n此模式实现了一个类似 StepMania 的计时器系统，\n但部分代码缺失导致功能受限。",
-		"SETTINGS_GAME_SCOREMODE": "记分模式",
+		"SETTINGS_GAME_SCOREMODE": "计分模式",
 		"SETTINGS_GAME_SCOREMODE_DESC": "— TYPE-A：第一代\n— TYPE-B：第二代\n— TYPE-C：第三代",
 		"SETTINGS_GAME_SHINUCHI": "真打模式",
 		"SETTINGS_GAME_SHINUCHI_DESC": "使所有音符得分相同，\n使用第四代公式。",
@@ -325,10 +325,10 @@
 		"SETTINGS_KEYASSIGN_TRAINING_INCREASESCROLL_DESC": "鼓按键分配：\n分配提高卷动速度按键。",
 		"SETTINGS_KEYASSIGN_TRAINING_DECREASESCROLL": "降低卷动速度",
 		"SETTINGS_KEYASSIGN_TRAINING_DECREASESCROLL_DESC": "鼓按键分配：\n分配降低卷动速度按键。",
-		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED": "提高音乐播放速度",
-		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED_DESC": "鼓按键分配：\n分配提高音乐播放速度按键。",
-		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED": "降低音乐播放速度",
-		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED_DESC": "鼓按键分配：\n分配降低音乐播放速度按键。",
+		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED": "提高歌曲播放速度",
+		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED_DESC": "鼓按键分配：\n分配提高歌曲播放速度按键。",
+		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED": "降低歌曲播放速度",
+		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED_DESC": "鼓按键分配：\n分配降低歌曲播放速度按键。",
 		"SETTINGS_KEYASSIGN_TRAINING_BRANCHNORMAL": "切换分歧为普通谱面",
 		"SETTINGS_KEYASSIGN_TRAINING_BRANCHNORMAL_DESC": "鼓按键分配：\n分配切换分歧为普通谱面按键。",
 		"SETTINGS_KEYASSIGN_TRAINING_BRANCHEXPERT": "切换分歧为进阶谱面",
@@ -364,10 +364,10 @@
 		"TITLE_MODE_EDITOR": "谱面编辑器",
 		"TITLE_MODE_TOOLS": "开放工具箱",
 
-		"TITLE_MODE_TAIKO_DESC": "按照您自己的节奏演奏曲目！",
+		"TITLE_MODE_TAIKO_DESC": "按照您自己的节奏演奏歌曲！",
 		"TITLE_MODE_DAN_DESC": "连续演奏多个谱面并通过挑战测试！",
-		"TITLE_MODE_TOWER_DESC": "在限定条命内演奏长谱面并到达塔顶！",
-		"TITLE_MODE_SHOP_DESC": "使用游戏中获得的金币购买曲目和角色！",
+		"TITLE_MODE_TOWER_DESC": "在限定次机会内演奏长谱面并到达塔顶！",
+		"TITLE_MODE_SHOP_DESC": "使用游戏中获得的金币购买歌曲和角色！",
 		"TITLE_MODE_STORY_DESC": "克服各种障碍来获得新内容！",
 		"TITLE_MODE_HEYA_DESC": "更改名牌信息或角色外观！",
 		"TITLE_MODE_SETTINGS_DESC": "更改游戏风格或设置！",
@@ -382,9 +382,9 @@
 		// Song Select
 		// {0}: Folder path
 		"SONGSELECT_RETURN_PATH": "返回（{0}）",
-		"SONGSELECT_RANDOM": "随机曲目",
+		"SONGSELECT_RANDOM": "随机歌曲",
 		// {0}: Folder path
-		"SONGSELECT_RANDOM_PATH": "随机曲目（{0}）",
+		"SONGSELECT_RANDOM_PATH": "随机歌曲（{0}）",
 
 		"SONGSELECT_SORT": "排序菜单",
 		"SONGSELECT_SORT_PATH": "文件路径",
@@ -422,7 +422,7 @@
 		"ONLINE_EXIT": "返回主菜单",
 		"ONLINE_DOWNLOAD": "下载内容",
 		"ONLINE_DOWNLOAD_CDN": "选择 CDN 服务器",
-		"ONLINE_DOWNLOAD_SONG": "下载曲目",
+		"ONLINE_DOWNLOAD_SONG": "下载歌曲",
 		"ONLINE_DOWNLOAD_CHARA": "下载角色（不可用）",
 		"ONLINE_DOWNLOAD_PUCHI": "下载迷你角色（不可用）",
 		"ONLINE_MULTIPLAYER": "在线多人（不可用）",
@@ -430,7 +430,7 @@
 		// Taiko Towers
 		"TOWER_FLOOR_REACHED": "到达楼层",
 		"TOWER_FLOOR_INITIAL": "层",
-		"TOWER_SCORE": "分数",
+		"TOWER_SCORE": "得分",
 		"TOWER_SCORE_INITIAL": "点",
 
 		// Dan Dojo
@@ -438,13 +438,13 @@
 		"DAN_CONDITION_NAME_GOOD": "“良”数",
 		"DAN_CONDITION_NAME_OK": "“可”数",
 		"DAN_CONDITION_NAME_BAD": "“不可”数",
-		"DAN_CONDITION_NAME_SCORE": "分数",
+		"DAN_CONDITION_NAME_SCORE": "得分",
 		"DAN_CONDITION_NAME_ROLL": "连打数",
 		"DAN_CONDITION_NAME_HIT": "击打数",
 		"DAN_CONDITION_NAME_COMBO": "连击",
 		"DAN_CONDITION_NAME_ACCURACY": "准确率",
-		"DAN_CONDITION_NAME_ADLIB": "隐藏音符",
-		"DAN_CONDITION_NAME_BOMB": "踩中地雷",
+		"DAN_CONDITION_NAME_ADLIB": "ADLib音符",
+		"DAN_CONDITION_NAME_BOMB": "击中炸弹",
 
 		// Heya / Quick Heya
 		"HEYA_PUCHI": "迷你角色",
@@ -571,10 +571,10 @@
 		"MOD_BLANK": "-",
 		"MOD_SWITCH_OFF": "关闭",
 		"MOD_SWITCH_ON": "开启",
-		"MOD_SCOREMULTIPLY": "分数倍率：{0}",
+		"MOD_SCOREMULTIPLY": "得分倍率：{0}",
 		"MOD_COINMULTIPLY": "金币倍率：{0}",
 
-		"MOD_SPEED": "速度",
+		"MOD_SPEED": "卷动速度",
 
 		"MOD_HIDE": "隐藏音符",
 		"MOD_STEALTH": "隐形",
@@ -582,8 +582,8 @@
 		"MOD_FLIP": "翻转",
 
 		"MOD_RANDOM": "随机",
-		"MOD_RANDOM_SHUFFLE": "轻度",
-		"MOD_RANDOM_CHAOS": "重度",
+		"MOD_RANDOM_SHUFFLE": "洗牌",
+		"MOD_RANDOM_CHAOS": "混沌",
 
 		"MOD_TIMING": "时机判断",
 		"MOD_TIMING1": "非常宽松",
@@ -601,12 +601,12 @@
 		"MOD_GAMETYPE_KONGA": "康加鼓",
 
 		"MOD_GAMEMODE": "游戏模式",
-		"MOD_GAMEMODE_TRAINING": "特训模式",
+		"MOD_GAMEMODE_TRAINING": "训练模式",
 
 		"MOD_AUTO": "自动",
 
-		"MOD_SONGSPEED": "曲目播放速度",
-		"SETTINGS_MOD_SONGSPEED_DESC": "调整曲目播放速度。\n当时间拉伸模式开启，且曲目播放速度低于 0.9 倍时可能\n会出现问题。\n提示：此选项会影响曲目音高。",
+		"MOD_SONGSPEED": "歌曲播放速度",
+		"SETTINGS_MOD_SONGSPEED_DESC": "调整歌曲播放速度。\n当时间拉伸模式开启，且歌曲播放速度低于 0.9 倍时可能\n会出现问题。\n提示：此选项会影响歌曲音高。",
 
 		"MOD_HITSOUND": "音色",
 
@@ -615,7 +615,7 @@
 		"MOD_FUN_MINESWEEPER": "扫雷"
 	},
   // In the case that a key is missing, this message will display, with the name of the missing/unknown key.
-  "InvalidKey": "键值找不到：{0}",
+  "InvalidKey": "键找不到：{0}",
   // If a skin does not include a font for a specific language, the game will fallback to this language's fonts. This ensures that all text for all languages can be clearly read.
   // Font name can be a file, or the name of an already installed font (i.e. "Arial"). If using a font name instead of a file name, please ensure that the user already has this font installed on their computer.
   "FontName": "SourceHanSansSC-Medium.otf",


### PR DESCRIPTION
1. Revised some Chinese texts by referencing English text after enjoying most my achievements for a couple of months with discovering inconsistencies of terms.
2. Skip button in Russian should use the perfective form of «пропустить». However, I still appreciate that @IepIweidieng knows using infinitive, or the base form on the action button in French, Spanish and Russian. Other few terms are also revised.