### PR TITLE
fix character animation issues at high BPM including crashes

### DIFF
--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -563,8 +563,8 @@ internal class CActImplCharacter : CActivity {
 					if (CharaAction_Balloon_FadeOut[i].Counter.IsStoped && nNowCharaFrame[i] > CharaAction_Balloon_FadeOut_StartMs[i][0]) {
 						CharaAction_Balloon_FadeOut[i].Start();
 					}
-					float kusuOutX = ((1.0f - MathF.Cos(nNowCharaCounter[i] * MathF.PI)) * OpenTaiko.Skin.Resolution[0] / 2.0f) * resolutionScaleX;
-					float kusuOutY = (MathF.Sin(nNowCharaCounter[i] * MathF.PI / 2) * OpenTaiko.Skin.Resolution[1] / 2.0f) * resolutionScaleY;
+					float kusuOutX = ((1.0f - MathF.Cos(Math.Min(1, nNowCharaCounter[i]) * MathF.PI)) * OpenTaiko.Skin.Resolution[0] / 2.0f) * resolutionScaleX;
+					float kusuOutY = (MathF.Sin(Math.Min(1, nNowCharaCounter[i]) * MathF.PI / 2) * OpenTaiko.Skin.Resolution[1] / 2.0f) * resolutionScaleY;
 
 					if (OpenTaiko.Skin.Characters_Kusudama_Broke_Ptn[this.iCurrentCharacter[i]] != 0 && OpenTaiko.Tx.Characters_Kusudama_Broke[this.iCurrentCharacter[i]][nNowCharaFrame[i]] != null) {
 						OpenTaiko.Tx.Characters_Kusudama_Broke[this.iCurrentCharacter[i]][nNowCharaFrame[i]].Opacity = nowOpacity;
@@ -595,7 +595,7 @@ internal class CActImplCharacter : CActivity {
 						CharaAction_Balloon_FadeOut[i].Start();
 					}
 
-					float kusuOutY = (Math.Max(nNowCharaCounter[i] - 0.5f, 0) * OpenTaiko.Skin.Resolution[1] * 2) * resolutionScaleY;
+					float kusuOutY = (Math.Max(Math.Min(1, nNowCharaCounter[i]) - 0.5f, 0) * OpenTaiko.Skin.Resolution[1] * 2) * resolutionScaleY;
 
 					if (OpenTaiko.Skin.Characters_Kusudama_Miss_Ptn[this.iCurrentCharacter[i]] != 0 && OpenTaiko.Tx.Characters_Kusudama_Miss[this.iCurrentCharacter[i]][nNowCharaFrame[i]] != null) {
 						OpenTaiko.Tx.Characters_Kusudama_Miss[this.iCurrentCharacter[i]][nNowCharaFrame[i]].Opacity = nowOpacity;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -151,11 +151,23 @@ internal class CActImplCharacter : CActivity {
 			ctKusuIn[i].Tick();
 
 			bool endAnime = nNowCharaCounter[i] >= 1;
-			if (endAnime)
-				nNowCharaFrame[i] = nCharaFrameCount[i]; // max, to prevent a huge-value counter from overflowing the int
-			else
+
+			void getNowCharaFrame(double speed = 1.0) {
+				if (endAnime)
+					nNowCharaFrame[i] = nCharaFrameCount[i]; // max, to prevent a huge-value counter from overflowing the int
+				else
+					nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * speed * (nCharaFrameCount[i] + 1));
+				nNowCharaFrame[i] = Math.Clamp(nNowCharaFrame[i], 0, nCharaFrameCount[i]);
+			}
+
+			void getNowCharaFrameLooped() {
+				if (double.IsFinite(nNowCharaCounter[i]))
+					nNowCharaCounter[i] %= 1;
+				else
+					nNowCharaCounter[i] = 0;
 				nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * (nCharaFrameCount[i] + 1));
-			nNowCharaFrame[i] = Math.Min(nNowCharaFrame[i], nCharaFrameCount[i]);
+				nNowCharaFrame[i] = Math.Clamp(nNowCharaFrame[i], 0, nCharaFrameCount[i]);
+			}
 
 			if (eNowAnime[i] != Anime.None) {
 				switch (eNowAnime[i]) {
@@ -164,56 +176,42 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Normal: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_Normal[Character][OpenTaiko.Skin.Characters_Motion_Normal[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.Miss: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_Normal_Missed[Character][OpenTaiko.Skin.Characters_Motion_Miss[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.MissDown: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_Normal_MissedDown[Character][OpenTaiko.Skin.Characters_Motion_MissDown[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.Cleared: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_Normal_Cleared[Character][OpenTaiko.Skin.Characters_Motion_Clear[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.Maxed: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_Normal_Maxed[Character][OpenTaiko.Skin.Characters_Motion_ClearMax[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.MissIn: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_MissIn[Character] != null && OpenTaiko.Skin.Characters_MissIn_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_MissIn[Character][OpenTaiko.Skin.Characters_Motion_MissIn[Character][nNowCharaFrame[i]]];
@@ -224,6 +222,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.MissDownIn: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_MissDownIn[Character] != null && OpenTaiko.Skin.Characters_MissDownIn_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_MissDownIn[Character][OpenTaiko.Skin.Characters_Motion_MissDownIn[Character][nNowCharaFrame[i]]];
@@ -234,26 +233,21 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.GoGoTime: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_GoGoTime[Character][OpenTaiko.Skin.Characters_Motion_GoGo[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.GoGoTime_Maxed: {
+							getNowCharaFrameLooped();
 							updateNormal();
 							ReturnDefaultAnime(i, false);
 							nowChara = OpenTaiko.Tx.Characters_GoGoTime_Maxed[Character][OpenTaiko.Skin.Characters_Motion_GoGoMax[Character][nNowCharaFrame[i]]];
-							if (endAnime) {
-								nNowCharaCounter[i] = 0;
-								nNowCharaFrame[i] = 0;
-							}
 						}
 						break;
 					case Anime.Combo10: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_10Combo[Character] != null && OpenTaiko.Skin.Characters_10Combo_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_10Combo[Character][OpenTaiko.Skin.Characters_Motion_10Combo[Character][nNowCharaFrame[i]]];
@@ -264,6 +258,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Combo10_Clear: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_10Combo_Clear[Character] != null && OpenTaiko.Skin.Characters_10Combo_Clear_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_10Combo_Clear[Character][OpenTaiko.Skin.Characters_Motion_10Combo_Clear[Character][nNowCharaFrame[i]]];
@@ -274,6 +269,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Combo10_Max: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_10Combo_Maxed[Character] != null && OpenTaiko.Skin.Characters_10Combo_Maxed_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_10Combo_Maxed[Character][OpenTaiko.Skin.Characters_Motion_10ComboMax[Character][nNowCharaFrame[i]]];
@@ -284,6 +280,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.GoGoStart: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_GoGoStart[Character] != null && OpenTaiko.Skin.Characters_GoGoStart_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_GoGoStart[Character][OpenTaiko.Skin.Characters_Motion_GoGoStart[Character][nNowCharaFrame[i]]];
@@ -294,6 +291,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.GoGoStart_Clear: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_GoGoStart_Clear[Character] != null && OpenTaiko.Skin.Characters_GoGoStart_Clear_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_GoGoStart_Clear[Character][OpenTaiko.Skin.Characters_Motion_GoGoStart_Clear[Character][nNowCharaFrame[i]]];
@@ -304,6 +302,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.GoGoStart_Max: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_GoGoStart_Maxed[Character] != null && OpenTaiko.Skin.Characters_GoGoStart_Maxed_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_GoGoStart_Maxed[Character][OpenTaiko.Skin.Characters_Motion_GoGoStartMax[Character][nNowCharaFrame[i]]];
@@ -314,6 +313,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Become_Cleared: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_Become_Cleared[Character] != null && OpenTaiko.Skin.Characters_Become_Cleared_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_Become_Cleared[Character][OpenTaiko.Skin.Characters_Motion_ClearIn[Character][nNowCharaFrame[i]]];
@@ -324,6 +324,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Become_Maxed: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_Become_Maxed[Character] != null && OpenTaiko.Skin.Characters_Become_Maxed_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_Become_Maxed[Character][OpenTaiko.Skin.Characters_Motion_SoulIn[Character][nNowCharaFrame[i]]];
@@ -334,6 +335,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.SoulOut: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_SoulOut[Character] != null && OpenTaiko.Skin.Characters_SoulOut_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_SoulOut[Character][OpenTaiko.Skin.Characters_Motion_SoulOut[Character][nNowCharaFrame[i]]];
@@ -344,6 +346,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.ClearOut: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_ClearOut[Character] != null && OpenTaiko.Skin.Characters_ClearOut_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_ClearOut[Character][OpenTaiko.Skin.Characters_Motion_ClearOut[Character][nNowCharaFrame[i]]];
@@ -354,6 +357,7 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Return: {
+							getNowCharaFrame();
 							updateNormal();
 							if (OpenTaiko.Tx.Characters_Return[Character] != null && OpenTaiko.Skin.Characters_Return_Ptn[Character] != 0) {
 								nowChara = OpenTaiko.Tx.Characters_Return[Character][OpenTaiko.Skin.Characters_Motion_Return[Character][nNowCharaFrame[i]]];
@@ -369,15 +373,12 @@ internal class CActImplCharacter : CActivity {
 					case Anime.Kusudama_Idle:
 					case Anime.Kusudama_Breaking:
 					case Anime.Kusudama_Broke: {
+							getNowCharaFrame();
 							updateBalloon();
 						}
 						break;
 					case Anime.Kusudama_Miss: {
-							if (endAnime)
-								nNowCharaFrame[i] = nCharaFrameCount[i]; // max, to prevent a huge-value counter from overflowing the int
-							else
-								nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * 2 * (nCharaFrameCount[i] + 1));
-							nNowCharaFrame[i] = Math.Clamp(nNowCharaFrame[i], 0, nCharaFrameCount[i]);
+							getNowCharaFrame(2); // ?
 							updateBalloon();
 						}
 						break;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -151,7 +151,10 @@ internal class CActImplCharacter : CActivity {
 			ctKusuIn[i].Tick();
 
 			bool endAnime = nNowCharaCounter[i] >= 1;
-			nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * (nCharaFrameCount[i] + 1));
+			if (endAnime)
+				nNowCharaFrame[i] = nCharaFrameCount[i]; // max, to prevent a huge-value counter from overflowing the int
+			else
+				nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * (nCharaFrameCount[i] + 1));
 			nNowCharaFrame[i] = Math.Min(nNowCharaFrame[i], nCharaFrameCount[i]);
 
 			if (eNowAnime[i] != Anime.None) {
@@ -370,8 +373,11 @@ internal class CActImplCharacter : CActivity {
 						}
 						break;
 					case Anime.Kusudama_Miss: {
-							nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * 2 * (nCharaFrameCount[i] + 1));
-							nNowCharaFrame[i] = Math.Min(nNowCharaFrame[i], nCharaFrameCount[i]);
+							if (endAnime)
+								nNowCharaFrame[i] = nCharaFrameCount[i]; // max, to prevent a huge-value counter from overflowing the int
+							else
+								nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * 2 * (nCharaFrameCount[i] + 1));
+							nNowCharaFrame[i] = Math.Clamp(nNowCharaFrame[i], 0, nCharaFrameCount[i]);
 							updateBalloon();
 						}
 						break;


### PR DESCRIPTION
* fix high BPM (e.g., 10¹⁶ or 10000000000000000 BPM) caused crash due to character frame index overflowed by huge-valued frame counter
* fix looped character animation had each loop delayed to align to drawing frame
* fix exiting Kusudama flew too far when BPM is high

The 10¹⁶ or 10000000000000000 BPM:
![image](https://github.com/user-attachments/assets/0ceae2ed-6bc5-4389-929f-20785258b33f)