### PR TITLE
redo "fix character animation issues at high BPM including crashes" (#835) with crash fix

### DIFF
--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -152,12 +152,13 @@ internal class CActImplCharacter : CActivity {
 
 			bool endAnime = nNowCharaCounter[i] >= 1;
 
+			// Notice that nCharaFrameCount is -1 when no frames are defined
 			void getNowCharaFrame(double speed = 1.0) {
 				if (endAnime)
-					nNowCharaFrame[i] = nCharaFrameCount[i]; // max, to prevent a huge-value counter from overflowing the int
+					nNowCharaFrame[i] = Math.Max(0, nCharaFrameCount[i]); // to prevent a huge-value counter from overflowing the int
 				else
 					nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * speed * (nCharaFrameCount[i] + 1));
-				nNowCharaFrame[i] = Math.Clamp(nNowCharaFrame[i], 0, nCharaFrameCount[i]);
+				nNowCharaFrame[i] = Math.Max(0, Math.Min(nNowCharaFrame[i], nCharaFrameCount[i]));
 			}
 
 			void getNowCharaFrameLooped() {
@@ -166,7 +167,7 @@ internal class CActImplCharacter : CActivity {
 				else
 					nNowCharaCounter[i] = 0;
 				nNowCharaFrame[i] = (int)(nNowCharaCounter[i] * (nCharaFrameCount[i] + 1));
-				nNowCharaFrame[i] = Math.Clamp(nNowCharaFrame[i], 0, nCharaFrameCount[i]);
+				nNowCharaFrame[i] = Math.Max(0, Math.Min(nNowCharaFrame[i], nCharaFrameCount[i]));
 			}
 
 			if (eNowAnime[i] != Anime.None) {


### PR DESCRIPTION
This fixes the crash issue in 0auBSQ/OpenTaiko#835, when the character has no frames defined for a played animation.