### PR TITLE
fix some misc bugs

### DIFF
--- a/OpenTaiko/src/Common/CConfigIni.cs
+++ b/OpenTaiko/src/Common/CConfigIni.cs
@@ -1769,20 +1769,14 @@ internal class CConfigIni : INotifyPropertyChanged {
 					continue;
 				}
 				for (int k = 0; k < 0x10; k++) {
-					if (this.KeyAssign[i][j][k].InputDevice != deviceType ||
-						this.KeyAssign[i][j][k].ID != nID ||
-						this.KeyAssign[i][j][k].Code != nCode) {
-						continue;
+					if (this.KeyAssign[i][j][k].InputDevice == deviceType
+						&& this.KeyAssign[i][j][k].ID == nID
+						&& this.KeyAssign[i][j][k].Code == nCode
+						) {
+						this.KeyAssign[i][j][k].InputDevice = EInputDevice.Unknown;
+						this.KeyAssign[i][j][k].ID = 0;
+						this.KeyAssign[i][j][k].Code = 0;
 					}
-
-					for (int m = k; m < 15; m++) {
-						this.KeyAssign[i][j][m] = this.KeyAssign[i][j][m + 1];
-					}
-
-					this.KeyAssign[i][j][15].InputDevice = EInputDevice.Unknown;
-					this.KeyAssign[i][j][15].ID = 0;
-					this.KeyAssign[i][j][15].Code = 0;
-					k--;
 				}
 			}
 		}

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -1981,8 +1981,7 @@ internal class CTja : CActivity {
 		} else if (command == "#MERGELANE") {
 			this.listChip.Add(this.NewEventChipAtDefCursor(0xE3, 1));
 		} else if (command == "#BARLINE") {
-			var chip = this.NewEventChipAtDefCursor(0xE4, 1);
-			chip.dbSCROLL_Y = this.dbNowScrollY;
+			var chip = this.NewScrolledChipAtDefCursor(0xE4, 0, 1, this.n現在のコース);
 			chip.bHideBarLine = false;
 			this.listChip.Add(chip);
 			this.listBarLineChip.Add(chip);

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -569,6 +569,7 @@ internal class CTja : CActivity {
 						cwav.rSound[i].Stop();
 					}
 				}
+				cwav.n一時停止時刻[i] = long.MinValue; // prevent unpause
 			}
 		}
 	}
