### PR TITLE
Fixes #840 - Linux: Blank window / Not booting

### DIFF
--- a/FDK/src/01.Framework/Core/Game.cs
+++ b/FDK/src/01.Framework/Core/Game.cs
@@ -287,8 +287,12 @@ public abstract class Game : IDisposable {
 		options.Title = Text;
 
 
-		Silk.NET.Windowing.Glfw.GlfwWindowing.Use();
-		//Silk.NET.Windowing.Sdl.SdlWindowing.Use();
+		// Use SDL on Linux with Wayland, otherwise use GLFW for everything else
+		if (OperatingSystem.IsLinux() && Environment.GetEnvironmentVariable("XDG_SESSION_TYPE") == "wayland") {
+		    Silk.NET.Windowing.Sdl.SdlWindowing.Use();
+		} else {
+		    Silk.NET.Windowing.Glfw.GlfwWindowing.Use();
+		}
 
 		Window_ = Window.Create(options);
 


### PR DESCRIPTION
1. Detects if running on Linux with Wayland session
2. Uses SDL for that specific case
3. Uses GLFW for all other cases (Windows, macOS, Linux with X11)
4. Requires no additional imports since OperatingSystem and Environment are in the base library