### PR TITLE
Change to linear filtering

### DIFF
--- a/FDK/src/04.Graphics/CTexture.cs
+++ b/FDK/src/04.Graphics/CTexture.cs
@@ -434,8 +434,10 @@ public class CTexture : IDisposable {
 		//-----
 
 		//拡大縮小の時の補完を指定------
-		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMinFilter, (int)TextureMinFilter.Nearest); //この場合は補完しない
-		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMagFilter, (int)TextureMinFilter.Nearest);
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMinFilter, (int)TextureMinFilter.Linear); //この場合は補完しない
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureMagFilter, (int)TextureMagFilter.Linear);
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureWrapS, (int)TextureWrapMode.ClampToEdge);
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureWrapT, (int)TextureWrapMode.ClampToEdge);
 		//------
 
 		Game.Gl.BindTexture(TextureTarget.Texture2D, 0); //バインドを解除することを忘れないように
@@ -482,6 +484,14 @@ public class CTexture : IDisposable {
 	public void tSetScale(float x, float y) {
 		vcScaleRatio.X = x;
 		vcScaleRatio.Y = y;
+	}
+	public void tSetWrapMode(TextureWrapMode mode) {
+		Game.Gl.BindTexture(TextureTarget.Texture2D, Pointer);
+
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureWrapS, (int)mode);
+		Game.Gl.TexParameterI(GLEnum.Texture2D, GLEnum.TextureWrapT, (int)mode);
+
+		Game.Gl.BindTexture(TextureTarget.Texture2D, 0);
 	}
 
 	// メソッド

--- a/OpenTaiko/System/Open-World Memories/Graphics/5_Game/5_Background/Normal/Down/0/Script.lua
+++ b/OpenTaiko/System/Open-World Memories/Graphics/5_Game/5_Background/Normal/Down/0/Script.lua
@@ -15,7 +15,7 @@ end
 function init()
     func:AddGraph("Down.png");
     func:AddGraph("Down_Clear.png");
-    func:AddGraph("Down_Scroll.png");
+    func:AddGraph("Down_Scroll.png", "Repeat");
 end
 
 function update()

--- a/OpenTaiko/System/Open-World Memories/Graphics/5_Game/5_Background/Normal/Up/1/Script.lua
+++ b/OpenTaiko/System/Open-World Memories/Graphics/5_Game/5_Background/Normal/Up/1/Script.lua
@@ -27,11 +27,11 @@ end
 function init()
     func:AddGraph("1P_Up_1st.png");
     func:AddGraph("2P_Up_1st.png");
-    func:AddGraph("1P_Up_3rd.png");
-    func:AddGraph("2P_Up_3rd.png");
+    func:AddGraph("1P_Up_3rd.png", "Repeat");
+    func:AddGraph("2P_Up_3rd.png", "Repeat");
     func:AddGraph("Clear_Up_1st.png");
-    func:AddGraph("Clear_Up_2nd.png");
-    func:AddGraph("Clear_Up_3rd.png");
+    func:AddGraph("Clear_Up_2nd.png", "Repeat");
+    func:AddGraph("Clear_Up_3rd.png", "Repeat");
 end
 
 function update()

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using FDK;
 using NLua;
+using Silk.NET.OpenGLES;
 
 namespace OpenTaiko;
 
@@ -18,10 +19,11 @@ class ScriptBGFunc {
 	public (int x, int y) DrawNum(double x, double y, double text) {
 		return OpenTaiko.actTextConsole.Print((int)x, (int)y, CTextConsole.EFontType.White, text.ToString());
 	}
-	public void AddGraph(string fileName) {
+	public void AddGraph(string fileName, string wrapMode = "") {
 		string trueFileName = fileName.Replace('/', Path.DirectorySeparatorChar);
 		trueFileName = trueFileName.Replace('\\', Path.DirectorySeparatorChar);
 		Textures.Add(fileName, OpenTaiko.tテクスチャの生成($@"{DirPath}{Path.DirectorySeparatorChar}{trueFileName}"));
+		SetWrapMode(wrapMode, fileName);
 	}
 	public void DrawGraph(double x, double y, string fileName) {
 		Textures[fileName]?.t2D描画((int)x, (int)y);
@@ -90,6 +92,19 @@ class ScriptBGFunc {
 					Textures[fileName].bスクリーン合成 = true;
 					break;
 			}
+		}
+	}
+	public void SetWrapMode(string mode, string fileName) {
+		if (Textures[fileName] == null) return;
+
+		switch (mode.ToLower()) {
+			case "clamp to edge":
+			default:
+				Textures[fileName].tSetWrapMode(TextureWrapMode.ClampToEdge);
+				break;
+			case "repeat":
+				Textures[fileName].tSetWrapMode(TextureWrapMode.Repeat);
+				break;
 		}
 	}
 


### PR DESCRIPTION
This is in essence a continuation of #819, setting the texture filters to linear for a smoother look at resolutions above 1080p, while removing artifacting and still allowing textures such as scrolling backgrounds to repeat.

I tried to keep it compatible with existing skins the best I could, so I ended up making clamp to edge the default for most textures, requiring only repeating textures to be manually set to repeat. The helper function `CTexture.tSetWrapMode` can be used to change the wrap mode, and there is an additional Lua function `SetWrapMode` for use in skin scripts. Instead of setting it directly, the wrap mode can also be passed to `AddGraph` which makes updating skins very easy (see changes).

NB I have not changed all scripts in the Open-World Memories skin yet, only those that appear in standard play, but I'll edit those as well if the changes are approved.