### PR TITLE
RefactorAndFixTJAParser2

### DIFF
--- a/FDK/src/00.Common/CJudgeTextEncoding.cs
+++ b/FDK/src/00.Common/CJudgeTextEncoding.cs
@@ -44,26 +44,8 @@ public class CJudgeTextEncoding {
 			str = reader.Text;
 		}
 
-		str = str.Replace(JudgeNewLine(str), "\n");
+		str = str.ReplaceLineEndings("\n");
 
 		return str;
 	}
-
-	/// <summary>
-	/// Environment.NewLineはプラットフォーム依存である。
-	/// だが、ファイルごとに改行コードは違うので、使用すべきではない。
-	/// なので、勝手に改行文字を判断する。
-	/// </summary>
-	/// <param name="str"></param>
-	/// <returns></returns>
-	public static string JudgeNewLine(string str) {
-		if (str.Contains("\r\n"))
-			return ("\r\n");
-
-		if (str.Contains("\r"))
-			return ("\r");
-
-		return ("\n");
-	}
-
 }

--- a/OpenTaiko/src/Components/CVisualLogManager.cs
+++ b/OpenTaiko/src/Components/CVisualLogManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using FDK;
 
 namespace OpenTaiko;
@@ -43,13 +44,17 @@ class CVisualLogManager {
 	}
 
 	public void Display() {
-		while (this.cards.TryPeek(out var card) && card.IsExpired()) {
-			this.cards.Dequeue();
+		if (this.firstCard?.IsExpired() ?? true) {
+			while (this.cards.TryDequeue(out this.firstCard) && this.firstCard.IsExpired())
+				;
 		}
 		int y = 0;
+		if (this.firstCard != null)
+			y = this.firstCard.Display(y);
 		foreach (var card in this.cards)
 			y = card.Display(y);
 	}
 
-	private readonly Queue<LogCard> cards = new Queue<LogCard>();
+	private readonly ConcurrentQueue<LogCard> cards = new();
+	private LogCard? firstCard = null;
 }

