### PR TITLE
Fix discarded disruption

### DIFF
--- a/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageCutScene.cs
@@ -117,6 +117,7 @@ class CStageCutScene : CStage {
 		// On de-activation
 		this.StopSound();
 		this.rVD?.Dispose();
+		this.rVD = null;
 
 		this.cutScenes?.Clear();
 		this.cutScenes = null;

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏AVI.cs
@@ -95,7 +95,7 @@ internal class CAct演奏AVI : CActivity {
 
 	private CTexture tx描画用;
 
-	public CVideoDecoder rVD;
+	public CVideoDecoder? rVD;
 
 	//-----------------
 	#endregion

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -278,7 +278,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 
 		// Double play set here
-		this.bDoublePlay = OpenTaiko.ConfigIni.nPlayerCount >= 2 ? true : false;
+		this.isMultiPlay = OpenTaiko.ConfigIni.nPlayerCount >= 2 ? true : false;
 
 		this.nLoopCount_Clear = 1;
 
@@ -706,7 +706,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 	protected CSound[] soundBlue = new CSound[5];
 	protected CSound[] soundAdlib = new CSound[5];
 	protected CSound[] soundClap = new CSound[5];
-	public bool bDoublePlay; // 2016.08.21 kairera0467 表示だけ。
+	public bool isMultiPlay; // 2016.08.21 kairera0467 表示だけ。
 	protected Stopwatch sw;     // 2011.6.13 最適化検討用のストップウォッチ
 	public int ListDan_Number;
 	private bool IsDanFailed;

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -2509,7 +2509,12 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 
 	protected void t進行描画_AVI() {
-		if (((base.ePhaseID != CStage.EPhase.Game_STAGE_FAILED) && (base.ePhaseID != CStage.EPhase.Game_STAGE_FAILED_FadeOut)) && OpenTaiko.ConfigIni.bEnableAVI) {
+		if (((base.ePhaseID == CStage.EPhase.Game_STAGE_FAILED) || (base.ePhaseID == CStage.EPhase.Game_STAGE_FAILED_FadeOut))
+			&& (this.actAVI?.rVD.bPlaying ?? false)
+			) {
+			this.actAVI.Pause(); // paused but still shown
+		}
+		if (OpenTaiko.ConfigIni.bEnableAVI) {
 			this.actAVI.Draw();
 		}
 	}

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -409,6 +409,8 @@ internal abstract class CStage演奏画面共通 : CStage {
 		queueMixerSound = null;
 		//			GCSettings.LatencyMode = this.gclatencymode;
 
+		this.actAVI.rVD = null; // Will be disposed by TJA.DeActivate() later
+
 		var meanLag = CLagLogger.LogAndReturnMeanLag();
 
 		this.actDan.IsAnimating = false;// IsAnimating=trueのときにそのまま選曲画面に戻ると、文字列が描画されない問題修正用。
@@ -4318,6 +4320,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		}
 		this.objHandlers.Clear();
 
+		this.actAVI.rVD = null;
 		if ((OpenTaiko.TJA.listVD.TryGetValue(1, out CVideoDecoder vd2))) {
 			ShowVideo = true;
 		} else {
@@ -4415,24 +4418,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 							}
 							#endregion
 						}
-					}
-				}
-			}
-			#endregion
-			#region [ 演奏開始時点で既に表示されているBGAとAVIの、シークと再生 ]
-			if (tjai.listVD.Count > 0) {
-				for (int i = 0; i < iLastChipAtStart[nPlayer]; i++) {
-					CChip chip = tjai.listChip[i];
-					if (chip.nChannelNo == 0x54) {
-						if (chip.n発声時刻ms <= nStartTime) {
-							chip.bHit = true;
-							this.actAVI.Seek(nStartTime - chip.n発声時刻ms);
-							this.actAVI.Start(this.actAVI.rVD);
-							break;
-						} else {
-							this.actAVI.Seek(0);
-						}
-						break;
 					}
 				}
 			}

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -2510,7 +2510,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 	}
 
 
-	protected void t進行描画_AVI() {
+	protected bool t進行描画_AVI() {
 		if (((base.ePhaseID == CStage.EPhase.Game_STAGE_FAILED) || (base.ePhaseID == CStage.EPhase.Game_STAGE_FAILED_FadeOut))
 			&& (this.actAVI?.rVD.bPlaying ?? false)
 			) {
@@ -2518,7 +2518,9 @@ internal abstract class CStage演奏画面共通 : CStage {
 		}
 		if (OpenTaiko.ConfigIni.bEnableAVI) {
 			this.actAVI.Draw();
+			return true;
 		}
+		return false;
 	}
 	protected void t進行描画_STAGEFAILED() {
 		// Transition for failed games
@@ -4503,10 +4505,12 @@ internal abstract class CStage演奏画面共通 : CStage {
 			this.actPlayInfo.Draw();
 		}
 	}
-	protected void t進行描画_背景() {
+	protected bool t進行描画_背景() {
 		if (this.txBgImage != null) {
 			this.txBgImage.t2D描画(0, 0);
+			return true;
 		}
+		return false;
 	}
 
 	protected void t進行描画_判定文字列1_通常位置指定の場合() {

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBackground.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBackground.cs
@@ -528,7 +528,7 @@ internal class CActImplBackground : CActivity {
 			ctFailAnimation?.Tick();
 
 			#endregion
-		} else if (!OpenTaiko.stageGameScreen.bDoublePlay && OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan) {
+		} else if (!OpenTaiko.stageGameScreen.isMultiPlay && OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan) {
 			if (!IsDownNotFound) {
 				if (!OpenTaiko.stageGameScreen.bPAUSE) DownScript?.Update();
 				DownScript?.Draw();

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -494,7 +494,7 @@ internal class CActImplLaneTaiko : CActivity {
 		if (OpenTaiko.ConfigIni.nPlayerCount <= 2) {
 			if (OpenTaiko.Tx.Lane_Background_Sub != null) {
 				OpenTaiko.Tx.Lane_Background_Sub.t2D描画(OpenTaiko.Skin.Game_Lane_Sub_X[0], OpenTaiko.Skin.Game_Lane_Sub_Y[0]);
-				if (OpenTaiko.stageGameScreen.bDoublePlay) {
+				if (OpenTaiko.stageGameScreen.isMultiPlay) {
 					OpenTaiko.Tx.Lane_Background_Sub.t2D描画(OpenTaiko.Skin.Game_Lane_Sub_X[1], OpenTaiko.Skin.Game_Lane_Sub_Y[1]);
 				}
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMob.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplMob.cs
@@ -49,7 +49,7 @@ internal class CActImplMob : CActivity {
 	}
 
 	public override int Draw() {
-		if (!OpenTaiko.stageGameScreen.bDoublePlay) {
+		if (!OpenTaiko.stageGameScreen.isMultiPlay) {
 			if (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Tower && OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan) {
 				if (!OpenTaiko.stageGameScreen.bPAUSE) MobScript?.Update();
 				MobScript?.Draw();

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplRollEffect.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplRollEffect.cs
@@ -21,7 +21,7 @@ internal class CActImplRollEffect : CActivity {
 				RollCharas[i].Type = random.Next(0, OpenTaiko.Skin.Game_Effect_Roll_Ptn);
 				RollCharas[i].OldValue = 0;
 				RollCharas[i].Counter = new CCounter(0, 5000, 1, OpenTaiko.Timer);
-				if (OpenTaiko.stageGameScreen.bDoublePlay) {
+				if (OpenTaiko.stageGameScreen.isMultiPlay) {
 					switch (player) {
 						case 0:
 							RollCharas[i].X = OpenTaiko.Skin.Game_Effect_Roll_StartPoint_1P_X[random.Next(0, OpenTaiko.Skin.Game_Effect_Roll_StartPoint_1P_X.Length)];

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -421,7 +421,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			//this.t進行描画_レーン();
 			//this.t進行描画_レーンフラッシュD();
 
-			if ((OpenTaiko.ConfigIni.eClipDispType == EClipDispType.WindowOnly || OpenTaiko.ConfigIni.eClipDispType == EClipDispType.Both) && !this.isMultiPlay)
+			if (BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode && !this.isMultiPlay)
 				this.actAVI.t窓表示();
 
 			if (!OpenTaiko.ConfigIni.bNoInfo && !OpenTaiko.ConfigIni.bTokkunMode)

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -358,31 +358,37 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				base.ePhaseID = CStage.EPhase.Game_STAGE_FAILED;
 			}
 
-			bool BGA_Hidden = OpenTaiko.ConfigIni.bEnableAVI && OpenTaiko.TJA.listVD.Count > 0 && ShowVideo;
+			bool BGA_Shown = OpenTaiko.ConfigIni.bEnableAVI && OpenTaiko.TJA.listVD.Count > 0 && ShowVideo;
 
+			// Layer: background
+
+			// BGIMAGE
 			// (????)
-			if (!String.IsNullOrEmpty(OpenTaiko.TJA.strBGIMAGE_PATH) || (OpenTaiko.TJA.listVD.Count == 0) || !ShowVideo || !OpenTaiko.ConfigIni.bEnableAVI) //背景動画があったら背景画像を描画しない。
+			if (!(String.IsNullOrEmpty(OpenTaiko.TJA.strBGIMAGE_PATH) && BGA_Shown)) //背景動画があったら背景画像を描画しない。
 			{
 				this.t進行描画_背景();
 			}
 
-			if (OpenTaiko.ConfigIni.bEnableAVI && OpenTaiko.TJA.listVD.Count > 0 && ShowVideo && !OpenTaiko.ConfigIni.bTokkunMode) {
+			// BGMOVIE & #BGAON
+			if (BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode) {
 				this.t進行描画_AVI();
 			} else if (OpenTaiko.ConfigIni.bEnableBGA) {
-				if (OpenTaiko.ConfigIni.bTokkunMode) actTokkun.On進行描画_背景();
-				else actBackground.Draw();
+				if (OpenTaiko.ConfigIni.bTokkunMode)
+					actTokkun.On進行描画_背景();
+				else
+					actBackground.Draw();
 			}
 
-			if (!BGA_Hidden && !OpenTaiko.ConfigIni.bTokkunMode) {
+			// Layer: below-character background elements
+			if (!BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode) {
 				actRollChara.Draw();
+				if (!this.isMultiPlay) {
+					if (OpenTaiko.ConfigIni.ShowDancer)
+						actDancer.Draw();
+					if (OpenTaiko.ConfigIni.ShowFooter)
+						this.actFooter.Draw();
+				}
 			}
-
-			if (!BGA_Hidden && !bDoublePlay && OpenTaiko.ConfigIni.ShowDancer && !OpenTaiko.ConfigIni.bTokkunMode) {
-				actDancer.Draw();
-			}
-
-			if (!BGA_Hidden && !bDoublePlay && OpenTaiko.ConfigIni.ShowFooter && !OpenTaiko.ConfigIni.bTokkunMode)
-				this.actFooter.Draw();
 
 			//this.t進行描画_グラフ();   // #24074 2011.01.23 add ikanick
 
@@ -390,11 +396,14 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			//this.t進行描画_DANGER();
 			//this.t進行描画_判定ライン();
 
+			// 1/2-player mode character
 			if (OpenTaiko.ConfigIni.ShowChara && OpenTaiko.ConfigIni.nPlayerCount <= 2) {
 				this.actChara.Draw();
 			}
 
-			if (!BGA_Hidden && OpenTaiko.ConfigIni.ShowMob && !OpenTaiko.ConfigIni.bTokkunMode)
+			// Layer: above-character background elements
+
+			if (!BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode && OpenTaiko.ConfigIni.ShowMob)
 				this.actMob.Draw();
 
 			if (OpenTaiko.ConfigIni.eGameMode != EGame.Off)
@@ -403,15 +412,17 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			this.t進行描画_譜面スクロール速度();
 			this.t進行描画_チップアニメ();
 
+			// Layer: note lane + below-note foreground elements
+
 			this.actLaneTaiko.Draw();
 
-			if (OpenTaiko.ConfigIni.ShowRunner && !OpenTaiko.ConfigIni.bAIBattleMode && OpenTaiko.ConfigIni.nPlayerCount <= 2)
+			if (OpenTaiko.ConfigIni.ShowRunner && !OpenTaiko.ConfigIni.bAIBattleMode && !this.isMultiPlay)
 				this.actRunner.Draw();
 
 			//this.t進行描画_レーン();
 			//this.t進行描画_レーンフラッシュD();
 
-			if ((OpenTaiko.ConfigIni.eClipDispType == EClipDispType.WindowOnly || OpenTaiko.ConfigIni.eClipDispType == EClipDispType.Both) && OpenTaiko.ConfigIni.nPlayerCount == 1)
+			if ((OpenTaiko.ConfigIni.eClipDispType == EClipDispType.WindowOnly || OpenTaiko.ConfigIni.eClipDispType == EClipDispType.Both) && !this.isMultiPlay)
 				this.actAVI.t窓表示();
 
 			if (!OpenTaiko.ConfigIni.bNoInfo && !OpenTaiko.ConfigIni.bTokkunMode)
@@ -423,6 +434,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			this.actDan.Draw();
 
+			// Layer: notes & bar lines
 			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 				// bIsFinishedPlaying = this.t進行描画_チップ(E楽器パート.DRUMS, i);
 				bool btmp = this.t進行描画_チップ(EInstrumentPad.Drums, i);
@@ -435,6 +447,8 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				}
 #endif
 			}
+
+			// Layer: above-note elements
 
 			this.actMtaiko.Draw();
 
@@ -452,10 +466,12 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			if (!OpenTaiko.ConfigIni.bNoInfo && !OpenTaiko.ConfigIni.bTokkunMode)
 				this.t進行描画_スコア();
 
+			// 3+-player mode character
 			if (OpenTaiko.ConfigIni.ShowChara && OpenTaiko.ConfigIni.nPlayerCount > 2) {
 				this.actChara.Draw();
 			}
 
+			// note effects
 			this.Rainbow.Draw();
 			this.FireWorks.Draw();
 			this.actChipEffects.Draw();
@@ -465,17 +481,22 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			if (!OpenTaiko.ConfigIni.bNoInfo)
 				this.t進行描画_パネル文字列();
 
+			// dialogue balloons
+
 			this.actComboBalloon.Draw();
 
 			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 				this.actRoll.On進行描画(this.nCurrentRollCount[i], i);
 			}
 
+			// infos
 
 			if (!OpenTaiko.ConfigIni.bNoInfo)
 				this.t進行描画_判定文字列1_通常位置指定の場合();
 
 			this.t進行描画_演奏情報();
+
+			// LYRIC[S/FILE]: & #LYRIC
 
 			if (OpenTaiko.TJA.listLyric2.Count > ShownLyric2 && OpenTaiko.TJA.listLyric2[ShownLyric2].Time < (long)OpenTaiko.TJA.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs)) {
 				this.actPanel.t歌詞テクスチャを生成する(OpenTaiko.TJA.listLyric2[ShownLyric2++].TextTex);
@@ -496,12 +517,16 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			this.ScoreRank.Draw();
 
+			// Layer: Interactive elements
+
 			if (OpenTaiko.ConfigIni.bTokkunMode) {
 				actTokkun.Draw();
 			}
 
 			// handle retry states here
 			this.actPauseMenu.Draw();
+
+			// Layer: Gameplay complete animation and fading out
 
 			bIsFinishedEndAnime = this.actEnd.Draw() == 1 ? true : false;
 			bIsFinishedFadeout = this.t進行描画_フェードイン_アウト();

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -363,8 +363,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 			// Layer: background
 
 			// BGIMAGE
-			// (????)
-			if (!(String.IsNullOrEmpty(OpenTaiko.TJA.strBGIMAGE_PATH) && BGA_Shown)) //背景動画があったら背景画像を描画しない。
+			if (!BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode && !string.IsNullOrEmpty(OpenTaiko.TJA.strBGIMAGE_PATH)) //背景動画があったら背景画像を描画しない。
 			{
 				this.t進行描画_背景();
 			}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -362,15 +362,10 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 			// Layer: background
 
-			// BGIMAGE
-			if (!BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode && !string.IsNullOrEmpty(OpenTaiko.TJA.strBGIMAGE_PATH)) //背景動画があったら背景画像を描画しない。
-			{
-				this.t進行描画_背景();
-			}
-
-			// BGMOVIE & #BGAON
-			if (BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode) {
-				this.t進行描画_AVI();
+			if (BGA_Shown && !OpenTaiko.ConfigIni.bTokkunMode && this.t進行描画_AVI()) {
+				// BGMOVIE & #BGAON
+			} else if (!OpenTaiko.ConfigIni.bTokkunMode && this.t進行描画_背景()) {
+				// BGIMAGE
 			} else if (OpenTaiko.ConfigIni.bEnableBGA) {
 				if (OpenTaiko.ConfigIni.bTokkunMode)
 					actTokkun.On進行描画_背景();


### PR DESCRIPTION
This fixes 0auBSQ/OpenTaiko#837.

* feat(`CStage演奏画面共通`): pause the BGA/MOVIE instead of hiding it for STAGE FAILED [`CStageGameplayScreenCommon`]
* fix crash when playing a song with any BGA/MOVIE ever played, then choose another song, then seek to after any BPM/MOVIE in this song should play before any such event plays, and then resume play, due to using `Dispose()`ed `CVideoDecoder` from the last song, fix 0auBSQ/OpenTaiko#837
* fix BGIMAGE was drawn when BGA is shown or in training mode
* fix BGA/MOVIE window display did not hide on `#BGAOFF` or retrying
* fix BGIMAGE was overlapped by predefined background and was invisible