### PR TITLE
Change scaling method from nearest neighbor to bilinear

### DIFF
--- a/FDK/src/04.Graphics/CTexture.cs
+++ b/FDK/src/04.Graphics/CTexture.cs
@@ -434,8 +434,8 @@ public class CTexture : IDisposable {
 		//-----
 
 		//拡大縮小の時の補完を指定------
-		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMinFilter, (int)TextureMinFilter.Nearest); //この場合は補完しない
-		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMagFilter, (int)TextureMinFilter.Nearest);
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMinFilter, (int)TextureMinFilter.Linear); //この場合は補完しない
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMagFilter, (int)TextureMagFilter.Linear);
 		//------
 
 		Game.Gl.BindTexture(TextureTarget.Texture2D, 0); //バインドを解除することを忘れないように


### PR DESCRIPTION
With nearest neighbor interpolation, the game looks very pixelated if it's not running at its native resolution. Bilinear interpolation can be used instead to avoid that issue.