--- a/OpenTaiko/src/Helpers/ObjectExtensions.cs
+++ b/OpenTaiko/src/Helpers/ObjectExtensions.cs
@@ -217,41 +217,41 @@ namespace System {
 		public static double[] ParseComplex(this string input) {
 			try {
 				// Removing all spaces from the input for easier processing
-				input = input.Replace(" ", "").ToLower();
+				var str = input.Replace(" ", "").ToLower();
 
 				double real = 0;
 				double imaginary = 0;
 
 				// If the input contains 'i', we need to handle the imaginary part
-				if (input.Contains("i")) {
+				if (str.Contains("i")) {
 					// Special cases for 'i', '-i', '1+i', '1-i'
-					if (input == "i") {
+					if (str == "i") {
 						imaginary = 1;
-					} else if (input == "-i") {
+					} else if (str == "-i") {
 						imaginary = -1;
 					} else {
 						// Remove 'i' for further processing
-						input = input.Replace("i", "");
+						str = str.Replace("i", "");
 
 						// Check if input ends with '+' or '-', meaning it was something like '1+i' or '1-i'
-						if (input.EndsWith("+") || input.EndsWith("-")) {
-							real = double.Parse(input.TrimEnd('+', '-'), CultureInfo.InvariantCulture);
-							imaginary = input.EndsWith("+") ? 1 : -1;
+						if (str.EndsWith("+") || str.EndsWith("-")) {
+							real = double.Parse(str.TrimEnd('+', '-'), CultureInfo.InvariantCulture);
+							imaginary = str.EndsWith("+") ? 1 : -1;
 						} else {
 							// Split the input into real and imaginary parts
-							string[] parts = input.Split(new[] { '+', '-' }, StringSplitOptions.RemoveEmptyEntries);
+							string[] parts = str.Split(new[] { '+', '-' }, StringSplitOptions.RemoveEmptyEntries);
 
 							// If starts by - (fix for -1+3i, etc)
-							double factor = input.StartsWith("-") ? -1 : 1;
+							double factor = str.StartsWith("-") ? -1 : 1;
 
-							if (input.Contains("+")) {
+							if (str.Contains("+")) {
 								real = double.Parse(parts[0], CultureInfo.InvariantCulture);
 								imaginary = double.Parse(parts[1], CultureInfo.InvariantCulture);
-							} else if (input.LastIndexOf('-') > 0) // handling cases like "1-2i"
+							} else if (str.LastIndexOf('-') > 0) // handling cases like "1-2i"
 								{
 								real = double.Parse(parts[0], CultureInfo.InvariantCulture);
 								imaginary = -double.Parse(parts[1], CultureInfo.InvariantCulture);
-							} else if (input.StartsWith("-")) {
+							} else if (str.StartsWith("-")) {
 								imaginary = -double.Parse(parts[0], CultureInfo.InvariantCulture);
 							} else {
 								imaginary = double.Parse(parts[0], CultureInfo.InvariantCulture);
@@ -262,12 +262,12 @@ namespace System {
 					}
 				} else {
 					// If there is no 'i', it is purely a real number
-					real = double.Parse(input, CultureInfo.InvariantCulture);
+					real = double.Parse(str, CultureInfo.InvariantCulture);
 				}
 
 				return new double[] { real, imaginary };
 			} catch (FormatException ex) {
-				throw new FormatException("Invalid complex number", ex);
+				throw new FormatException($"The input string '{input}' was not in a correct format.", ex);
 			}
 		}
 	}

--- a/OpenTaiko/src/Helpers/ObjectExtensions.cs
+++ b/OpenTaiko/src/Helpers/ObjectExtensions.cs
@@ -266,9 +266,8 @@ namespace System {
 				}
 
 				return new double[] { real, imaginary };
-			} catch (Exception ex) {
-				LogNotification.PopWarning($"'{input}': Incorrect complex number formatting, defaulting to 0");
-				return new double[] { 0, 0 }; // Return default value in case of error
+			} catch (FormatException ex) {
+				throw new FormatException("Invalid complex number", ex);
 			}
 		}
 	}

--- a/OpenTaiko/src/Songs/CDTXStyleExtractor.cs
+++ b/OpenTaiko/src/Songs/CDTXStyleExtractor.cs
@@ -31,24 +31,27 @@ namespace OpenTaiko;
 /// 8. Reassemble the string
 /// </summary>
 public static class CDTXStyleExtractor {
-	private const RegexOptions StyleExtractorRegexOptions =
+	// The sections are splitted right before the header or command for the section kind,
+	// so only the first line need to be considered.
+	private const RegexOptions StyleGetSectionKindRegexOptions =
 		RegexOptions.Compiled |
 		RegexOptions.CultureInvariant |
 		RegexOptions.IgnoreCase |
-		RegexOptions.Multiline |
 		RegexOptions.Singleline;
 
-	private const string StylePrefixRegexPattern = @"^STYLE\s*:\s*";
+	// For splitting the sections, all lines need to be considered.
+	private const RegexOptions StyleSectionSplitRegexOptions =
+		StyleGetSectionKindRegexOptions |
+		RegexOptions.Multiline;
+
+	private const string StylePrefixRegexPattern = @"^STYLE\s*:";
 	private const string SheetStartPrefixRegexPattern = @"^#START";
 
 	private static readonly string StyleSingleSectionRegexMatchPattern =
-		$"{StylePrefixRegexPattern}(?:Single|1)";
+		$"{StylePrefixRegexPattern}\\s*(?:Single|1)";
 
 	private static readonly string StyleDoubleSectionRegexMatchPattern =
-		$"{StylePrefixRegexPattern}(?:Double|Couple|2)";
-
-	private static readonly string StyleUnrecognizedSectionRegexMatchPattern =
-		$"{StylePrefixRegexPattern}";
+		$"{StylePrefixRegexPattern}\\s*(?:Double|Couple|2)";
 
 	private static readonly string SheetStartBareRegexMatchPattern =
 		$"{SheetStartPrefixRegexPattern}$";
@@ -59,21 +62,17 @@ public static class CDTXStyleExtractor {
 	private static readonly string SheetStartP2RegexMatchPattern =
 		$"{SheetStartPrefixRegexPattern}\\s*P2";
 
-	private static readonly string SheetStartUnrecognizedRegexMatchPattern =
-		$"{SheetStartPrefixRegexPattern}.*$";
+	private static readonly Regex SectionSplitRegex = new Regex($"(?={StylePrefixRegexPattern})", StyleSectionSplitRegexOptions);
+	private static readonly Regex SubSectionSplitRegex = new Regex($"(?={SheetStartPrefixRegexPattern})|(?<=#END\\n)", StyleSectionSplitRegexOptions);
 
-	private static readonly Regex SectionSplitRegex = new Regex($"(?={StylePrefixRegexPattern})", StyleExtractorRegexOptions);
-	private static readonly Regex SubSectionSplitRegex = new Regex($"(?={SheetStartPrefixRegexPattern})|(?<=#END\\n)", StyleExtractorRegexOptions);
+	private static readonly Regex StyleSingleSectionMatchRegex = new Regex(StyleSingleSectionRegexMatchPattern, StyleGetSectionKindRegexOptions);
+	private static readonly Regex StyleDoubleSectionMatchRegex = new Regex(StyleDoubleSectionRegexMatchPattern, StyleGetSectionKindRegexOptions);
+	private static readonly Regex StyleUnrecognizedSectionMatchRegex = new Regex(StylePrefixRegexPattern, StyleGetSectionKindRegexOptions);
 
-	private static readonly Regex StyleSingleSectionMatchRegex = new Regex(StyleSingleSectionRegexMatchPattern, StyleExtractorRegexOptions);
-	private static readonly Regex StyleDoubleSectionMatchRegex = new Regex(StyleDoubleSectionRegexMatchPattern, StyleExtractorRegexOptions);
-	private static readonly Regex StyleUnrecognizedSectionMatchRegex = new Regex(StyleUnrecognizedSectionRegexMatchPattern, StyleExtractorRegexOptions);
-
-	private static readonly Regex SheetStartPrefixMatchRegex = new Regex(SheetStartPrefixRegexPattern, StyleExtractorRegexOptions);
-	private static readonly Regex SheetStartBareMatchRegex = new Regex(SheetStartBareRegexMatchPattern, StyleExtractorRegexOptions);
-	private static readonly Regex SheetStartP1MatchRegex = new Regex(SheetStartP1RegexMatchPattern, StyleExtractorRegexOptions);
-	private static readonly Regex SheetStartP2MatchRegex = new Regex(SheetStartP2RegexMatchPattern, StyleExtractorRegexOptions);
-	private static readonly Regex SheetStartUnrecognizedMatchRegex = new Regex(SheetStartUnrecognizedRegexMatchPattern, StyleExtractorRegexOptions);
+	private static readonly Regex SheetStartBareMatchRegex = new Regex(SheetStartBareRegexMatchPattern, StyleGetSectionKindRegexOptions);
+	private static readonly Regex SheetStartP1MatchRegex = new Regex(SheetStartP1RegexMatchPattern, StyleGetSectionKindRegexOptions);
+	private static readonly Regex SheetStartP2MatchRegex = new Regex(SheetStartP2RegexMatchPattern, StyleGetSectionKindRegexOptions);
+	private static readonly Regex SheetStartUnrecognizedMatchRegex = new Regex(SheetStartPrefixRegexPattern, StyleGetSectionKindRegexOptions);
 
 	private static readonly SectionKindAndSubSectionKind StyleSingleAndSheetStartBare =
 		new SectionKindAndSubSectionKind(SectionKind.StyleSingle, SubSectionKind.SheetStartBare);
@@ -315,22 +314,20 @@ public static class CDTXStyleExtractor {
 	}
 
 	private static SubSectionKind GetSubsectionKind(string subsection) {
-		if (SheetStartPrefixMatchRegex.IsMatch(subsection)) {
-			if (SheetStartBareMatchRegex.IsMatch(subsection)) {
-				return SubSectionKind.SheetStartBare;
-			}
+		if (SheetStartBareMatchRegex.IsMatch(subsection)) {
+			return SubSectionKind.SheetStartBare;
+		}
 
-			if (SheetStartP1MatchRegex.IsMatch(subsection)) {
-				return SubSectionKind.SheetStartP1;
-			}
+		if (SheetStartP1MatchRegex.IsMatch(subsection)) {
+			return SubSectionKind.SheetStartP1;
+		}
 
-			if (SheetStartP2MatchRegex.IsMatch(subsection)) {
-				return SubSectionKind.SheetStartP2;
-			}
+		if (SheetStartP2MatchRegex.IsMatch(subsection)) {
+			return SubSectionKind.SheetStartP2;
+		}
 
-			if (SheetStartUnrecognizedMatchRegex.IsMatch(subsection)) {
-				return SubSectionKind.SheetStartUnrecognized;
-			}
+		if (SheetStartUnrecognizedMatchRegex.IsMatch(subsection)) {
+			return SubSectionKind.SheetStartUnrecognized;
 		}
 
 		return SubSectionKind.NonSheet;

--- a/OpenTaiko/src/Songs/CDTXStyleExtractor.cs
+++ b/OpenTaiko/src/Songs/CDTXStyleExtractor.cs
@@ -63,7 +63,7 @@ public static class CDTXStyleExtractor {
 		$"{SheetStartPrefixRegexPattern}\\s*P2";
 
 	private static readonly Regex SectionSplitRegex = new Regex($"(?={StylePrefixRegexPattern})", StyleSectionSplitRegexOptions);
-	private static readonly Regex SubSectionSplitRegex = new Regex($"(?={SheetStartPrefixRegexPattern})|(?<=#END\\n)", StyleSectionSplitRegexOptions);
+	private static readonly Regex SubSectionSplitRegex = new Regex($"(?={SheetStartPrefixRegexPattern})|(?<=^#END\\n)", StyleSectionSplitRegexOptions);
 
 	private static readonly Regex StyleSingleSectionMatchRegex = new Regex(StyleSingleSectionRegexMatchPattern, StyleGetSectionKindRegexOptions);
 	private static readonly Regex StyleDoubleSectionMatchRegex = new Regex(StyleDoubleSectionRegexMatchPattern, StyleGetSectionKindRegexOptions);

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -361,9 +361,9 @@ internal class CTja : CActivity {
 
 	public bool[] b譜面が存在する = new bool[(int)Difficulty.Total];
 
-	private string[] dlmtSpace = { " " };
-	private string[] dlmtEnter = { "\n" };
-	private string[] dlmtCOURSE = { "COURSE:" };
+	private const string dlmtSpace = " ";
+	private const string dlmtEnter = "\n";
+	private const string dlmtCOURSE = "COURSE:";
 
 	private int nスクロール方向 = 0;
 	//2015.09.18 kairera0467
@@ -1328,7 +1328,7 @@ internal class CTja : CActivity {
 		if (nMode == 0) {
 			str = str.Replace("\n", " ");
 		} else if (nMode == 1) {
-			return str.Split(this.dlmtEnter, StringSplitOptions.RemoveEmptyEntries);
+			return str.Split(dlmtEnter, StringSplitOptions.RemoveEmptyEntries);
 		}
 
 		return str;
@@ -1344,7 +1344,7 @@ internal class CTja : CActivity {
 
 		if (strTJA.IndexOf("COURSE", 0) != -1) {
 			//tja内に「COURSE」があればここを使う。
-			string[] strTemp = strTJA.Split(this.dlmtCOURSE, StringSplitOptions.RemoveEmptyEntries);
+			string[] strTemp = strTJA.Split(dlmtCOURSE, StringSplitOptions.RemoveEmptyEntries);
 
 			for (int n = 1; n < strTemp.Length; n++) {
 				int nCourse = 0;
@@ -1455,7 +1455,7 @@ internal class CTja : CActivity {
 				this.strFullPath);
 
 			//命令をすべて消去した譜面
-			var strSplit読み込むコース = strSplitした譜面[n読み込むコース].Split(this.dlmtEnter, StringSplitOptions.RemoveEmptyEntries);
+			var strSplit読み込むコース = strSplitした譜面[n読み込むコース].Split(dlmtEnter, StringSplitOptions.RemoveEmptyEntries);
 
 
 			var str命令消去譜面 = this.tコマンド行を削除したTJAを返す(strSplit読み込むコース, 0);
@@ -3527,7 +3527,7 @@ internal class CTja : CActivity {
 	private void LyricFileParser(string strFilePath, int ordnumber)//lrcファイルのパース用
 	{
 		string str = CJudgeTextEncoding.ReadTextFile(strFilePath);
-		var strSplit後 = str.Split(this.dlmtEnter, StringSplitOptions.RemoveEmptyEntries);
+		var strSplit後 = str.Split(dlmtEnter, StringSplitOptions.RemoveEmptyEntries);
 		Regex timeRegex = new Regex(@"^(\[)(\d{2})(:)(\d{2})([:.])(\d{2})(\])", RegexOptions.Multiline | RegexOptions.Compiled);
 		Regex timeRegexO = new Regex(@"^(\[)(\d{2})(:)(\d{2})(\])", RegexOptions.Multiline | RegexOptions.Compiled);
 		List<long> list;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1250,6 +1250,12 @@ internal class CTja : CActivity {
 		}
 	}
 
+	/// <summary>
+	/// <paramref name="nMode"/> == 0: preserve notechart symbols
+	/// <paramref name="nMode"/> == 1: preserve notechart symbols, commands, and EXAM headers
+	/// <paramref name="nMode"/> == 2: preserve notechart symbols and #BRANCHSTART/#N/#E/#M commands
+	/// </summary>
+	/// <returns>TJA lines without certain commands and headers</returns>
 	private string[] tコマンド行を削除したTJAを返す(string[] input, int nMode) {
 		var sb = new StringBuilder();
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1610,11 +1610,7 @@ internal class CTja : CActivity {
 
 			this.listChip.Add(chip);
 		} else if (command == "#BPMCHANGE") {
-			double dbBPM;
-			if (!double.TryParse(argument, out dbBPM)) {
-				AddCommandError(command, argument, "invalid number");
-				dbBPM = 150;
-			}
+			double dbBPM = double.Parse(argument);
 			this.dbNowBPM = dbBPM;
 
 			if (dbBPM > MaxBPM) {
@@ -1632,17 +1628,11 @@ internal class CTja : CActivity {
 		} else if (command == "#SCROLL") {
 			double[] dbComplexNum = new double[2];
 			//2016.08.13 kairera0467 複素数スクロールもどきのテスト
-			try {
-				//iが入っていた場合、複素数スクロールとみなす。
-				if (argument.IndexOf('i') != -1)
-					this.tParsedComplexNumber(argument, ref dbComplexNum);
-				else
-					dbComplexNum[0] = double.Parse(argument);
-			} catch (Exception ex) {
-				this.AddCommandError(command, argument, "invalid complex number");
-				dbComplexNum[0] = 1.0;
-				dbComplexNum[1] = 0.0;
-			}
+			//iが入っていた場合、複素数スクロールとみなす。
+			if (argument.IndexOf('i') != -1)
+				this.tParsedComplexNumber(argument, ref dbComplexNum);
+			else
+				dbComplexNum[0] = double.Parse(argument);
 
 			this.dbNowScroll = dbComplexNum[0];
 			this.dbNowScrollY = dbComplexNum[1];
@@ -1662,12 +1652,8 @@ internal class CTja : CActivity {
 			WarnSplitLength("#MEASURE subsplit", strArray, 2);
 
 			double[] dbLength = new double[2];
-			try {
-				dbLength[0] = Convert.ToDouble(strArray[0]);
-				dbLength[1] = Convert.ToDouble(strArray[1]);
-			} catch (Exception ex) {
-				this.AddCommandError(command, argument, "invalid number");
-			}
+			dbLength[0] = Convert.ToDouble(strArray[0]);
+			dbLength[1] = Convert.ToDouble(strArray[1]);
 
 			double db小節長倍率 = dbLength[0] / dbLength[1];
 			this.fNow_Measure_m = (float)dbLength[1];
@@ -1675,11 +1661,7 @@ internal class CTja : CActivity {
 
 			this.listChip.Add(this.NewEventChipAtDefCursor(0x02, 1, argDb: db小節長倍率));
 		} else if (command == "#DELAY") {
-			double nDELAY = 0;
-			if (!double.TryParse(argument, out nDELAY)) {
-				this.AddCommandError(command, argument, "invalid number");
-				nDELAY = 0;
-			}
+			double nDELAY = double.Parse(argument);
 			nDELAY *= 1000;
 
 			//チップ追加して割り込んでみる。
@@ -2268,14 +2250,8 @@ internal class CTja : CActivity {
 	private void ParseArgCamSetCommand(string command, string argument, int channelNo, CChip? camChip, Action<CChip, float> setValue, string commandEnd) {
 		if (camChip == null) {
 			var chip = this.NewEventChipAtDefCursor(channelNo, 1);
-
-			if (float.TryParse(argument, out float value)) {
-				setValue(chip, value);
-			} else {
-				this.AddCommandError(command, argument, "invalid number");
-			}
+			setValue(chip, float.Parse(argument));
 			chip.strCamEaseType = "IN_OUT";
-
 			// チップを配置。
 			this.listChip.Add(chip);
 		} else {
@@ -2941,11 +2917,7 @@ internal class CTja : CActivity {
 					"jm" => Exam.Type.JudgeMine,
 					"g" or _ => Exam.Type.Gauge,
 				};
-				try {
-					examValue = new int[] { int.Parse(splitExam[1]), int.Parse(splitExam[2]) };
-				} catch (Exception) {
-					examValue = new int[] { 100, 100 };
-				}
+				examValue = new int[] { int.Parse(splitExam[1]), int.Parse(splitExam[2]) };
 
 				var examRange = splitExam[3] switch {
 					"l" => Exam.Range.Less,

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2220,8 +2220,6 @@ internal class CTja : CActivity {
 
 			AddPreBakedMusicPreTimeMs(); // 段位の幕が開いてからの遅延。
 
-			strArray = SplitComma(argument); // \,をエスケープ処理するメソッドだぞっ
-
 			for (int i = listChip.Count - 1; i >= 0; i--) {
 				//if (listChip[i].nチャンネル番号 >= 0x11 && listChip[i].nチャンネル番号 <= 0x18)
 				if (NotesManager.IsHittableNote(listChip[i])) {
@@ -2233,29 +2231,24 @@ internal class CTja : CActivity {
 				}
 			}
 
-			WarnSplitLength("#NEXTSONG", strArray, 8);
+			strArray = SplitComma(argument); // \,をエスケープ処理するメソッドだぞっ
+			WarnSplitLength("#NEXTSONG", strArray, 4);
 			var dansongs = new DanSongs();
-			dansongs.Title = strArray[0];
-			dansongs.SubTitle = strArray[1];
-			dansongs.Genre = strArray[2];
-			dansongs.FileName = strArray[3];
-			dansongs.ScoreInit = int.Parse(strArray[4]);
-			dansongs.ScoreDiff = int.Parse(strArray[5]);
 
-			if (strArray.Length >= 7 && strArray[6] != "" && strArray[6] != null)
-				dansongs.Level = int.Parse(strArray[6]);
-			else if (strArray.Length < 7)
-				dansongs.Level = 10;
+			// basic fields
+			dansongs.Title = (strArray.Length > 0) ? strArray[0] : "";
+			dansongs.SubTitle = (strArray.Length > 1) ? strArray[1] : "";
+			dansongs.Genre = (strArray.Length > 2) ? strArray[2] : "";
+			dansongs.FileName = (strArray.Length > 3) ? strArray[3] : "";
 
-			if (strArray.Length >= 8 && strArray[7] != "" && strArray[7] != null)
-				dansongs.Difficulty = strConvertCourse(strArray[7]);
-			else if (strArray.Length < 8)
-				dansongs.Difficulty = 3;
+			// required by TJAP3
+			dansongs.ScoreInit = (strArray.Length > 4 && !string.IsNullOrWhiteSpace(strArray[4])) ? int.Parse(strArray[4]) : -1;
+			dansongs.ScoreDiff = (strArray.Length > 5 && !string.IsNullOrWhiteSpace(strArray[5])) ? int.Parse(strArray[5]) : -1;
 
-			if (strArray.Length == 9 && strArray[8] != "" && strArray[8] != null)
-				dansongs.bTitleShow = bool.Parse(strArray[8]);
-			else if (strArray.Length < 9)
-				dansongs.bTitleShow = false;
+			// optional in TJAP3-Dev-ReW and OpTk
+			dansongs.Level = (strArray.Length > 6 && !string.IsNullOrWhiteSpace(strArray[6])) ? int.Parse(strArray[6]) : 10;
+			dansongs.Difficulty = (strArray.Length > 7 && !string.IsNullOrWhiteSpace(strArray[7])) ? strConvertCourse(strArray[7]) : 3;
+			dansongs.bTitleShow = (strArray.Length > 8 && !string.IsNullOrWhiteSpace(strArray[8])) ? bool.Parse(strArray[8]) : false;
 
 			dansongs.Wave = new CWAV {
 				n内部番号 = this.n内部番号WAV1to,

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1562,14 +1562,12 @@ internal class CTja : CActivity {
 
 		var command = match.Groups[1].Value;
 		var argumentMatchGroup = match.Groups[2];
-		var argument = argumentMatchGroup.Success ? argumentMatchGroup.Value : null;
+		var argumentFull = argumentMatchGroup.Success ? argumentMatchGroup.Value : "";
 
-		while (true) {//命令の最後に,が残ってしまっているときの対応
-			if (argument != null && argument[argument.Length - 1] == ',')
-				argument = argument.Substring(0, argument.Length - 1);
-			else
-				break;
-		}
+		// For handling arguments ending in a ` `-or-`,`-containing string, use argumentFull
+
+		//命令の最後に,が残ってしまっているときの対応
+		var argument = argumentFull.TrimEnd([',', ' ']);
 
 		char[] chDelimiter = new char[] { ' ' };
 		string[] strArray = null;
@@ -1836,7 +1834,7 @@ internal class CTja : CActivity {
 			var chip = this.NewEventChipAtDefCursor(0xBC, 1);
 
 			try {
-				string[] args = argument.Split(',');
+				string[] args = argumentFull.Split(',');
 
 				chip.strObjName = args[0];
 				chip.fObjX = float.Parse(args[1]);
@@ -1914,7 +1912,7 @@ internal class CTja : CActivity {
 		} else if (command == "#CHANGETEXTURE") {
 			var chip = this.NewEventChipAtDefCursor(0xD1, 1);
 
-			string[] args = argument.Split(',');
+			string[] args = argumentFull.Split(',');
 			try {
 				chip.strTargetTxName = args[0]
 					.Replace('/', Path.DirectorySeparatorChar)
@@ -2132,7 +2130,7 @@ internal class CTja : CActivity {
 		} else if (command == "#LYRIC" && !usingLyricsFile && OpenTaiko.ConfigIni.nPlayerCount < 4) // Do not parse LYRIC tags if a lyric file is already loaded
 		{
 			if (OpenTaiko.rCurrentStage.eStageID == CStage.EStage.SongLoading)//起動時に重たくなってしまう問題の修正用
-				this.listLyric.Add(this.pf歌詞フォント.DrawText(argument, OpenTaiko.Skin.Game_Lyric_ForeColor, OpenTaiko.Skin.Game_Lyric_BackColor, null, 30));
+				this.listLyric.Add(this.pf歌詞フォント.DrawText(argumentFull, OpenTaiko.Skin.Game_Lyric_ForeColor, OpenTaiko.Skin.Game_Lyric_BackColor, null, 30));
 
 			var chip = this.NewEventChipAtDefCursor(0xF1, this.listLyric.Count - 1);
 			chip.nBranch = this.n現在のコース;
@@ -2231,7 +2229,7 @@ internal class CTja : CActivity {
 				}
 			}
 
-			strArray = SplitComma(argument); // \,をエスケープ処理するメソッドだぞっ
+			strArray = SplitComma(argumentFull); // \,をエスケープ処理するメソッドだぞっ
 			WarnSplitLength("#NEXTSONG", strArray, 4);
 			var dansongs = new DanSongs();
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2870,7 +2870,7 @@ internal class CTja : CActivity {
 			}
 		}
 
-		string[] strArray = InputText.Split(new char[] { ':' });
+		string[] strArray = InputText.Split(new char[] { ':' }, 2);
 		string strCommandName = "";
 		string strCommandParam = "";
 
@@ -2938,7 +2938,7 @@ internal class CTja : CActivity {
 	}
 
 	private void tDanExamLoad(string input) {
-		string[] strArray = input.Split(new char[] { ':' });
+		string[] strArray = input.Split(new char[] { ':' }, 2);
 		string strCommandName = "";
 		string strCommandParam = "";
 
@@ -3045,27 +3045,6 @@ internal class CTja : CActivity {
 		if (strArray.Length == 2) {
 			strCommandName = strArray[0].Trim();
 			strCommandParam = strArray[1].Trim();
-		} else if (strArray.Length > 2) {
-			//strArrayが2じゃない場合、ヘッダのSplitを通していない可能性がある。
-			//この処理自体は「t入力」を改造したもの。STARTでSplitしていない等、一部の処理が異なる。
-
-			#region [Header]
-			InputText = InputText.Replace(Environment.NewLine, "\n"); //改行文字を別の文字列に差し替え。
-			InputText = InputText.Replace('\t', ' '); //何の文字か知らないけどスペースに差し替え。
-			InputText = InputText + "\n";
-
-			string[] strDelimiter2 = { "\n" };
-			strArray = InputText.Split(strDelimiter2, StringSplitOptions.RemoveEmptyEntries);
-
-
-			strArray = strArray[0].Split(new char[] { ':' });
-			WarnSplitLength("Header Name & Value", strArray, 2);
-
-			strCommandName = strArray[0].Trim();
-			strCommandParam = strArray[1].Trim();
-
-			#endregion
-			//lblMessage.Text = "おや?strArrayのLengthが2じゃないようですね。お兄様。";
 		}
 
 		void ParseOptionalInt16(Action<short> setValue) {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1432,7 +1432,7 @@ internal class CTja : CActivity {
 			//指定したコースの譜面の命令を消去する。
 			var strCourse = strSplitした譜面[n読み込むコース] = CDTXStyleExtractor.tセッション譜面がある(
 				strSplitした譜面[n読み込むコース],
-				OpenTaiko.ConfigIni.nPlayerCount > 1 ? (this.nPlayerSide + 1) : 0,
+				(OpenTaiko.ConfigIni.nPlayerCount > 1 && !OpenTaiko.ConfigIni.bAIBattleMode) ? (this.nPlayerSide + 1) : 0,
 				this.strFullPath);
 
 			//ここで1行の文字数をカウント。配列にして返す。

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1375,10 +1375,8 @@ internal class CTja : CActivity {
 		@"^(?!(TITLE|LEVEL|BPM|WAVE|OFFSET|BALLOON|EXAM1|EXAM2|EXAM3|EXAM4|EXAM5|EXAM6|EXAM7|DANTICK|DANTICKCOLOR|RENREN22|RENREN23|RENREN32|RENREN33|RENREN42|RENREN43|BALLOONNOR|BALLOONEXP|BALLOONMAS|SONGVOL|SEVOL|SCOREINIT|SCOREDIFF|COURSE|STYLE|TOWERTYPE|GAME|LIFE|DEMOSTART|SIDE|SUBTITLE|SCOREMODE|GENRE|MAKER|SELECTBG|MOVIEOFFSET|BGIMAGE|BGMOVIE|HIDDENBRANCH|GAUGEINCR|LYRICFILE|#HBSCROLL|#BMSCROLL)).+\n",
 		RegexOptions.Multiline | RegexOptions.Compiled);
 
-	private int nDifficulty;
-
 	public int nInstanceDifficulty {
-		get => this.nDifficulty;
+		get => this.n参照中の難易度;
 	}
 
 	/// <summary>
@@ -1390,7 +1388,6 @@ internal class CTja : CActivity {
 	/// </summary>
 	/// <param name="strInput">譜面のデータ</param>
 	private void t入力_V4(string strInput, int difficulty) {
-		nDifficulty = difficulty;
 		if (!String.IsNullOrEmpty(strInput)) //空なら通さない
 		{
 			strInput = this.preprocessTjaStr(strInput);
@@ -1427,6 +1424,7 @@ internal class CTja : CActivity {
 				}
 			} else
 				n読み込むコース = difficulty;
+			this.n参照中の難易度 = n読み込むコース;
 			#endregion
 
 			//指定したコースの譜面の命令を消去する。
@@ -1516,10 +1514,10 @@ internal class CTja : CActivity {
 		new Regex(@"^([^,\s]+)\s*,\s*([^,\s]+)\s*,\s*([^,\s]+)$", RegexOptions.Compiled);
 
 	private void AddCommandError(string command, string argument, string reason) {
-		this.listErrors.Add($"{nameof(CTja)}: Bad {command} arguments: {argument}, at {(Difficulty)nDifficulty}, line {nNowReadLine}, in {strFullPath}: {reason}");
+		this.listErrors.Add($"{nameof(CTja)}: Bad {command} arguments: {argument}, at {(Difficulty)this.n参照中の難易度}, line {nNowReadLine}, in {strFullPath}: {reason}");
 	}
 	private void AddWarn(string msg) {
-		this.listErrors.Add($"{nameof(CTja)}: {msg}, at {(Difficulty)nDifficulty}, line {nNowReadLine}, in {strFullPath}");
+		this.listErrors.Add($"{nameof(CTja)}: {msg}, at {(Difficulty)this.n参照中の難易度}, line {nNowReadLine}, in {strFullPath}");
 	}
 
 	private string[] SplitComma(string input) {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1490,9 +1490,9 @@ internal class CTja : CActivity {
 				}
 				for (int i = 0; i < str命令消去譜面.Count; i++) {
 					if (str命令消去譜面[i].IndexOf(',', 0) == -1 && !String.IsNullOrEmpty(str命令消去譜面[i])) {
-						divPerMeasure += str命令消去譜面[i].Length;
+						divPerMeasure += str命令消去譜面[i].Count(c => !char.IsWhiteSpace(c));
 					} else {
-						this.divsPerMeasureAllBranches.Add(divPerMeasure + str命令消去譜面[i].Length - 1);
+						this.divsPerMeasureAllBranches.Add(divPerMeasure + str命令消去譜面[i].Count(c => !char.IsWhiteSpace(c)) - 1);
 						divPerMeasure = 0;
 					}
 				}
@@ -2653,6 +2653,9 @@ internal class CTja : CActivity {
 						this.n現在の小節数++;
 						this.b小節線を挿入している = false;
 						return;
+					}
+					if (string.IsNullOrWhiteSpace(InputText.Substring(n, 1))) {
+						continue; // skip whitespaces
 					}
 
 					if (InputText.Substring(0, 1) == "F") {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1250,16 +1250,6 @@ internal class CTja : CActivity {
 		}
 	}
 
-	private string tコメントを削除する(string input) {
-		string strOutput = Regex.Replace(input, @" *//.*", ""); //2017.01.28 DD コメント前のスペースも削除するように修正
-
-		return strOutput;
-	}
-
-	private string[] tコマンド行を削除したTJAを返す(string[] input) {
-		return this.tコマンド行を削除したTJAを返す(input, 0);
-	}
-
 	private string[] tコマンド行を削除したTJAを返す(string[] input, int nMode) {
 		var sb = new StringBuilder();
 
@@ -1321,9 +1311,6 @@ internal class CTja : CActivity {
 		return strOutput;
 	}
 
-	private string StringArrayToString(string[] input) {
-		return this.StringArrayToString(input, "");
-	}
 	private string StringArrayToString(string[] input, string strデリミタ文字) {
 		var sb = new StringBuilder();
 
@@ -1332,15 +1319,6 @@ internal class CTja : CActivity {
 		}
 
 		return sb.ToString();
-	}
-
-	/// <summary>
-	///
-	/// </summary>
-	/// <param name="InputText"></param>
-	/// <returns>1小節内の文字数</returns>
-	private int t1小節の文字数をカウントする(string InputText) {
-		return InputText.Length - 1;
 	}
 
 	/// <summary>
@@ -1610,33 +1588,6 @@ internal class CTja : CActivity {
 			}
 			#endregion
 		}
-	}
-
-	private CChip t発声位置から過去方向で一番近くにある指定チャンネルのチップを返す(int n発声時刻, int nチャンネル番号) {
-		//過去方向への検索
-		for (int i = this.listChip.Count - 1; i >= 0; i--) {
-			if (this.listChip[i].nChannelNo == nチャンネル番号) {
-				return this.listChip[i];
-			}
-		}
-
-		return null;
-	}
-
-	//現在、以下のような行には対応できていません。
-	//_パラメータを持つ命令がある
-	//_行の途中に命令がある
-	private int t文字数解析(string InputText) {
-		int n文字数 = 0;
-
-		for (int i = 0; i < InputText.Length; i++) {
-			if (this.CharConvertNote(InputText.Substring(i, 1)) != -1) {
-				n文字数++;
-			}
-		}
-
-
-		return n文字数;
 	}
 
 	private static readonly Regex CommandAndArgumentRegex =
@@ -4072,9 +4023,6 @@ internal class CTja : CActivity {
 		return !isOutOfBound;
 	}
 
-	public void SwapGuitarBassInfos() {
-	}
-
 	// SwapGuitarBassInfos_AutoFlags()は、CDTXからCConfigIniに移動。
 
 	// CActivity 実装
@@ -4226,12 +4174,6 @@ internal class CTja : CActivity {
 	private CChip currentCamHScaleChip;
 
 	private Dictionary<string, CChip> currentObjAnimations;
-
-	private void t行のコメント処理(ref string strText) {
-		int nCommentPos = strText.IndexOf("//");
-		if (nCommentPos != -1)
-			strText = strText.Remove(nCommentPos);
-	}
 
 	/// <summary>
 	/// 音源再生前の空白を追加するメソッド。

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -327,7 +327,7 @@ internal class CTja : CActivity {
 	private ECourse nLineCountCourseTemp = ECourse.eNormal; //現在カウント中のコースを記録。
 
 	public int n参照中の難易度 = 3;
-	public int nScoreModeTmp = 99; //2017.01.28 DD
+	public int nScoreMode = -1;
 	public int[,] nScoreInit = new int[2, (int)Difficulty.Total]; //[ x, y ] x=通常or真打 y=コース
 	public int[] nScoreDiff = new int[(int)Difficulty.Total]; //[y]
 	public bool[,] b配点が指定されている = new bool[3, (int)Difficulty.Total]; //2017.06.04 kairera0467 [ x, y ] x=通常(Init)or真打orDiff y=コース
@@ -2902,7 +2902,7 @@ internal class CTja : CActivity {
 			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eMaster]);
 			//tbBALLOON.Text = strCommandParam;
 		} else if (strCommandName.Equals("SCOREMODE")) {
-			ParseOptionalInt16(value => this.nScoreModeTmp = value);
+			ParseOptionalInt16(value => this.nScoreMode = value);
 		} else if (strCommandName.Equals("SCOREINIT")) {
 			if (!string.IsNullOrEmpty(strCommandParam)) {
 				string[] scoreinit = strCommandParam.Split(',');
@@ -2926,7 +2926,7 @@ internal class CTja : CActivity {
 			});
 		} else if (strCommandName.Equals("SCOREMODE")) {
 			if (!string.IsNullOrEmpty(strCommandParam)) {
-				this.nScoreModeTmp = Convert.ToInt16(strCommandParam);
+				this.nScoreMode = Convert.ToInt16(strCommandParam);
 			}
 		} else if (strCommandName.Equals("SCOREINIT")) {
 			if (!string.IsNullOrEmpty(strCommandParam)) {
@@ -2944,13 +2944,6 @@ internal class CTja : CActivity {
 				this.nScoreDiff[this.n参照中の難易度] = Convert.ToInt16(strCommandParam);
 				this.b配点が指定されている[1, this.n参照中の難易度] = true;
 			}
-		}
-		if (this.nScoreModeTmp == 99) //2017.01.28 DD SCOREMODEを入力していない場合のみConfigで設定したモードにする
-		{
-			this.nScoreModeTmp = OpenTaiko.ConfigIni.nScoreMode;
-		}
-		if (OpenTaiko.ConfigIni.nScoreMode == 3 && !this.b配点が指定されている[2, this.n参照中の難易度]) { //2017.06.04 kairera0467
-			this.nScoreModeTmp = 3;
 		}
 	}
 
@@ -3193,7 +3186,7 @@ internal class CTja : CActivity {
 			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eMaster]);
 			//tbBALLOON.Text = strCommandParam;
 		} else if (strCommandName.Equals("SCOREMODE")) {
-			ParseOptionalInt16(value => this.nScoreModeTmp = value);
+			ParseOptionalInt16(value => this.nScoreMode = value);
 		} else if (strCommandName.Equals("SCOREINIT")) {
 			if (!string.IsNullOrEmpty(strCommandParam)) {
 				string[] scoreinit = strCommandParam.Split(',');
@@ -3467,10 +3460,6 @@ internal class CTja : CActivity {
 					}
 				}
 			}
-		}
-		if (this.nScoreModeTmp == 99) {
-			//2017.01.28 DD
-			this.nScoreModeTmp = OpenTaiko.ConfigIni.nScoreMode;
 		}
 	}
 	/// <summary>

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1332,7 +1332,7 @@ internal class CTja : CActivity {
 		RegexOptions.IgnoreCase |
 		RegexOptions.Multiline |
 		RegexOptions.Singleline;
-	private const string CoursePrefixRegexPattern = @"^COURSE\s*:"
+	private const string CoursePrefixRegexPattern = @"^COURSE\s*:";
 	private static readonly Regex CourseSplitRegex = new Regex($"(?={CoursePrefixRegexPattern})", CourseSectionSplitRegexOptions);
 
 	/// <summary>
@@ -3496,6 +3496,7 @@ internal class CTja : CActivity {
 
 		// 小文字大文字区別しない正規表現で仮対応。 (AioiLight)
 		// 相変わらず原始的なやり方だが、正常に動作した。
+		str = str.Trim();
 		string[] Matchptn = new string[7] { "easy", "normal", "hard", "oni", "edit", "tower", "dan" };
 		for (int i = 0; i < Matchptn.Length; i++) {
 			if (string.Equals(str, Matchptn[i], StringComparison.InvariantCultureIgnoreCase)) {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1392,15 +1392,6 @@ internal class CTja : CActivity {
 		nDifficulty = difficulty;
 		if (!String.IsNullOrEmpty(strInput)) //空なら通さない
 		{
-			//2017.02.03 DD ヘッダ内にある命令以外の文字列を削除
-			var startIndex = strInput.IndexOf("#START");
-			if (startIndex < 0) {
-				Trace.TraceWarning($"#START命令が少なくとも1つは必要です。 ({strFullPath})");
-			}
-			string strInputHeader = strInput.Remove(startIndex);
-			strInput = strInput.Remove(0, startIndex);
-			strInput = strInputHeader + "\n" + strInput;
-
 			//どうせ使わないので先にSplitしてコメントを削除。
 			var strSplitした譜面 = (string[])this.str改行文字を削除する(strInput, 1);
 

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1569,7 +1569,6 @@ internal class CTja : CActivity {
 		//命令の最後に,が残ってしまっているときの対応
 		var argument = argumentFull.TrimEnd([',', ' ']);
 
-		char[] chDelimiter = new char[] { ' ' };
 		string[] strArray = null;
 
 		#endregion
@@ -1700,7 +1699,7 @@ internal class CTja : CActivity {
 			this.listChip.Add(this.NewEventChipAtDefCursor(0x9F, 1));
 		} else if (command == "#BGAON") {
 			try {
-				var commandData = argument.Split(' ');
+				var commandData = argument.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 				string listvdIndex = commandData[0];
 				var bgaStartTime = commandData[1];
 				int index = (10 * int.Parse(listvdIndex[0].ToString())) + int.Parse(listvdIndex[1].ToString()) + 2;
@@ -2150,7 +2149,7 @@ internal class CTja : CActivity {
 
 			this.listChip.Add(chip);
 		} else if (command == "#SUDDEN") {
-			strArray = argument.Split(chDelimiter);
+			strArray = argument.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 			WarnSplitLength("#SUDDEN", strArray, 2);
 			double db出現時刻 = Convert.ToDouble(strArray[0]);
 			double db移動待機時刻 = Convert.ToDouble(strArray[1]);
@@ -2168,7 +2167,7 @@ internal class CTja : CActivity {
 
 			this.listChip.Add(chip);
 		} else if (command == "#JPOSSCROLL") {
-			strArray = argument.Split(chDelimiter);
+			strArray = argument.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 			WarnSplitLength("#JPOSSCROLL", strArray, 2);
 			double msMoveDt = double.Max(0, 1000 * Convert.ToDouble(strArray[0]));
 			double pxMoveDx = 0;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1496,6 +1496,7 @@ internal class CTja : CActivity {
 						divPerMeasure = 0;
 					}
 				}
+				this.divsPerMeasureAllBranches.Add(divPerMeasure); // after last comma
 			} catch (Exception ex) {
 				Trace.TraceError(ex.ToString());
 				Trace.TraceError("例外が発生しましたが処理を継続します。 (9e401212-0b78-4073-88d0-f7e791f36a91)");
@@ -2596,8 +2597,7 @@ internal class CTja : CActivity {
 
 	private void t入力_行解析譜面_V4(string InputText) {
 		if (!String.IsNullOrEmpty(InputText)) {
-			int n文字数 = (this.iNowMeasureAllBranches < this.divsPerMeasureAllBranches.Count) ? 16 // after last comma
-				: this.divsPerMeasureAllBranches[this.iNowMeasureAllBranches];
+			int n文字数 = this.divsPerMeasureAllBranches[this.iNowMeasureAllBranches];
 
 			if (InputText.StartsWith("#")) {
 				// Call orders here

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1321,8 +1321,6 @@ internal class CTja : CActivity {
 				for (int i = 0; i < str.Length; i++) {
 					if (s[i] == '\t')
 						s[i] = ' ';
-					else if (s[i] == '\r')
-						s[i] = '\n';
 				}
 			}
 		}
@@ -3552,7 +3550,6 @@ internal class CTja : CActivity {
 						timestring = timeRegex.Match(strSplit後[i]);
 						timestringO = timeRegexO.Match(strSplit後[i]);
 					}
-					strSplit後[i] = strSplit後[i].Replace("\r", "").Replace("\n", "");
 
 					for (int listindex = 0; listindex < list.Count; listindex++) {
 						STLYRIC stlrc;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2894,12 +2894,12 @@ internal class CTja : CActivity {
 		}
 
 		if (strCommandName.Equals("BALLOON") || strCommandName.Equals("BALLOONNOR")) {
-			ParseBalloon(strCommandParam, this.listBalloon_Branch[(int)ECourse.eNormal]);
+			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eNormal]);
 		} else if (strCommandName.Equals("BALLOONEXP")) {
-			ParseBalloon(strCommandParam, this.listBalloon_Branch[(int)ECourse.eExpert]);
+			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eExpert]);
 			//tbBALLOON.Text = strCommandParam;
 		} else if (strCommandName.Equals("BALLOONMAS")) {
-			ParseBalloon(strCommandParam, this.listBalloon_Branch[(int)ECourse.eMaster]);
+			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eMaster]);
 			//tbBALLOON.Text = strCommandParam;
 		} else if (strCommandName.Equals("SCOREMODE")) {
 			ParseOptionalInt16(value => this.nScoreModeTmp = value);
@@ -3019,8 +3019,9 @@ internal class CTja : CActivity {
 	}
 
 
-	private void ParseBalloon(string strCommandParam, List<int> listBalloon) {
+	private void ParseBalloon(string strCommandParam, ref List<int> listBalloon) {
 		string[] strParam = strCommandParam.Split(',');
+		var listTmp = new List<int>(strParam.Length);
 		for (int n = 0; n < strParam.Length; n++) {
 			int n打数;
 			try {
@@ -3032,11 +3033,13 @@ internal class CTja : CActivity {
 				Trace.TraceError($"おや?エラーが出たようです。お兄様。 ({strFullPath})");
 				Trace.TraceError(ex.ToString());
 				Trace.TraceError("例外が発生しましたが処理を継続します。 (95327158-4e83-4fa9-b5e9-ad3c3d4c2a22)");
-				break;
+				return;
 			}
 
-			listBalloon.Add(n打数);
+			listTmp.Add(n打数);
 		}
+		// Arguments are valid, update balloon list
+		listBalloon = listTmp;
 	}
 	private void t入力_行解析ヘッダ(string InputText) {
 		//やべー。先頭にコメント行あったらやばいやん。
@@ -3182,12 +3185,12 @@ internal class CTja : CActivity {
 		}
 		#region[移動→不具合が起こるのでここも一応復活させておく]
 		else if (strCommandName.Equals("BALLOON") || strCommandName.Equals("BALLOONNOR")) {
-			ParseBalloon(strCommandParam, this.listBalloon_Branch[(int)ECourse.eNormal]);
+			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eNormal]);
 		} else if (strCommandName.Equals("BALLOONEXP")) {
-			ParseBalloon(strCommandParam, this.listBalloon_Branch[(int)ECourse.eExpert]);
+			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eExpert]);
 			//tbBALLOON.Text = strCommandParam;
 		} else if (strCommandName.Equals("BALLOONMAS")) {
-			ParseBalloon(strCommandParam, this.listBalloon_Branch[(int)ECourse.eMaster]);
+			ParseBalloon(strCommandParam, ref this.listBalloon_Branch[(int)ECourse.eMaster]);
 			//tbBALLOON.Text = strCommandParam;
 		} else if (strCommandName.Equals("SCOREMODE")) {
 			ParseOptionalInt16(value => this.nScoreModeTmp = value);

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -13,7 +13,6 @@ namespace OpenTaiko;
 internal class CTja : CActivity {
 	// 定数
 
-	public List<string> listErrors = new List<string>();
 	private int nNowReadLine;
 	// Class
 
@@ -1514,10 +1513,10 @@ internal class CTja : CActivity {
 		new Regex(@"^([^,\s]+)\s*,\s*([^,\s]+)\s*,\s*([^,\s]+)$", RegexOptions.Compiled);
 
 	private void AddCommandError(string command, string argument, string reason) {
-		this.listErrors.Add($"{nameof(CTja)}: Bad {command} arguments: {argument}, at {(Difficulty)this.n参照中の難易度}, line {nNowReadLine}, in {strFullPath}: {reason}");
+		LogNotification.PopWarning($"{nameof(CTja)}: Bad {command} arguments: {argument}, at {(Difficulty)this.n参照中の難易度}, line {nNowReadLine}, in {strFullPath}: {reason}");
 	}
 	private void AddWarn(string msg) {
-		this.listErrors.Add($"{nameof(CTja)}: {msg}, at {(Difficulty)this.n参照中の難易度}, line {nNowReadLine}, in {strFullPath}");
+		LogNotification.PopWarning($"{nameof(CTja)}: {msg}, at {(Difficulty)this.n参照中の難易度}, line {nNowReadLine}, in {strFullPath}");
 	}
 
 	private string[] SplitComma(string input) {

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2694,7 +2694,13 @@ internal class CTja : CActivity {
 								this.nNowRollCountBranch[iBranch] = listChip_Branch[iBranch].Count;
 							}
 
-							InsertNoteAtDefCursor(nObjectNum, n, n文字数, branch);
+							if (nObjectNum < 0) {
+								Trace.TraceWarning(this.bHasBranch[this.n参照中の難易度] ?
+									$"{nameof(CTja)}: Unknown note symbol {InputText.Substring(n, 1)} treated as a non-roll blank in branch {branch} at measure {this.n現在の小節数}. Input: {InputText} In {this.strFullPath}"
+									: $"{nameof(CTja)}: Unknown note symbol {InputText.Substring(n, 1)} treated as a non-roll blank at measure {this.n現在の小節数}. Input: {InputText} In {this.strFullPath}");
+							} else {
+								InsertNoteAtDefCursor(nObjectNum, n, n文字数, branch);
+							}
 						}
 					}
 

--- a/OpenTaiko/src/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/OpenTaiko/src/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -348,14 +348,6 @@ internal class CStage曲読み込み : CStage {
 						for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; ++i)
 							OpenTaiko.SetTJA(i, new CTja(str, false, 0, i, true, OpenTaiko.stageSongSelect.nChoosenSongDifficulty[i]));
 
-						if (OpenTaiko.TJA.listErrors.Count != 0) {
-							string message = "";
-							foreach (var text in OpenTaiko.TJA.listErrors) {
-								LogNotification.PopWarning(text);
-								//System.Windows.Forms.MessageBox.Show(text, "譜面にエラーが見つかりました");
-							}
-						}
-
 						Trace.TraceInformation("---- Song information -----------------");
 						Trace.TraceInformation("TITLE: {0}", OpenTaiko.TJA.TITLE.GetString(""));
 						Trace.TraceInformation("FILE: {0}", OpenTaiko.TJA.strFullPath);

--- a/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
+++ b/OpenTaiko/src/Stages/07.Game/CAct演奏演奏情報.cs
@@ -33,7 +33,7 @@ internal class CAct演奏演奏情報 : CActivity {
 		NotesTextE = string.Format("NoteE:         {0:####0}", OpenTaiko.TJA.nノーツ数_Branch[1]);
 		NotesTextM = string.Format("NoteM:         {0:####0}", OpenTaiko.TJA.nノーツ数_Branch[2]);
 		NotesTextC = string.Format("NoteC:         {0:####0}", OpenTaiko.TJA.nノーツ数[3]);
-		ScoreModeText = string.Format("SCOREMODE:     {0:####0}", OpenTaiko.TJA.nScoreModeTmp);
+		ScoreModeText = string.Format("SCOREMODE:     {0:####0}", OpenTaiko.stageGameScreen.scoreMode[0]);
 		ListChipText = string.Format("ListChip:      {0:####0}", _chipCounts[0]);
 		ListChipMText = string.Format("ListChipM:     {0:####0}", _chipCounts[1]);
 

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -705,7 +705,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 	protected const int NOTE_GAP = 25;
 	public int nLoopCount_Clear;
-	protected int[] nScore = new int[11];
+	protected int[,] nScore = new int[5, 11]; // [iPlayer, comboLevel]
 	protected int[] nHand = new int[5];
 	protected CSound[] soundRed = new CSound[5];
 	protected CSound[] soundBlue = new CSound[5];
@@ -1017,7 +1017,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 			if (!OpenTaiko.ConfigIni.ShinuchiMode) {
 				// 旧配点・旧筐体配点
-				if (this.scoreMode[0] == 0 || this.scoreMode[0] == 1) {
+				if (this.scoreMode[nPlayer] == 0 || this.scoreMode[nPlayer] == 1) {
 					if (pChip.nChannelNo == 0x15)
 						nAddScore = 300L;
 					else
@@ -1764,17 +1764,17 @@ internal abstract class CStage演奏画面共通 : CStage {
 				}
 
 				this.actScore.Add((long)nAddScore, nPlayer);
-			} else if (this.scoreMode[0] == 2) {
+			} else if (this.scoreMode[nPlayer] == 2) {
 				if (nCombos < 10) {
-					nAddScore = this.nScore[0];
+					nAddScore = this.nScore[nPlayer, 0];
 				} else if (nCombos >= 10 && nCombos <= 29) {
-					nAddScore = this.nScore[1];
+					nAddScore = this.nScore[nPlayer, 1];
 				} else if (nCombos >= 30 && nCombos <= 49) {
-					nAddScore = this.nScore[2];
+					nAddScore = this.nScore[nPlayer, 2];
 				} else if (nCombos >= 50 && nCombos <= 99) {
-					nAddScore = this.nScore[3];
+					nAddScore = this.nScore[nPlayer, 3];
 				} else if (nCombos >= 100) {
-					nAddScore = this.nScore[4];
+					nAddScore = this.nScore[nPlayer, 4];
 				}
 
 				if (eJudgeResult == ENoteJudge.Great || eJudgeResult == ENoteJudge.Good) {
@@ -1805,29 +1805,29 @@ internal abstract class CStage演奏画面共通 : CStage {
 				}
 
 				this.actScore.Add(nAddScore, nPlayer);
-			} else if (this.scoreMode[0] == 1) {
+			} else if (this.scoreMode[nPlayer] == 1) {
 				if (nCombos < 10) {
-					nAddScore = this.nScore[0];
+					nAddScore = this.nScore[nPlayer, 0];
 				} else if (nCombos >= 10 && nCombos <= 19) {
-					nAddScore = this.nScore[1];
+					nAddScore = this.nScore[nPlayer, 1];
 				} else if (nCombos >= 20 && nCombos <= 29) {
-					nAddScore = this.nScore[2];
+					nAddScore = this.nScore[nPlayer, 2];
 				} else if (nCombos >= 30 && nCombos <= 39) {
-					nAddScore = this.nScore[3];
+					nAddScore = this.nScore[nPlayer, 3];
 				} else if (nCombos >= 40 && nCombos <= 49) {
-					nAddScore = this.nScore[4];
+					nAddScore = this.nScore[nPlayer, 4];
 				} else if (nCombos >= 50 && nCombos <= 59) {
-					nAddScore = this.nScore[5];
+					nAddScore = this.nScore[nPlayer, 5];
 				} else if (nCombos >= 60 && nCombos <= 69) {
-					nAddScore = this.nScore[6];
+					nAddScore = this.nScore[nPlayer, 6];
 				} else if (nCombos >= 70 && nCombos <= 79) {
-					nAddScore = this.nScore[7];
+					nAddScore = this.nScore[nPlayer, 7];
 				} else if (nCombos >= 80 && nCombos <= 89) {
-					nAddScore = this.nScore[8];
+					nAddScore = this.nScore[nPlayer, 8];
 				} else if (nCombos >= 90 && nCombos <= 99) {
-					nAddScore = this.nScore[9];
+					nAddScore = this.nScore[nPlayer, 9];
 				} else if (nCombos >= 100) {
-					nAddScore = this.nScore[10];
+					nAddScore = this.nScore[nPlayer, 10];
 				}
 
 				if (eJudgeResult == ENoteJudge.Great || eJudgeResult == ENoteJudge.Good) {
@@ -4245,7 +4245,10 @@ internal abstract class CStage演奏画面共通 : CStage {
 			this.ePhaseID = CStage.EPhase.Common_NORMAL;//初期化すれば、リザルト変遷は止まる。
 			this.eフェードアウト完了時の戻り値 = EGameplayScreenReturnValue.Continue;
 
-			this.ReSetScore(OpenTaiko.TJA.nScoreInit[0, OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0]], OpenTaiko.TJA.nScoreDiff[OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0]]);
+			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; ++i) {
+				CTja tja = OpenTaiko.GetTJA(i)!;
+				this.ReSetScore(tja.nScoreInit[0, OpenTaiko.stageSongSelect.nChoosenSongDifficulty[i]], tja.nScoreDiff[OpenTaiko.stageSongSelect.nChoosenSongDifficulty[i]], i);
+			}
 			this.nHand = new int[] { 0, 0, 0, 0, 0 };
 		}
 
@@ -4560,24 +4563,24 @@ internal abstract class CStage演奏画面共通 : CStage {
 		return judgement;
 	}
 
-	public void ReSetScore(int scoreInit, int scoreDiff) {
+	public void ReSetScore(int scoreInit, int scoreDiff, int iPlayer) {
 		//一打目の処理落ちがひどいので、あらかじめここで点数の計算をしておく。
 		// -1だった場合、その前を引き継ぐ。
-		int nInit = scoreInit != -1 ? scoreInit : this.nScore[0];
-		int nDiff = scoreDiff != -1 ? scoreDiff : this.nScore[1] - this.nScore[0];
+		int nInit = scoreInit != -1 ? scoreInit : this.nScore[iPlayer, 0];
+		int nDiff = scoreDiff != -1 ? scoreDiff : this.nScore[iPlayer, 1] - this.nScore[iPlayer, 0];
 		int nAddScore = 0;
 		int[] n倍率 = { 0, 1, 2, 4, 8 };
 
-		if (this.scoreMode[0] == 1) {
+		if (this.scoreMode[iPlayer] == 1) {
 			for (int i = 0; i < 11; i++) {
-				this.nScore[i] = (int)(nInit + (nDiff * (i)));
+				this.nScore[iPlayer, i] = (int)(nInit + (nDiff * (i)));
 			}
-		} else if (this.scoreMode[0] == 2) {
+		} else if (this.scoreMode[iPlayer] == 2) {
 			for (int i = 0; i < 5; i++) {
-				this.nScore[i] = (int)(nInit + (nDiff * n倍率[i]));
+				this.nScore[iPlayer, i] = (int)(nInit + (nDiff * n倍率[i]));
 
-				this.nScore[i] = (int)(this.nScore[i] / 10.0);
-				this.nScore[i] = this.nScore[i] * 10;
+				this.nScore[iPlayer, i] = (int)(this.nScore[iPlayer, i] / 10.0);
+				this.nScore[iPlayer, i] = this.nScore[iPlayer, i] * 10;
 
 			}
 		}

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -36,6 +36,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 	public int[] nBalloonCount = new int[5];
 	public double[] nRollTimeMs = new double[5];
 	public double[] nAddScoreNiji = new double[5];
+	public int[] scoreMode = new int[5];
 
 	public override void Activate() {
 		listChip = new List<CChip>[5];
@@ -62,6 +63,8 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			CTja _dtx = OpenTaiko.GetTJA(i)!;
+
+			this.scoreMode[i] = (_dtx.nScoreMode >= 0) ? _dtx.nScoreMode : OpenTaiko.ConfigIni.nScoreMode;
 
 			if (OpenTaiko.ConfigIni.nPlayerCount >= 2) {
 				for (int j = 0; j < balloonChips[i].Count; j++) {
@@ -1014,7 +1017,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 			if (!OpenTaiko.ConfigIni.ShinuchiMode) {
 				// 旧配点・旧筐体配点
-				if (OpenTaiko.TJA.nScoreModeTmp == 0 || OpenTaiko.TJA.nScoreModeTmp == 1) {
+				if (this.scoreMode[0] == 0 || this.scoreMode[0] == 1) {
 					if (pChip.nChannelNo == 0x15)
 						nAddScore = 300L;
 					else
@@ -1761,7 +1764,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				}
 
 				this.actScore.Add((long)nAddScore, nPlayer);
-			} else if (OpenTaiko.TJA.nScoreModeTmp == 2) {
+			} else if (this.scoreMode[0] == 2) {
 				if (nCombos < 10) {
 					nAddScore = this.nScore[0];
 				} else if (nCombos >= 10 && nCombos <= 29) {
@@ -1802,7 +1805,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				}
 
 				this.actScore.Add(nAddScore, nPlayer);
-			} else if (OpenTaiko.TJA.nScoreModeTmp == 1) {
+			} else if (this.scoreMode[0] == 1) {
 				if (nCombos < 10) {
 					nAddScore = this.nScore[0];
 				} else if (nCombos >= 10 && nCombos <= 19) {
@@ -4565,11 +4568,11 @@ internal abstract class CStage演奏画面共通 : CStage {
 		int nAddScore = 0;
 		int[] n倍率 = { 0, 1, 2, 4, 8 };
 
-		if (OpenTaiko.TJA.nScoreModeTmp == 1) {
+		if (this.scoreMode[0] == 1) {
 			for (int i = 0; i < 11; i++) {
 				this.nScore[i] = (int)(nInit + (nDiff * (i)));
 			}
-		} else if (OpenTaiko.TJA.nScoreModeTmp == 2) {
+		} else if (this.scoreMode[0] == 2) {
 			for (int i = 0; i < 5; i++) {
 				this.nScore[i] = (int)(nInit + (nDiff * n倍率[i]));
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -61,7 +61,7 @@ internal class Dan_Cert : CActivity {
 
 		ScreenPoint = new double[] { OpenTaiko.Skin.Game_Lane_X[0] - OpenTaiko.Tx.DanC_Screen.szTextureSize.Width / 2, OpenTaiko.Skin.Resolution[0] };
 
-		OpenTaiko.stageGameScreen.ReSetScore(OpenTaiko.TJA.List_DanSongs[NowShowingNumber].ScoreInit, OpenTaiko.TJA.List_DanSongs[NowShowingNumber].ScoreDiff);
+		OpenTaiko.stageGameScreen.ReSetScore(OpenTaiko.TJA.List_DanSongs[NowShowingNumber].ScoreInit, OpenTaiko.TJA.List_DanSongs[NowShowingNumber].ScoreDiff, 0);
 
 		OpenTaiko.stageGameScreen.ftDanReSetScoreNiji(OpenTaiko.TJA.nDan_NotesCount[NowShowingNumber], OpenTaiko.TJA.nDan_BalloonCount[NowShowingNumber]);
 		OpenTaiko.stageGameScreen.ftDanReSetBranches(OpenTaiko.TJA.bHasBranchDan[NowShowingNumber]);


### PR DESCRIPTION
## Fixed


* fix note symbols after last comma (before `#END`) were treated as 16 divisions per measure
* fix unknown note symbols were treated as `#NMSCROLL`
* fix(CTja): ignore inner whitespaces in note symbol lines as in TaikoJiro
* fix the first arbitrary mid-line `#START` (e.g., `TITLE:#START`) to be recognized as `#START` by forbidding indentation of `#START`
* fix commented-out or in-argument `COURSE:` & `#END` affected parsing by requiring them to be at line head
* fix `COURSE:` argument failed to be recognized when it has surrounding space(s)
* fix 2-players chart took in AI battle mode
* fix BALLOON headers could not reset balloon counts and failed to work per–player-side, fix incompatibility with TaikoJiro
* fix non–Shin-uchi score setting for non-P1 was forced to P1's
* fix(CTja): make all `#NEXTSONG` argument soft-optional to prevent crashes due to `,`s at line end ignored
* fix TJA command trailing `,` trimming issues
* fix consecutive spaces in `#JPOSSCROLL`, `#SUDDEN`, & `#BGAON` terminates TJA parsing
* fix 2nd `:` and on ignored for per-player-side and EXAM headers and remove handling of impossible cases
* fix crash when `LogCard`s are frequently added into CVisualLogManager
* fix the last-defined difficulty was used as the score setting difficulty, <cd> store-expr variable difficulty, and reported parsing difficulty
* fix: reject invalid argument instead of using a default value for commands #BPMCHANGE, #SCROLL, #MEASURE, #DELAY, & CAM setter, and EXAM header

## Performance

* perf(CTja): remove unnecessary string-joining-then-splitting by `\n` for chart chunk processing
* perf(CTja): O(n^2) -> O(n): reduce total TJA-line-to-divsPerMeasure lookup time complexity
* perf(CTja): eliminate temporary TJA line lists for preprocessing and parsing TJA commands and notes
* perf(CDTXStyleExtractor): reduce unneeded scanning for recognizing style and player-side kind

## Features

* feat(CTja): catch and report argument error per TJA header or command
* feat: print and log every TJA parse warning right away
* feat: use simplified message for printed TJA parse warnings