@@ -876,7 +877,9 @@ internal class CTja : CActivity {
 	public void t全チップの再生再開() {
 		foreach (CWAV cwav in this.listWAV.Values) {
 			for (int i = 0; i < nPolyphonicSounds; i++) {
-				if ((cwav.rSound[i] != null) && cwav.rSound[i].IsPaused) {
+				// paused: pause >= play time (do resume)
+				// stopped: pause < play time (do not resume)
+				if ((cwav.rSound[i] != null) && cwav.rSound[i].IsPaused && cwav.n一時停止時刻[i] >= cwav.n再生開始時刻[i]) {
 					cwav.rSound[i].Resume(cwav.n一時停止時刻[i] - cwav.n再生開始時刻[i]);
 					cwav.n再生開始時刻[i] += SoundManager.PlayTimer.SystemTimeMs - cwav.n一時停止時刻[i];
 				}

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -2776,24 +2776,28 @@ internal class CTja : CActivity {
 			if (branch == (IsEndedBranching ? ECourse.eNormal : ECourse.eMaster)) {
 				if (this.n参照中の難易度 == (int)Difficulty.Dan) {
 					this.nDan_NotesCount[List_DanSongs.Count - 1]++;
-					if (NotesManager.IsADLIB(chip))
-						this.nDan_AdLibCount[List_DanSongs.Count - 1]++;
-					else if (NotesManager.IsMine(chip))
-						this.nDan_MineCount[List_DanSongs.Count - 1]++;
 				}
 				if (IsEndedBranching) {
 					this.nノーツ数[3]++;
 				}
 			}
+		} else if (NotesManager.IsADLIB(chip)) {
+			if (branch == (IsEndedBranching ? ECourse.eNormal : ECourse.eMaster) && this.n参照中の難易度 == (int)Difficulty.Dan) {
+				this.nDan_AdLibCount[List_DanSongs.Count - 1]++;
+			}
+		} else if (NotesManager.IsMine(chip)) {
+			if (branch == (IsEndedBranching ? ECourse.eNormal : ECourse.eMaster) && this.n参照中の難易度 == (int)Difficulty.Dan) {
+				this.nDan_MineCount[List_DanSongs.Count - 1]++;
+			}
 		} else if (NotesManager.IsGenericBalloon(chip)) {
 			if (branch == (IsEndedBranching ? ECourse.eNormal : ECourse.eMaster) && this.n参照中の難易度 == (int)Difficulty.Dan) {
 				this.nDan_BalloonHitCount[List_DanSongs.Count - 1] += chip.nBalloon;
+				if (NotesManager.IsFuzeRoll(chip))
+					this.nDan_MineCount[List_DanSongs.Count - 1]++;
 			}
 		} else if (NotesManager.IsGenericRoll(chip) && !NotesManager.IsRollEnd(chip)) {
 			if (branch == (IsEndedBranching ? ECourse.eNormal : ECourse.eMaster) && this.n参照中の難易度 == (int)Difficulty.Dan) {
 				this.nDan_BarRollCount[List_DanSongs.Count - 1]++;
-				if (NotesManager.IsFuzeRoll(chip))
-					this.nDan_MineCount[List_DanSongs.Count - 1]++;
 			}
 		}
 

--- a/OpenTaiko/src/Stages/04.Config/CActConfigKeyAssign.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigKeyAssign.cs
@@ -158,7 +158,7 @@ internal class CActConfigKeyAssign : CActivity {
 			}
 			OpenTaiko.stageConfig.actFont.t文字列描画(x + num5, y, "Reset", this.n現在の選択行 == 0x10, 0.75f);
 			y += num5;
-			OpenTaiko.stageConfig.actFont.t文字列描画(x + num5, y, "<< Returnto List", this.n現在の選択行 == 0x11, 0.75f);
+			OpenTaiko.stageConfig.actFont.t文字列描画(x + num5, y, "<< Return to List", this.n現在の選択行 == 0x11, 0.75f);
 			y += num5;
 			if (this.bキー入力待ち && (OpenTaiko.Tx.Config_KeyAssign != null)) {
 				OpenTaiko.Tx.Config_KeyAssign.t2D描画(OpenTaiko.Skin.Config_KeyAssign[0], OpenTaiko.Skin.Config_KeyAssign[1]);

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -525,29 +525,14 @@ internal abstract class CStage演奏画面共通 : CStage {
 		double screen_ratio = OpenTaiko.Skin.Resolution[0] / 1280.0;
 		return (int)(JPOSCROLLX[player] * screen_ratio);
 	}
-	public int[] NoteOriginX {
-		get {
-			if (OpenTaiko.ConfigIni.nPlayerCount == 5) {
-				return new int[] {
-					OpenTaiko.Skin.nScrollField_5P[0] + (OpenTaiko.Skin.Game_UIMove_5P[0] * 0) + GetJPOSCROLLX(0),
-					OpenTaiko.Skin.nScrollField_5P[0] + (OpenTaiko.Skin.Game_UIMove_5P[0] * 1) + GetJPOSCROLLX(1),
-					OpenTaiko.Skin.nScrollField_5P[0] + (OpenTaiko.Skin.Game_UIMove_5P[0] * 2) + GetJPOSCROLLX(2),
-					OpenTaiko.Skin.nScrollField_5P[0] + (OpenTaiko.Skin.Game_UIMove_5P[0] * 3) + GetJPOSCROLLX(3),
-					OpenTaiko.Skin.nScrollField_5P[0] + (OpenTaiko.Skin.Game_UIMove_5P[0] * 4) + GetJPOSCROLLX(4)
-				};
-			} else if (OpenTaiko.ConfigIni.nPlayerCount == 4 || OpenTaiko.ConfigIni.nPlayerCount == 3) {
-				return new int[] {
-					OpenTaiko.Skin.nScrollField_4P[0] + (OpenTaiko.Skin.Game_UIMove_4P[0] * 0) + GetJPOSCROLLX(0),
-					OpenTaiko.Skin.nScrollField_4P[0] + (OpenTaiko.Skin.Game_UIMove_4P[0] * 1) + GetJPOSCROLLX(1),
-					OpenTaiko.Skin.nScrollField_4P[0] + (OpenTaiko.Skin.Game_UIMove_4P[0] * 2) + GetJPOSCROLLX(2),
-					OpenTaiko.Skin.nScrollField_4P[0] + (OpenTaiko.Skin.Game_UIMove_4P[0] * 3) + GetJPOSCROLLX(3)
-				};
-			} else {
-				return new int[] {
-					OpenTaiko.Skin.nScrollFieldX[0] + GetJPOSCROLLX(0),
-					OpenTaiko.Skin.nScrollFieldX[1] + GetJPOSCROLLX(1)
-				};
-			}
+
+	public int GetNoteOriginX(int iPlayer) {
+		if (OpenTaiko.ConfigIni.nPlayerCount == 5) {
+			return OpenTaiko.Skin.nScrollField_5P[0] + (OpenTaiko.Skin.Game_UIMove_5P[0] * iPlayer) + GetJPOSCROLLX(iPlayer);
+		} else if (OpenTaiko.ConfigIni.nPlayerCount == 4 || OpenTaiko.ConfigIni.nPlayerCount == 3) {
+			return OpenTaiko.Skin.nScrollField_4P[0] + (OpenTaiko.Skin.Game_UIMove_4P[0] * iPlayer) + GetJPOSCROLLX(iPlayer);
+		} else {
+			return OpenTaiko.Skin.nScrollFieldX[iPlayer] + GetJPOSCROLLX(iPlayer);
 		}
 	}
 
@@ -556,29 +541,14 @@ internal abstract class CStage演奏画面共通 : CStage {
 		double screen_ratio = OpenTaiko.Skin.Resolution[1] / 720.0;
 		return (int)(JPOSCROLLY[player] * screen_ratio);
 	}
-	public int[] NoteOriginY {
-		get {
-			if (OpenTaiko.ConfigIni.nPlayerCount == 5) {
-				return new int[] {
-					OpenTaiko.Skin.nScrollField_5P[1] + (OpenTaiko.Skin.Game_UIMove_5P[1] * 0) + GetJPOSCROLLY(0),
-					OpenTaiko.Skin.nScrollField_5P[1] + (OpenTaiko.Skin.Game_UIMove_5P[1] * 1) + GetJPOSCROLLY(1),
-					OpenTaiko.Skin.nScrollField_5P[1] + (OpenTaiko.Skin.Game_UIMove_5P[1] * 2) + GetJPOSCROLLY(2),
-					OpenTaiko.Skin.nScrollField_5P[1] + (OpenTaiko.Skin.Game_UIMove_5P[1] * 3) + GetJPOSCROLLY(3),
-					OpenTaiko.Skin.nScrollField_5P[1] + (OpenTaiko.Skin.Game_UIMove_5P[1] * 4) + GetJPOSCROLLY(4)
-				};
-			} else if (OpenTaiko.ConfigIni.nPlayerCount == 4 || OpenTaiko.ConfigIni.nPlayerCount == 3) {
-				return new int[] {
-					OpenTaiko.Skin.nScrollField_4P[1] + (OpenTaiko.Skin.Game_UIMove_4P[1] * 0) + GetJPOSCROLLY(0),
-					OpenTaiko.Skin.nScrollField_4P[1] + (OpenTaiko.Skin.Game_UIMove_4P[1] * 1) + GetJPOSCROLLY(1),
-					OpenTaiko.Skin.nScrollField_4P[1] + (OpenTaiko.Skin.Game_UIMove_4P[1] * 2) + GetJPOSCROLLY(2),
-					OpenTaiko.Skin.nScrollField_4P[1] + (OpenTaiko.Skin.Game_UIMove_4P[1] * 3) + GetJPOSCROLLY(3)
-				};
-			} else {
-				return new int[] {
-					OpenTaiko.Skin.nScrollFieldY[0] + GetJPOSCROLLY(0),
-					OpenTaiko.Skin.nScrollFieldY[1] + GetJPOSCROLLY(1)
-				};
-			}
+
+	public int GetNoteOriginY(int iPlayer) {
+		if (OpenTaiko.ConfigIni.nPlayerCount == 5) {
+			return OpenTaiko.Skin.nScrollField_5P[1] + (OpenTaiko.Skin.Game_UIMove_5P[1] * iPlayer) + GetJPOSCROLLY(iPlayer);
+		} else if (OpenTaiko.ConfigIni.nPlayerCount == 4 || OpenTaiko.ConfigIni.nPlayerCount == 3) {
+			return OpenTaiko.Skin.nScrollField_4P[1] + (OpenTaiko.Skin.Game_UIMove_4P[1] * iPlayer) + GetJPOSCROLLY(iPlayer);
+		} else {
+			return OpenTaiko.Skin.nScrollFieldY[iPlayer] + GetJPOSCROLLY(iPlayer);
 		}
 	}
 

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -4145,11 +4145,12 @@ internal abstract class CStage演奏画面共通 : CStage {
 				switch (chara.effect.tGetGaugeType()) {
 					default:
 					case "Normal":
-						bIsAlreadyCleared[i] = false;
+						bIsAlreadyMaxed[i] = bIsAlreadyCleared[i] = false;
 						break;
 					case "Hard":
 					case "Extreme":
 						bIsAlreadyCleared[i] = true;
+						bIsAlreadyMaxed[i] = false;
 						break;
 				}
 

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -335,7 +335,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				nBalloonHits += Math.Min(_chip.nBalloon, expectedHits);
 			}
 
-			if (NotesManager.IsRoll(_chip) || NotesManager.IsFuzeRoll(_chip))
+			if (NotesManager.IsRoll(_chip))
 				msRollTime += (_chip.end.n発声時刻ms - _chip.n発声時刻ms);
 		}
 	}

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -797,10 +797,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 	}
 
 	private void UpdateCharaCounter(int nPlayer) {
-		for (int i = 0; i < 5; i++) {
-			ctChipAnime[i] = new CCounter(0, 3, CTja.TjaDurationToGameDuration(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i] * 1 / 4), SoundManager.PlayTimer);
-		}
-
+		ctChipAnime[nPlayer] = new CCounter(0, 3, CTja.TjaDurationToGameDuration(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer] * 1 / 4), SoundManager.PlayTimer);
 		OpenTaiko.stageGameScreen.PuchiChara.ChangeBPM(CTja.TjaDurationToGameDuration(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer]));
 	}
 
@@ -1393,8 +1390,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 		bool cleared = HGaugeMethods.UNSAFE_FastNormaCheck(nPlayer);
 
 		if (eJudgeResult != ENoteJudge.Poor && eJudgeResult != ENoteJudge.Miss) {
-			double dbUnit = (((60.0 / (OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer]))));
-
 			// ランナー(たたけたやつ)
 			this.actRunner.Start(nPlayer, false, pChip);
 
@@ -1472,10 +1467,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 		void returnChara() {
 			int Character = this.actChara.iCurrentCharacter[nPlayer];
-
-			double dbUnit = (((60.0 / (OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer]))));
-			dbUnit = (((60.0 / pChip.dbBPM)));
-
 			if (OpenTaiko.Skin.Characters_Return_Ptn[Character] != 0 && !bIsGOGOTIME[nPlayer] && actChara.CharaAction_Balloon_Delay[nPlayer].IsEnded) {
 				{
 					// 魂ゲージMAXではない
@@ -1610,9 +1601,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 			// Combo voice here
 			this.actComboVoice.tPlay(this.actCombo.nCurrentCombo[nPlayer], nPlayer);
-
-			double dbUnit = (((60.0 / (OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[nPlayer]))));
-			dbUnit = (((60.0 / pChip.dbBPM)));
 
 			//CDTXMania.act文字コンソール.tPrint(620, 80, C文字コンソール.Eフォント種別.白, "BPM: " + dbUnit.ToString());
 

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -1099,7 +1099,10 @@ internal abstract class CStage演奏画面共通 : CStage {
 			return false;
 		}
 
+		this.bCurrentlyDrumRoll[player] = true;
+		this.actChara.b風船連打中[player] = true;
 		if (IsKusudama) {
+			this.actChara.IsInKusudama = true;
 			rollCount = pChip.nRollCount = ++nCurrentKusudamaRollCount;
 			balloon = nCurrentKusudamaCount;
 			if (nCurrentKusudamaCount > 0) {
@@ -1114,8 +1117,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 				}
 			}
 		} else {
-			this.bCurrentlyDrumRoll[player] = true;
-			this.actChara.b風船連打中[player] = true;
 			actChara.ChangeAnime(player, CActImplCharacter.Anime.Balloon_Breaking, true);
 
 
@@ -3649,6 +3650,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 				this.nowProcessingKusudama = chip;
 				actBalloon.KusuIn();
 				actChara.KusuIn();
+				this.actChara.IsInKusudama = true;
 				for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 					this.bCurrentlyDrumRoll[i] = true;
 					this.actChara.b風船連打中[i] = true;
@@ -3674,11 +3676,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 							OpenTaiko.Skin.soundKusudamaMiss.tPlay();
 							for (int p = 0; p < OpenTaiko.ConfigIni.nPlayerCount; p++) {
 								this.actChara.ChangeAnime(p, CActImplCharacter.Anime.Kusudama_Miss, true);
-
-								if (actChara.CharaAction_Balloon_Delay[p] != null) actChara.CharaAction_Balloon_Delay[p] = new CCounter(0,
-									OpenTaiko.Skin.Characters_Balloon_Delay[actChara.iCurrentCharacter[p]] - 1,
-									1,
-									OpenTaiko.Timer);
 							}
 						}
 						nCurrentKusudamaRollCount = 0;
@@ -3689,11 +3686,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 					if (!this.bPAUSE && !this.isRewinding) {
 						if (chip.nRollCount > 0) {
 							this.actChara.ChangeAnime(iPlayer, CActImplCharacter.Anime.Balloon_Miss, true);
-
-							if (actChara.CharaAction_Balloon_Delay[iPlayer] != null) actChara.CharaAction_Balloon_Delay[iPlayer] = new CCounter(0,
-								OpenTaiko.Skin.Characters_Balloon_Delay[actChara.iCurrentCharacter[iPlayer]] - 1,
-								1,
-								OpenTaiko.Timer);
 						}
 					}
 				}
@@ -3741,8 +3733,6 @@ internal abstract class CStage演奏画面共通 : CStage {
 			actBalloon.KusuBroke();
 			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 				actChara.ChangeAnime(i, CActImplCharacter.Anime.Kusudama_Broke, true);
-				if (actChara.CharaAction_Balloon_Delay[i] != null)
-					actChara.CharaAction_Balloon_Delay[i] = new CCounter(0, OpenTaiko.Skin.Characters_Balloon_Delay[actChara.iCurrentCharacter[i]] - 1, 1, OpenTaiko.Timer);
 			}
 		} else {
 			//ﾊﾟｧｰﾝ
@@ -3756,11 +3746,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 			//this.b連打中 = false;
 			//this.actChara.b風船連打中 = false;
 			chip.bVisible = false;
-			{
-				actChara.ChangeAnime(iPlayer, CActImplCharacter.Anime.Balloon_Broke, true);
-				if (actChara.CharaAction_Balloon_Delay[iPlayer] != null)
-					actChara.CharaAction_Balloon_Delay[iPlayer] = new CCounter(0, OpenTaiko.Skin.Characters_Balloon_Delay[actChara.iCurrentCharacter[iPlayer]] - 1, 1, OpenTaiko.Timer);
-			}
+			actChara.ChangeAnime(iPlayer, CActImplCharacter.Anime.Balloon_Broke, true);
 			if (NotesManager.IsFuzeRoll(chip)) {
 				this.CChartScore[iPlayer].nMineAvoid++;
 				this.CSectionScore[iPlayer].nMineAvoid++;
@@ -3807,9 +3793,14 @@ internal abstract class CStage演奏画面共通 : CStage {
 		this.chip現在処理中の連打チップ[iPlayer].Remove(chip);
 		if (this.chip現在処理中の連打チップ[iPlayer].Count == 0) {
 			this.bCurrentlyDrumRoll[iPlayer] = false;
+			this.actChara.b風船連打中[iPlayer] = false;
+			this.actChara.IsInKusudama = false;
 			this.eRollState = ERollState.None;
 		} else if (!this.chip現在処理中の連打チップ[iPlayer].Any(x => NotesManager.IsGenericBalloon(x))) {
 			this.actChara.b風船連打中[iPlayer] = false;
+			this.actChara.IsInKusudama = false;
+		} else if (!this.chip現在処理中の連打チップ[iPlayer].Any(x => NotesManager.IsKusudama(x))) {
+			this.actChara.IsInKusudama = false;
 		}
 		if (resetStates || (!this.bPAUSE && !this.isRewinding)) {
 			chip.bProcessed = !resetStates;

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -1602,7 +1602,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 
 		#region[ Combo voice ]
 
-		if (!NotesManager.IsGenericRoll(pChip)) {
+		if (NotesManager.IsMissableNote(pChip)) {
 			if ((this.actCombo.nCurrentCombo[nPlayer] % 100 == 0 || this.actCombo.nCurrentCombo[nPlayer] == 50) && this.actCombo.nCurrentCombo[nPlayer] > 0) {
 				this.actComboBalloon.Start(this.actCombo.nCurrentCombo[nPlayer], nPlayer);
 			}

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -904,7 +904,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 			pChip.nLag = (int)(nTime - pChip.n発声時刻ms);
 			int nDeltaTime = Math.Abs(pChip.nLag);
 			//Debug.WriteLine("nAbsTime=" + (nTime - pChip.n発声時刻ms) + ", nDeltaTime=" + (nTime - pChip.n発声時刻ms));
-			if (NotesManager.IsRoll(pChip) || NotesManager.IsFuzeRoll(pChip)) {
+			if (NotesManager.IsRoll(pChip)) {
 				if (tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) >= pChip.n発声時刻ms && tja.GameTimeToTjaTime(SoundManager.PlayTimer.NowTimeMs) < pChip.end.n発声時刻ms) {
 					return ENoteJudge.Perfect;
 				}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBalloon.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBalloon.cs
@@ -127,9 +127,14 @@ internal class CActImplBalloon : CActivity {
 				num_x = OpenTaiko.Skin.Game_Balloon_Balloon_Number_X[player];
 				num_y = OpenTaiko.Skin.Game_Balloon_Balloon_Number_Y[player];
 			}
-			//1P:0 2P:245
-			//if (CDTXMania.Tx.Chara_Balloon_Breaking != null && CDTXMania.ConfigIni.ShowChara)
-			//    CDTXMania.Tx.Chara_Balloon_Breaking.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Chara_Balloon_X[player], CDTXMania.Skin.Game_Chara_Balloon_Y[player]);
+
+			x += OpenTaiko.stageGameScreen.GetJPOSCROLLX(player);
+			y += OpenTaiko.stageGameScreen.GetJPOSCROLLY(player);
+			frame_x += OpenTaiko.stageGameScreen.GetJPOSCROLLX(player);
+			frame_y += OpenTaiko.stageGameScreen.GetJPOSCROLLY(player);
+			num_x += OpenTaiko.stageGameScreen.GetJPOSCROLLX(player);
+			num_y += OpenTaiko.stageGameScreen.GetJPOSCROLLY(player);
+
 			for (int j = 0; j < 5; j++) {
 
 				if (n残り打数[j] < n連打数 && btype == EBalloonType.BALLOON) {

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -125,7 +125,7 @@ internal class CActImplCharacter : CActivity {
 
 			void updateNormal() {
 				if (!OpenTaiko.stageGameScreen.bPAUSE) {
-					nNowCharaCounter[i] += ((Math.Abs((float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i]) / 60.0f) * (float)OpenTaiko.FPS.DeltaTime) / nCharaBeat[i];
+					nNowCharaCounter[i] += ((Math.Abs((float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i])) / 60.0f) * (float)OpenTaiko.FPS.DeltaTime) / nCharaBeat[i];
 				}
 			}
 			void updateBalloon() {

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -48,25 +48,11 @@ internal class CActImplCharacter : CActivity {
 			if (OpenTaiko.Skin.Characters_Normal_Ptn[this.iCurrentCharacter[i]] != 0) ChangeAnime(i, Anime.Normal, true);
 			else ChangeAnime(i, Anime.None, true);
 
+			this.IsInKusudama = false;
 			this.b風船連打中[i] = false;
 			this.b演奏中[i] = false;
 
-			// CharaAction_Balloon_FadeOut[i] = new Animations.FadeOut(TJAPlayer3.Skin.Game_Chara_Balloon_FadeOut);
 			CharaAction_Balloon_FadeOut[i] = new Animations.FadeOut(OpenTaiko.Skin.Characters_Balloon_FadeOut[this.iCurrentCharacter[i]]);
-
-			var tick = OpenTaiko.Skin.Characters_Balloon_Timer[this.iCurrentCharacter[i]];
-
-			var balloonBrokePtn = OpenTaiko.Skin.Characters_Balloon_Broke_Ptn[this.iCurrentCharacter[i]];
-			var balloonMissPtn = OpenTaiko.Skin.Characters_Balloon_Miss_Ptn[this.iCurrentCharacter[i]];
-
-			CharaAction_Balloon_FadeOut_StartMs[i] = new int[2];
-
-			CharaAction_Balloon_FadeOut_StartMs[i][0] = (balloonBrokePtn * tick) - OpenTaiko.Skin.Characters_Balloon_FadeOut[this.iCurrentCharacter[i]];
-			CharaAction_Balloon_FadeOut_StartMs[i][1] = (balloonMissPtn * tick) - OpenTaiko.Skin.Characters_Balloon_FadeOut[this.iCurrentCharacter[i]];
-
-			if (balloonBrokePtn > 1) CharaAction_Balloon_FadeOut_StartMs[i][0] /= balloonBrokePtn - 1;
-			if (balloonMissPtn > 1) CharaAction_Balloon_FadeOut_StartMs[i][1] /= balloonMissPtn - 1; // - 1はタイマー用
-
 			if (CharaAction_Balloon_Delay[i] != null) CharaAction_Balloon_Delay[i].CurrentValue = (int)CharaAction_Balloon_Delay[i].EndValue;
 		}
 
@@ -502,10 +488,6 @@ internal class CActImplCharacter : CActivity {
 
 
 				if (eNowAnime[i] == Anime.Balloon_Broke) {
-					if (CharaAction_Balloon_FadeOut[i].Counter.IsStoped && nNowCharaFrame[i] > CharaAction_Balloon_FadeOut_StartMs[i][0]) {
-						CharaAction_Balloon_FadeOut[i].Start();
-					}
-
 					if (OpenTaiko.Skin.Characters_Balloon_Broke_Ptn[this.iCurrentCharacter[i]] != 0 && OpenTaiko.Tx.Characters_Balloon_Broke[this.iCurrentCharacter[i]][nNowCharaFrame[i]] != null) {
 						OpenTaiko.Tx.Characters_Balloon_Broke[this.iCurrentCharacter[i]][nNowCharaFrame[i]].Opacity = nowOpacity;
 						OpenTaiko.Tx.Characters_Balloon_Broke[this.iCurrentCharacter[i]][nNowCharaFrame[i]].vcScaleRatio.X = charaScale;
@@ -521,14 +503,9 @@ internal class CActImplCharacter : CActivity {
 							OpenTaiko.stageGameScreen.GetJPOSCROLLY(i) + OpenTaiko.Skin.Game_PuchiChara_BalloonY[i], false, nowOpacity, true, player: i);
 
 					if (endAnime) {
-						this.b風船連打中[i] = false;
 						ReturnDefaultAnime(i, true);
 					}
 				} else if (eNowAnime[i] == Anime.Balloon_Miss) {
-					if (CharaAction_Balloon_FadeOut[i].Counter.IsStoped && nNowCharaFrame[i] > CharaAction_Balloon_FadeOut_StartMs[i][1]) {
-						CharaAction_Balloon_FadeOut[i].Start();
-					}
-
 					if (OpenTaiko.Skin.Characters_Balloon_Miss_Ptn[this.iCurrentCharacter[i]] != 0 && OpenTaiko.Tx.Characters_Balloon_Miss[this.iCurrentCharacter[i]][nNowCharaFrame[i]] != null) {
 						OpenTaiko.Tx.Characters_Balloon_Miss[this.iCurrentCharacter[i]][nNowCharaFrame[i]].Opacity = nowOpacity;
 						OpenTaiko.Tx.Characters_Balloon_Miss[this.iCurrentCharacter[i]][nNowCharaFrame[i]].vcScaleRatio.X = charaScale;
@@ -544,7 +521,6 @@ internal class CActImplCharacter : CActivity {
 							OpenTaiko.stageGameScreen.GetJPOSCROLLY(i) + OpenTaiko.Skin.Game_PuchiChara_BalloonY[i], false, nowOpacity, true, player: i);
 
 					if (endAnime) {
-						this.b風船連打中[i] = false;
 						ReturnDefaultAnime(i, true);
 					}
 				} else if (eNowAnime[i] == Anime.Balloon_Breaking) {
@@ -561,9 +537,6 @@ internal class CActImplCharacter : CActivity {
 							OpenTaiko.stageGameScreen.GetJPOSCROLLX(i) + OpenTaiko.Skin.Game_PuchiChara_BalloonX[i],
 							OpenTaiko.stageGameScreen.GetJPOSCROLLY(i) + OpenTaiko.Skin.Game_PuchiChara_BalloonY[i], false, 255, true, player: i);
 				} else if (eNowAnime[i] == Anime.Kusudama_Broke) {
-					if (CharaAction_Balloon_FadeOut[i].Counter.IsStoped && nNowCharaFrame[i] > CharaAction_Balloon_FadeOut_StartMs[i][0]) {
-						CharaAction_Balloon_FadeOut[i].Start();
-					}
 					float kusuOutX = ((1.0f - MathF.Cos(Math.Min(1, nNowCharaCounter[i]) * MathF.PI)) * OpenTaiko.Skin.Resolution[0] / 2.0f) * resolutionScaleX;
 					float kusuOutY = (MathF.Sin(Math.Min(1, nNowCharaCounter[i]) * MathF.PI / 2) * OpenTaiko.Skin.Resolution[1] / 2.0f) * resolutionScaleY;
 
@@ -588,14 +561,9 @@ internal class CActImplCharacter : CActivity {
 					}
 
 					if (endAnime) {
-						this.b風船連打中[i] = false;
 						ReturnDefaultAnime(i, true);
 					}
 				} else if (eNowAnime[i] == Anime.Kusudama_Miss) {
-					if (CharaAction_Balloon_FadeOut[i].Counter.IsStoped && nNowCharaFrame[i] > CharaAction_Balloon_FadeOut_StartMs[i][1]) {
-						CharaAction_Balloon_FadeOut[i].Start();
-					}
-
 					float kusuOutY = (Math.Max(Math.Min(1, nNowCharaCounter[i]) - 0.5f, 0) * OpenTaiko.Skin.Resolution[1] * 2) * resolutionScaleY;
 
 					if (OpenTaiko.Skin.Characters_Kusudama_Miss_Ptn[this.iCurrentCharacter[i]] != 0 && OpenTaiko.Tx.Characters_Kusudama_Miss[this.iCurrentCharacter[i]][nNowCharaFrame[i]] != null) {
@@ -616,7 +584,6 @@ internal class CActImplCharacter : CActivity {
 						OpenTaiko.Skin.Game_PuchiChara_KusudamaY[i] + (int)kusuOutY, false, nowOpacity, true, player: i);
 
 					if (endAnime) {
-						this.b風船連打中[i] = false;
 						ReturnDefaultAnime(i, true);
 					}
 				} else if (eNowAnime[i] == Anime.Kusudama_Breaking) {
@@ -681,6 +648,15 @@ internal class CActImplCharacter : CActivity {
 
 
 	public void ReturnDefaultAnime(int player, bool resetCounter) {
+		if (this.IsInKusudama) {
+			ChangeAnime(player, Anime.Kusudama_Idle, resetCounter);
+			return;
+		}
+		if (this.b風船連打中[player]) {
+			ChangeAnime(player, Anime.Balloon_Breaking, resetCounter);
+			return;
+		}
+
 		if (OpenTaiko.stageGameScreen.bIsGOGOTIME[player] && OpenTaiko.Skin.Characters_GoGoTime_Ptn[this.iCurrentCharacter[player]] != 0) {
 			if (OpenTaiko.stageGameScreen.bIsAlreadyMaxed[player] && OpenTaiko.Skin.Characters_GoGoTime_Maxed_Ptn[this.iCurrentCharacter[player]] != 0) {
 				ChangeAnime(player, Anime.GoGoTime_Maxed, resetCounter);
@@ -882,16 +858,25 @@ internal class CActImplCharacter : CActivity {
 				nCharaBeat[player] = 0.5f;
 				break;
 		}
+
+		if (anime is Anime.Balloon_Broke or Anime.Balloon_Miss or Anime.Kusudama_Broke or Anime.Kusudama_Miss) {
+			CharaAction_Balloon_FadeOut[player].Start();
+			if (this.CharaAction_Balloon_Delay[player] != null) {
+				this.CharaAction_Balloon_Delay[player] = new CCounter(
+					0, OpenTaiko.Skin.Characters_Balloon_Delay[this.iCurrentCharacter[player]] - 1,
+					1,
+					OpenTaiko.Timer);
+			}
+		}
 	}
 
 	public CCounter[] CharaAction_Balloon_Delay = new CCounter[5];
 
 	public Animations.FadeOut[] CharaAction_Balloon_FadeOut = new Animations.FadeOut[5];
-	//private readonly int[] CharaAction_Balloon_FadeOut_StartMs = new int[5];
-	private readonly int[][] CharaAction_Balloon_FadeOut_StartMs = new int[5][];
 
 	//public bool[] bキャラクターアクション中 = new bool[5];
 
+	public bool IsInKusudama = false;
 	public bool[] b風船連打中 = new bool[5];
 	public bool[] b演奏中 = new bool[5];
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplDancer.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplDancer.cs
@@ -127,7 +127,8 @@ internal class CActImplDancer : CActivity {
 
 		if (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Tower && OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan) {
 			if (OpenTaiko.ConfigIni.ShowDancer && (this.ar踊り子モーション番号.Length - 1) != 0) {
-				if (!OpenTaiko.stageGameScreen.bPAUSE) nNowDancerCounter += Math.Abs((float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] / 60.0f) * (float)OpenTaiko.FPS.DeltaTime / nDancerBeat;
+				if (!OpenTaiko.stageGameScreen.bPAUSE)
+					nNowDancerCounter += Math.Abs((float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]) / 60.0f) * (float)OpenTaiko.FPS.DeltaTime / nDancerBeat;
 				if (nNowDancerCounter >= 1) {
 					nNowDancerCounter = 0;
 				}
@@ -153,7 +154,8 @@ internal class CActImplDancer : CActivity {
 								if (nDancerInInterval == 0) {
 									DancerStates[i] = 3;
 								} else {
-									if (!OpenTaiko.stageGameScreen.bPAUSE) nNowDancerInCounter[i] += Math.Abs((float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] / nDancerInInterval) * (float)OpenTaiko.FPS.DeltaTime;
+									if (!OpenTaiko.stageGameScreen.bPAUSE)
+										nNowDancerInCounter[i] += Math.Abs((float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]) / nDancerInInterval) * (float)OpenTaiko.FPS.DeltaTime;
 
 									if (nNowDancerInCounter[i] >= 1) {
 										nNowDancerInCounter[i] = 1;
@@ -172,7 +174,8 @@ internal class CActImplDancer : CActivity {
 								if (nDancerOutInterval == 0) {
 									DancerStates[i] = 0;
 								} else {
-									if (!OpenTaiko.stageGameScreen.bPAUSE) nNowDancerOutCounter[i] += Math.Abs((float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0] / nDancerOutInterval) * (float)OpenTaiko.FPS.DeltaTime;
+									if (!OpenTaiko.stageGameScreen.bPAUSE)
+										nNowDancerOutCounter[i] += Math.Abs((float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]) / nDancerOutInterval) * (float)OpenTaiko.FPS.DeltaTime;
 
 									if (nNowDancerOutCounter[i] >= 1) {
 										nNowDancerOutCounter[i] = 1;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -603,7 +603,7 @@ internal class CActImplLaneTaiko : CActivity {
 
 
 
-		if (OpenTaiko.ConfigIni.bEnableAVI && OpenTaiko.TJA.listVD.Count > 0 && OpenTaiko.stageGameScreen.ShowVideo) {
+		if (OpenTaiko.ConfigIni.bEnableAVI && OpenTaiko.TJA.listVD.Count > 0 && OpenTaiko.stageGameScreen.ShowVideo && !OpenTaiko.ConfigIni.bTokkunMode) {
 			if (OpenTaiko.Tx.Lane_Background_Main != null) OpenTaiko.Tx.Lane_Background_Main.Opacity = OpenTaiko.ConfigIni.nBGAlpha;
 			if (OpenTaiko.Tx.Lane_Background_AI != null) OpenTaiko.Tx.Lane_Background_AI.Opacity = OpenTaiko.ConfigIni.nBGAlpha;
 			if (OpenTaiko.Tx.Lane_Background_Sub != null) OpenTaiko.Tx.Lane_Background_Sub.Opacity = OpenTaiko.ConfigIni.nBGAlpha;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -630,8 +630,8 @@ internal class CActImplLaneTaiko : CActivity {
 			OpenTaiko.Tx.Judge_Frame.b加算合成 = OpenTaiko.Skin.Game_JudgeFrame_AddBlend;
 			for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 				OpenTaiko.Tx.Judge_Frame.t2D描画(
-					OpenTaiko.stageGameScreen.NoteOriginX[i],
-					OpenTaiko.stageGameScreen.NoteOriginY[i], new Rectangle(0, 0, OpenTaiko.Skin.Game_Notes_Size[0], OpenTaiko.Skin.Game_Notes_Size[1]));
+					OpenTaiko.stageGameScreen.GetNoteOriginX(i),
+					OpenTaiko.stageGameScreen.GetNoteOriginY(i), new Rectangle(0, 0, OpenTaiko.Skin.Game_Notes_Size[0], OpenTaiko.Skin.Game_Notes_Size[1]));
 			}
 		}
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplLaneTaiko.cs
@@ -674,6 +674,9 @@ internal class CActImplLaneTaiko : CActivity {
 						y += OpenTaiko.Skin.Game_Effect_Fire_Y[i];
 					}
 
+					x += OpenTaiko.stageGameScreen.GetJPOSCROLLX(i);
+					y += OpenTaiko.stageGameScreen.GetJPOSCROLLY(i);
+
 					OpenTaiko.Tx.Effects_Fire.vcScaleRatio.X = f倍率;
 					OpenTaiko.Tx.Effects_Fire.vcScaleRatio.Y = f倍率;
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplRunner.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplRunner.cs
@@ -114,7 +114,7 @@ internal class CActImplRunner : CActivity {
 					stRunners[i].b使用中 = false;
 				}
 				for (int n = stRunners[i].nOldValue; n < stRunners[i].ct進行.CurrentValue; n++) {
-					stRunners[i].fX += (float)OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[stRunners[i].nPlayer] / 18;
+					stRunners[i].fX += (float)CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[stRunners[i].nPlayer]) / 18;
 					int Width = OpenTaiko.Skin.Resolution[0] / Ptn;
 					stRunners[i].nNowPtn = (int)stRunners[i].fX / Width;
 				}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1399,7 +1399,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				}
 
 				int x = pChip.nHorizontalChipDistance;
-				int y = NoteOriginY[nPlayer] + pChip.nVerticalChipDistance; // either untouched (0/5) or unused (other) for #DIRECTION
+				int y = GetNoteOriginY(nPlayer) + pChip.nVerticalChipDistance; // either untouched (0/5) or unused (other) for #DIRECTION
 
 				int xTemp = 0;
 				int yTemp = 0;
@@ -1411,41 +1411,41 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 				}
 				switch (pChip.nScrollDirection) {
 					case 0:
-						x += (NoteOriginX[nPlayer]);
+						x += (GetNoteOriginX(nPlayer));
 						break;
 					case 1:
-						x = (NoteOriginX[nPlayer]);
-						y = NoteOriginY[nPlayer] - xTemp;
+						x = (GetNoteOriginX(nPlayer));
+						y = GetNoteOriginY(nPlayer) - xTemp;
 						break;
 					case 2:
-						x = (NoteOriginX[nPlayer] + 3);
-						y = NoteOriginY[nPlayer] + xTemp;
+						x = (GetNoteOriginX(nPlayer) + 3);
+						y = GetNoteOriginY(nPlayer) + xTemp;
 						break;
 					case 3:
-						x += (NoteOriginX[nPlayer]);
-						y = NoteOriginY[nPlayer] - xTemp;
+						x += (GetNoteOriginX(nPlayer));
+						y = GetNoteOriginY(nPlayer) - xTemp;
 						break;
 					case 4:
-						x += (NoteOriginX[nPlayer]);
-						y = NoteOriginY[nPlayer] + xTemp;
+						x += (GetNoteOriginX(nPlayer));
+						y = GetNoteOriginY(nPlayer) + xTemp;
 						break;
 					case 5:
-						x = (NoteOriginX[nPlayer] + 10) - xTemp;
+						x = (GetNoteOriginX(nPlayer) + 10) - xTemp;
 						break;
 					case 6:
-						x = (NoteOriginX[nPlayer]) - xTemp;
-						y = NoteOriginY[nPlayer] - xTemp;
+						x = (GetNoteOriginX(nPlayer)) - xTemp;
+						y = GetNoteOriginY(nPlayer) - xTemp;
 						break;
 					case 7:
-						x = (NoteOriginX[nPlayer]) - xTemp;
-						y = NoteOriginY[nPlayer] + xTemp;
+						x = (GetNoteOriginX(nPlayer)) - xTemp;
+						y = GetNoteOriginY(nPlayer) + xTemp;
 						break;
 				}
 				#endregion
 
 				#region[ 両手待ち時 ]
 				if (pChip.eNoteState == ENoteState.Wait) {
-					x = (NoteOriginX[nPlayer]);
+					x = (GetNoteOriginX(nPlayer));
 				}
 				#endregion
 
@@ -1655,15 +1655,15 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 					n先頭発声位置 = pChip.start.n発声時刻ms;
 			}
 
-			int x = NoteOriginX[nPlayer] + pChip.nHorizontalChipDistance;
-			int y = NoteOriginY[nPlayer] + pChip.nVerticalChipDistance;
-			int x末端 = NoteOriginX[nPlayer] + pChip.end.nHorizontalChipDistance;
-			int y末端 = NoteOriginY[nPlayer] + pChip.end.nVerticalChipDistance;
+			int x = GetNoteOriginX(nPlayer) + pChip.nHorizontalChipDistance;
+			int y = GetNoteOriginY(nPlayer) + pChip.nVerticalChipDistance;
+			int x末端 = GetNoteOriginX(nPlayer) + pChip.end.nHorizontalChipDistance;
+			int y末端 = GetNoteOriginY(nPlayer) + pChip.end.nVerticalChipDistance;
 
 			if (NotesManager.IsGenericBalloon(pChip)) {
 				if (nowTime >= pChip.n発声時刻ms && nowTime < pChip.end.n発声時刻ms) {
-					x = NoteOriginX[nPlayer];
-					y = NoteOriginY[nPlayer];
+					x = GetNoteOriginX(nPlayer);
+					y = GetNoteOriginY(nPlayer);
 				} else if (nowTime >= pChip.end.n発声時刻ms) {
 					x = x末端;
 					y = y末端;
@@ -1886,7 +1886,7 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		var head = new Vector2(xHead, yHead);
 		var end = new Vector2(xEnd, yEnd);
-		var origin = new Vector2(this.NoteOriginX[iPlayer], this.NoteOriginY[iPlayer]);
+		var origin = new Vector2(this.GetNoteOriginX(iPlayer), this.GetNoteOriginY(iPlayer));
 		float pos = NearestLineSegRelPos(head, end, origin);
 
 		Vector2 dr = Vector2.Lerp(new(dxHead, dyHead), new(dxEnd, dyEnd), pos);
@@ -1924,8 +1924,8 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		CTja tja = OpenTaiko.GetTJA(nPlayer)!;
 		//int n小節番号plus1 = pChip.n発声位置 / 384;
 		//int n小節番号plus1 = this.actPlayInfo.NowMeasure[nPlayer];
-		int x = NoteOriginX[nPlayer] + pChip.nHorizontalChipDistance;
-		int y = NoteOriginY[nPlayer] + pChip.nVerticalChipDistance;
+		int x = GetNoteOriginX(nPlayer) + pChip.nHorizontalChipDistance;
+		int y = GetNoteOriginY(nPlayer) + pChip.nVerticalChipDistance;
 
 		if ((pChip.bVisible && !pChip.bHideBarLine) && (OpenTaiko.Tx.Bar != null)) {
 			if (x >= 0 && x <= GameWindowSize.Width) {

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -284,7 +284,8 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		this.actLaneTaiko.ResetPlayStates();
 
-		PuchiChara.ChangeBPM(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]);
+		for (int i = 0; i < 5; i++)
+			PuchiChara.ChangeBPM(CTja.TjaDurationToGameDuration(60.0 / OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i]));
 
 		//dbUnit = Math.Ceiling( dbUnit * 1000.0 );
 		//dbUnit = dbUnit / 1000.0;
@@ -549,7 +550,6 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 						if (HGaugeMethods.UNSAFE_IsRainbow(i)) {
 							if (OpenTaiko.Skin.Characters_10Combo_Maxed_Ptn[Character] != 0) {
 								if (HGaugeMethods.UNSAFE_IsRainbow(i)) {
-									double dbUnit = (((60.0 / (OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i]))));
 									this.actChara.ChangeAnime(i, CActImplCharacter.Anime.Combo10_Max, true);
 								}
 							}

--- a/OpenTaiko/src/Stages/08.Result/CActResultParameterPanel.cs
+++ b/OpenTaiko/src/Stages/08.Result/CActResultParameterPanel.cs
@@ -302,15 +302,16 @@ internal class CActResultParameterPanel : CActivity {
 		// this.PuchiChara.IdleAnimation();
 
 		int nDrawnPlayers = OpenTaiko.ConfigIni.bAIBattleMode ? 1 : OpenTaiko.ConfigIni.nPlayerCount;
+		int nLayoutPlayers = OpenTaiko.ConfigIni.bAIBattleMode ? 2 : OpenTaiko.ConfigIni.nPlayerCount;
 		if (OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Dan && OpenTaiko.stageSongSelect.nChoosenSongDifficulty[0] != (int)Difficulty.Tower) {
 			int[] namePlate_x = new int[5];
 			int[] namePlate_y = new int[5];
 
 			for (int i = 0; i < nDrawnPlayers; i++) {
-				if (nDrawnPlayers == 5) {
+				if (nLayoutPlayers == 5) {
 					namePlate_x[i] = OpenTaiko.Skin.Result_NamePlate_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[i];
 					namePlate_y[i] = OpenTaiko.Skin.Result_NamePlate_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[i];
-				} else if (nDrawnPlayers == 4 || nDrawnPlayers == 3) {
+				} else if (nLayoutPlayers == 4 || nLayoutPlayers == 3) {
 					namePlate_x[i] = OpenTaiko.Skin.Result_NamePlate_4P[0] + OpenTaiko.Skin.Result_UIMove_4P_X[i];
 					namePlate_y[i] = OpenTaiko.Skin.Result_NamePlate_4P[1] + OpenTaiko.Skin.Result_UIMove_4P_Y[i];
 				} else {
@@ -329,7 +330,7 @@ internal class CActResultParameterPanel : CActivity {
 			int AnimeCount = 3000 + GaugeFactor * 59;
 			int ScoreApparitionTimeStamp = AnimeCount + 420 * 4 + 840;
 
-			bool is1P = (nDrawnPlayers == 1);
+			bool is1P = (nLayoutPlayers == 1);
 			bool is2PSide = OpenTaiko.P1IsBlue();
 
 			int shift = 635;
@@ -351,13 +352,13 @@ internal class CActResultParameterPanel : CActivity {
 
 				#region [General plate animations]
 
-				if (nDrawnPlayers <= 2) {
+				if (nLayoutPlayers <= 2) {
 					if (shiftPos == 0)
 						OpenTaiko.Tx.Result_Panel.t2D描画(0 + uioffset_x, 0);
 					else
 						OpenTaiko.Tx.Result_Panel_2P.t2D描画(0 + uioffset_x, 0);
 				} else {
-					if (nDrawnPlayers == 5) {
+					if (nLayoutPlayers == 5) {
 						OpenTaiko.Tx.Result_Panel_5P[i].t2D描画(OpenTaiko.Skin.Result_UIMove_5P_X[i], OpenTaiko.Skin.Result_UIMove_5P_Y[i]);
 					} else {
 						OpenTaiko.Tx.Result_Panel_4P[i].t2D描画(OpenTaiko.Skin.Result_UIMove_4P_X[i], OpenTaiko.Skin.Result_UIMove_4P_Y[i]);
@@ -373,13 +374,13 @@ internal class CActResultParameterPanel : CActivity {
 					int gauge_base_y;
 
 
-					if (nDrawnPlayers == 5) {
+					if (nLayoutPlayers == 5) {
 						_frame.vcScaleRatio.X = 0.5f;
 						bar_x = OpenTaiko.Skin.Result_DifficultyBar_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 						bar_y = OpenTaiko.Skin.Result_DifficultyBar_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
 						gauge_base_x = OpenTaiko.Skin.Result_Gauge_Base_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 						gauge_base_y = OpenTaiko.Skin.Result_Gauge_Base_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
-					} else if (nDrawnPlayers == 4 || nDrawnPlayers == 3) {
+					} else if (nLayoutPlayers == 4 || nLayoutPlayers == 3) {
 						_frame.vcScaleRatio.X = 0.5f;
 						bar_x = OpenTaiko.Skin.Result_DifficultyBar_4P[0] + OpenTaiko.Skin.Result_UIMove_4P_X[pos];
 						bar_y = OpenTaiko.Skin.Result_DifficultyBar_4P[1] + OpenTaiko.Skin.Result_UIMove_4P_Y[pos];
@@ -467,7 +468,7 @@ internal class CActResultParameterPanel : CActivity {
 						int[][] num_x;
 
 						int[][] num_y;
-						if (nDrawnPlayers == 5) {
+						if (nLayoutPlayers == 5) {
 							num_x = new int[][] { new int[5], new int[5], new int[5], new int[5], new int[5], new int[5], new int[5] };
 							num_y = new int[][] { new int[5], new int[5], new int[5], new int[5], new int[5], new int[5], new int[5] };
 
@@ -491,7 +492,7 @@ internal class CActResultParameterPanel : CActivity {
 
 							num_x[6][pos] = OpenTaiko.Skin.Result_Bomb_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 							num_y[6][pos] = OpenTaiko.Skin.Result_Bomb_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
-						} else if (nDrawnPlayers > 2) {
+						} else if (nLayoutPlayers > 2) {
 							num_x = new int[][] { new int[5], new int[5], new int[5], new int[5], new int[5], new int[5], new int[5] };
 							num_y = new int[][] { new int[5], new int[5], new int[5], new int[5], new int[5], new int[5], new int[5] };
 
@@ -541,9 +542,9 @@ internal class CActResultParameterPanel : CActivity {
 							if (ctMainCounter.CurrentValue >= AnimeCount + (Interval * k)) {
 								float numScale = 1.0f;
 
-								if (nDrawnPlayers == 5) {
+								if (nLayoutPlayers == 5) {
 									numScale = OpenTaiko.Skin.Result_Number_Scale_5P;
-								} else if (nDrawnPlayers == 3 || nDrawnPlayers == 4) {
+								} else if (nLayoutPlayers == 3 || nLayoutPlayers == 4) {
 									numScale = OpenTaiko.Skin.Result_Number_Scale_4P;
 								}
 								OpenTaiko.Tx.Result_Number.vcScaleRatio.X = ctMainCounter.CurrentValue <= AnimeCount + (Interval * k) + AddCount ? 1.3f - (float)Math.Sin((ctMainCounter.CurrentValue - (AnimeCount + (Interval * k))) / (AddCount / 90) * (Math.PI / 180)) * 0.3f : 1.0f;
@@ -574,11 +575,11 @@ internal class CActResultParameterPanel : CActivity {
 							float numScale = 1.0f;
 							int score_x;
 							int score_y;
-							if (nDrawnPlayers == 5) {
+							if (nLayoutPlayers == 5) {
 								numScale = OpenTaiko.Skin.Result_Score_Scale_5P;
 								score_x = OpenTaiko.Skin.Result_Score_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 								score_y = OpenTaiko.Skin.Result_Score_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
-							} else if (nDrawnPlayers == 4 || nDrawnPlayers == 3) {
+							} else if (nLayoutPlayers == 4 || nLayoutPlayers == 3) {
 								numScale = OpenTaiko.Skin.Result_Score_Scale_4P;
 								score_x = OpenTaiko.Skin.Result_Score_4P[0] + OpenTaiko.Skin.Result_UIMove_4P_X[pos];
 								score_y = OpenTaiko.Skin.Result_Score_4P[1] + OpenTaiko.Skin.Result_UIMove_4P_Y[pos];
@@ -780,8 +781,8 @@ internal class CActResultParameterPanel : CActivity {
 
 				#region [PuchiChara]
 
-				int puchi_x = chara_x + OpenTaiko.Skin.Adjustments_MenuPuchichara_X[nDrawnPlayers <= 2 ? pos : 0];
-				int puchi_y = chara_y + OpenTaiko.Skin.Adjustments_MenuPuchichara_Y[nDrawnPlayers <= 2 ? pos : 0];
+				int puchi_x = chara_x + OpenTaiko.Skin.Adjustments_MenuPuchichara_X[nLayoutPlayers <= 2 ? pos : 0];
+				int puchi_y = chara_y + OpenTaiko.Skin.Adjustments_MenuPuchichara_Y[nLayoutPlayers <= 2 ? pos : 0];
 
 				//int ttdiff = 640 - 152;
 				//int ttps = 640 + ((pos == 1) ? ttdiff + 60 : -ttdiff);
@@ -800,7 +801,7 @@ internal class CActResultParameterPanel : CActivity {
 
 					#region [Cherry blossom animation]
 
-					if (OpenTaiko.stageResults.nクリア[p] >= 1 && nDrawnPlayers <= 2) {
+					if (OpenTaiko.stageResults.nクリア[p] >= 1 && nLayoutPlayers <= 2) {
 						OpenTaiko.Tx.Result_Flower.vcScaleRatio.X = 0.6f * (ctMainCounter.CurrentValue <= MountainAppearValue + AddCount ? 1.3f - (float)Math.Sin((ctMainCounter.CurrentValue - MountainAppearValue) / (AddCount / 90) * (Math.PI / 180)) * 0.3f : 1.0f);
 						OpenTaiko.Tx.Result_Flower.vcScaleRatio.Y = 0.6f * (ctMainCounter.CurrentValue <= MountainAppearValue + AddCount ? 1.3f - (float)Math.Sin((ctMainCounter.CurrentValue - MountainAppearValue) / (AddCount / 90) * (Math.PI / 180)) * 0.3f : 1.0f);
 
@@ -815,7 +816,7 @@ internal class CActResultParameterPanel : CActivity {
 
 					#region [Cherry blossom Rotating flowers]
 
-					if (OpenTaiko.stageResults.nクリア[p] >= 1 && nDrawnPlayers <= 2) {
+					if (OpenTaiko.stageResults.nクリア[p] >= 1 && nLayoutPlayers <= 2) {
 						float FlowerTime = ctRotate_Flowers.CurrentValue;
 
 						for (int i = 0; i < 5; i++) {
@@ -848,7 +849,7 @@ internal class CActResultParameterPanel : CActivity {
 
 					#region [Panel shines]
 
-					if (OpenTaiko.stageResults.nクリア[p] >= 1 && nDrawnPlayers <= 2) {
+					if (OpenTaiko.stageResults.nクリア[p] >= 1 && nLayoutPlayers <= 2) {
 						int ShineTime = (int)ctShine_Plate.CurrentValue;
 						int Quadrant500 = ShineTime % 500;
 
@@ -897,7 +898,7 @@ internal class CActResultParameterPanel : CActivity {
 						}
 					}
 
-					if (nDrawnPlayers <= 2) {
+					if (nLayoutPlayers <= 2) {
 						int speechBuddle_width = OpenTaiko.Tx.Result_Speech_Bubble[pos].szTextureSize.Width / 4;
 						int speechBuddle_height = OpenTaiko.Tx.Result_Speech_Bubble[pos].szTextureSize.Height / 3;
 
@@ -906,7 +907,7 @@ internal class CActResultParameterPanel : CActivity {
 						OpenTaiko.Tx.Result_Speech_Bubble[pos].t2D拡大率考慮中央基準描画(OpenTaiko.Skin.Result_Speech_Bubble_X[pos], OpenTaiko.Skin.Result_Speech_Bubble_Y[pos],
 							new Rectangle(Mood * speechBuddle_width, RandomText * speechBuddle_height, speechBuddle_width, speechBuddle_height));
 					}
-					int speech_vubble_index = nDrawnPlayers <= 2 ? pos : 2;
+					int speech_vubble_index = nLayoutPlayers <= 2 ? pos : 2;
 					if (OpenTaiko.Tx.Result_Speech_Bubble_V2[speech_vubble_index] != null) {
 						int speechBuddle_width = OpenTaiko.Tx.Result_Speech_Bubble_V2[speech_vubble_index].szTextureSize.Width;
 						int speechBuddle_height = OpenTaiko.Tx.Result_Speech_Bubble_V2[speech_vubble_index].szTextureSize.Height / 6;
@@ -914,15 +915,15 @@ internal class CActResultParameterPanel : CActivity {
 						int speech_bubble_x;
 						int speech_bubble_y;
 						float scale;
-						if (nDrawnPlayers == 5) {
+						if (nLayoutPlayers == 5) {
 							speech_bubble_x = OpenTaiko.Skin.Result_Speech_Bubble_V2_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 							speech_bubble_y = OpenTaiko.Skin.Result_Speech_Bubble_V2_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
 							scale = 0.5f;
-						} else if (nDrawnPlayers == 4 || nDrawnPlayers == 3) {
+						} else if (nLayoutPlayers == 4 || nLayoutPlayers == 3) {
 							speech_bubble_x = OpenTaiko.Skin.Result_Speech_Bubble_V2_4P[0] + OpenTaiko.Skin.Result_UIMove_4P_X[pos];
 							speech_bubble_y = OpenTaiko.Skin.Result_Speech_Bubble_V2_4P[1] + OpenTaiko.Skin.Result_UIMove_4P_Y[pos];
 							scale = 0.5f;
-						} else if (nDrawnPlayers == 2) {
+						} else if (nLayoutPlayers == 2) {
 							speech_bubble_x = OpenTaiko.Skin.Result_Speech_Bubble_V2_2P_X[pos];
 							speech_bubble_y = OpenTaiko.Skin.Result_Speech_Bubble_V2_2P_Y[pos];
 							scale = 0.5f;
@@ -999,10 +1000,10 @@ internal class CActResultParameterPanel : CActivity {
 
 							int scoreRankEffect_x;
 							int scoreRankEffect_y;
-							if (nDrawnPlayers == 5) {
+							if (nLayoutPlayers == 5) {
 								scoreRankEffect_x = OpenTaiko.Skin.Result_ScoreRankEffect_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 								scoreRankEffect_y = OpenTaiko.Skin.Result_ScoreRankEffect_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
-							} else if (nDrawnPlayers == 4 || nDrawnPlayers == 3) {
+							} else if (nLayoutPlayers == 4 || nLayoutPlayers == 3) {
 								scoreRankEffect_x = OpenTaiko.Skin.Result_ScoreRankEffect_4P[0] + OpenTaiko.Skin.Result_UIMove_4P_X[pos];
 								scoreRankEffect_y = OpenTaiko.Skin.Result_ScoreRankEffect_4P[1] + OpenTaiko.Skin.Result_UIMove_4P_Y[pos];
 							} else {
@@ -1061,10 +1062,10 @@ internal class CActResultParameterPanel : CActivity {
 
 							int crownEffect_x;
 							int crownEffect_y;
-							if (nDrawnPlayers == 5) {
+							if (nLayoutPlayers == 5) {
 								crownEffect_x = OpenTaiko.Skin.Result_CrownEffect_5P[0] + OpenTaiko.Skin.Result_UIMove_5P_X[pos];
 								crownEffect_y = OpenTaiko.Skin.Result_CrownEffect_5P[1] + OpenTaiko.Skin.Result_UIMove_5P_Y[pos];
-							} else if (nDrawnPlayers == 4 || nDrawnPlayers == 3) {
+							} else if (nLayoutPlayers == 4 || nLayoutPlayers == 3) {
 								crownEffect_x = OpenTaiko.Skin.Result_CrownEffect_4P[0] + OpenTaiko.Skin.Result_UIMove_4P_X[pos];
 								crownEffect_y = OpenTaiko.Skin.Result_CrownEffect_4P[1] + OpenTaiko.Skin.Result_UIMove_4P_Y[pos];
 							} else {


### PR DESCRIPTION
* fix note lane became transparent in training mode for charts with BGA/MOVIE (not played in training mode)
* fix #BARLINE ignored scroll mode
* fix fuze rolls were counted into bar roll length (beyond balloon hit count) for scoring and Dan-i exam monitoring
* fix dan-i monitoring for AdLib, Mine, & Fuze roll notes was broken because these notes were not counted in TJA parsing due to wrong note type checking conditions
* fix timing window of fuze roll was the same as bar rolls and not expectedly the same as regular balloons
* fix music played too early when users retry after music plays and then pause + resume before music plays (although was able to resync when the music should play)
* fix AI battle mode failed to use 2P layout due to the fix of 0.6.0.79 (0auBSQ/OpenTaiko#851)
* fix setting duplicated key binds for the same key overrode the next key bind under cursor by stopping shifting out removed key binds
* "<< Returnto List" → "<< Return to List": fix missing space in key assign menu
* fix hitting AdLibs at combo milestone retriggered combo milestone effects
* fix players' animation failed to exit max-soul state after retrying
* fix balloon/Kusu chara/puchi animation for charts with dense balloon-type notes, follow-up of 0.6.0.55 (0auBSQ/OpenTaiko#809)
* fix player chara & puchi animation ignored play speed
* fix go-go judgemark fire, activated balloon, and number bubble for balloon and fuze rolls ignored JPosScroll