### PR TITLE
fix: prevent null-reference crash due to cutscenes were undefined in pre-0.6.0.52 song list cache

### DIFF
--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -429,7 +429,7 @@ internal class CTja : CActivity {
 	}
 
 	public CutSceneDef? CutSceneIntro;
-	public List<CutSceneDef> CutSceneOutros;
+	public List<CutSceneDef> CutSceneOutros = [];
 
 	#endregion
 

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
@@ -79,7 +79,7 @@ class CStageCutScene : CStage {
 			this.cutScenes = (selectedSong.CutSceneIntro != null) ? [selectedSong.CutSceneIntro] : [];
 		} else {
 			this.mode = ECutSceneMode.Outro;
-			this.cutScenes = [..selectedSong.CutSceneOutros];
+			this.cutScenes = (selectedSong.CutSceneOutros != null) ? [..selectedSong.CutSceneOutros] : [];
 		}
 		this.cutScenes.RemoveAll(x => !this.JudgeRequirement(x));
 		return this.cutScenes.Count > 0;


### PR DESCRIPTION
Fixes 0auBSQ/OpenTaiko#802.

How to test: back up the `songlist.db` for test build, copy `songlist.db` from old version into the test build, launch test build and do not hard reload song list, play any song already in the old `songlist.db` and without cutscenes.