### PR TITLE
Feat imgui sn dmgr

### DIFF
--- a/FDK/src/03.Sound/CSound.cs
+++ b/FDK/src/03.Sound/CSound.cs
@@ -263,6 +263,8 @@ public class CSound : IDisposable {
 		SoundPosition = pan;
 	}
 
+	public uint Pointer { get => (uint)this._hBassStream; }
+
 	/// <summary>
 	/// <para>全インスタンスリスト。</para>
 	/// <para>～を作成する() で追加され、t解放する() or Dispose() で解放される。</para>
@@ -464,11 +466,13 @@ public class CSound : IDisposable {
 	public void tGetPlayPositon(out long positionByte, out double positionMs) {
 		if (this.IsBassSound) {
 			positionByte = BassMix.ChannelGetPosition(this.hBassStream);
-			positionMs = Bass.ChannelBytes2Seconds(this.hBassStream, positionByte);
-		} else {
-			positionByte = 0;
-			positionMs = 0.0;
+			if (positionByte != -1) {
+				positionMs = 1000 * Bass.ChannelBytes2Seconds(this.hBassStream, positionByte);
+				return;
+			}
 		}
+		positionByte = 0;
+		positionMs = 0.0;
 	}
 
 

--- a/FDK/src/03.Sound/CSound.cs
+++ b/FDK/src/03.Sound/CSound.cs
@@ -40,6 +40,10 @@ public class CSound : IDisposable {
 
 	#region [ DTXMania用拡張 ]
 
+	public double dbTotalPlayTime {
+		get;
+		private set;
+	}
 	public int TotalPlayTime {
 		get;
 		private set;
@@ -662,7 +666,8 @@ public class CSound : IDisposable {
 
 		// n総演奏時間の取得; DTXMania用に追加。
 		double seconds = Bass.ChannelBytes2Seconds(this._hBassStream, nBytes);
-		this.TotalPlayTime = (int)(seconds * 1000);
+		this.dbTotalPlayTime = seconds * 1000;
+		this.TotalPlayTime = (int)Math.Ceiling(this.dbTotalPlayTime);
 		//this.pos = 0;
 		this.hMixer = hMixer;
 		float freq = 0.0f;

--- a/FDK/src/03.Sound/CSoundDeviceASIO.cs
+++ b/FDK/src/03.Sound/CSoundDeviceASIO.cs
@@ -61,6 +61,8 @@ internal class CSoundDeviceASIO : ISoundDevice {
 		protected set;
 	}
 
+	public long nBytesPerSec { get; protected set; }
+
 
 	// マスターボリュームの制御コードは、WASAPI/ASIOで全く同じ。
 	public int nMasterVolume {
@@ -253,7 +255,7 @@ internal class CSoundDeviceASIO : ISoundDevice {
 		}
 		//long nミキサーの1サンプルあたりのバイト数 = /*mixerInfo.chans*/ 2 * nサンプルサイズbyte;
 		long nミキサーの1サンプルあたりのバイト数 = mixerInfo.Channels * nサンプルサイズbyte;
-		this.nミキサーの1秒あたりのバイト数 = nミキサーの1サンプルあたりのバイト数 * mixerInfo.Frequency;
+		this.nBytesPerSec = nミキサーの1サンプルあたりのバイト数 * mixerInfo.Frequency;
 
 
 		// 単純に、hMixerの音量をMasterVolumeとして制御しても、
@@ -365,7 +367,7 @@ internal class CSoundDeviceASIO : ISoundDevice {
 		// 経過時間を更新。
 		// データの転送差分ではなく累積転送バイト数から算出する。
 
-		this.ElapsedTimeMs = (this.n累積転送バイト数 * 1000 / this.nミキサーの1秒あたりのバイト数) - this.OutputDelay;
+		this.ElapsedTimeMs = (this.n累積転送バイト数 * 1000 / this.nBytesPerSec) - this.OutputDelay;
 		this.UpdateSystemTimeMs = this.SystemTimer.SystemTimeMs;
 
 
@@ -375,7 +377,6 @@ internal class CSoundDeviceASIO : ISoundDevice {
 		return num;
 	}
 
-	private long nミキサーの1秒あたりのバイト数 = 0;
 	private long n累積転送バイト数 = 0;
 	private bool bIsBASSFree = true;
 }

--- a/FDK/src/03.Sound/CSoundDeviceBASS.cs
+++ b/FDK/src/03.Sound/CSoundDeviceBASS.cs
@@ -35,6 +35,8 @@ public class CSoundDeviceBASS : ISoundDevice {
 		protected set;
 	}
 
+	public long nBytesPerSec { get; protected set; }
+
 	public float CPUUsage => (float)Bass.CPUUsage;
 
 	// マスターボリュームの制御コードは、WASAPI/ASIOで全く同じ。

--- a/FDK/src/03.Sound/ISoundDevice.cs
+++ b/FDK/src/03.Sound/ISoundDevice.cs
@@ -8,6 +8,7 @@ internal interface ISoundDevice : IDisposable {
 	long ElapsedTimeMs { get; }
 	long UpdateSystemTimeMs { get; }
 	CTimer SystemTimer { get; }
+	long nBytesPerSec { get; }
 
 	CSound tCreateSound(string strファイル名, ESoundGroup soundGroup);
 	void tCreateSound(string strファイル名, CSound sound);

--- a/FDK/src/03.Sound/SoundManager.cs
+++ b/FDK/src/03.Sound/SoundManager.cs
@@ -163,6 +163,7 @@ public class SoundManager   // : CSound
 		}
 	}
 
+	public static long nBytesPerSec => SoundDevice.nBytesPerSec;
 	#endregion
 
 

--- a/FDK/src/04.Graphics/CTexture.cs
+++ b/FDK/src/04.Graphics/CTexture.cs
@@ -349,13 +349,19 @@ public class CTexture : IDisposable {
 	}
 
 	public void UpdateTexture(CTexture texture, int width, int height) {
+		if (texture.bDispose完了済み)
+			return;
 		Pointer = texture.Pointer;
 		this.sz画像サイズ = new Size(width, height);
 		this.szTextureSize = this.t指定されたサイズを超えない最適なテクスチャサイズを返す(this.sz画像サイズ);
 		this.rc全画像 = new Rectangle(0, 0, this.sz画像サイズ.Width, this.sz画像サイズ.Height);
+
+		this.bDispose完了済み = texture.bDispose完了済み;
 	}
 
 	public void UpdateTexture(IntPtr texture, int width, int height, PixelFormat rgbaType) {
+		if (texture == 0)
+			return;
 		unsafe {
 			Game.Gl.DeleteTexture(Pointer); //解放
 			void* data = texture.ToPointer();
@@ -930,6 +936,7 @@ public class CTexture : IDisposable {
 	public void Dispose() {
 		if (!this.bDispose完了済み) {
 			Game.Gl.DeleteTexture(Pointer); //解放
+			this.Pointer = 0;
 
 			this.bDispose完了済み = true;
 		}

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -381,170 +381,14 @@ internal class CSkin : IDisposable {
 	public CSystemSound soundKusudama = null;
 	public CSystemSound soundKusudamaMiss = null;
 
+	#region [ For disposing ]
+	public List<CSystemSound> listSystemSound = new();
+	#endregion
 
-	public readonly int nシステムサウンド数 = (int)Eシステムサウンド.Count;
-	public CSystemSound this[Eシステムサウンド sound] {
-		get {
-			switch (sound) {
-				case Eシステムサウンド.SOUNDカーソル移動音:
-					return this.soundカーソル移動音;
-
-				case Eシステムサウンド.SOUND決定音:
-					return this.soundDecideSFX;
-
-				case Eシステムサウンド.SOUND変更音:
-					return this.soundChangeSFX;
-
-				case Eシステムサウンド.SOUND取消音:
-					return this.soundCancelSFX;
-
-				case Eシステムサウンド.SOUND歓声音:
-					return this.sound歓声音;
-
-				case Eシステムサウンド.SOUNDステージ失敗音:
-					return this.soundSTAGEFAILED音;
-
-				case Eシステムサウンド.SOUNDゲーム開始音:
-					return this.soundゲーム開始音;
-
-				case Eシステムサウンド.SOUNDゲーム終了音:
-					return this.soundゲーム終了音;
-
-				case Eシステムサウンド.SOUNDステージクリア音:
-					return this.soundステージクリア音;
-
-				case Eシステムサウンド.SOUNDフルコンボ音:
-					return this.soundフルコンボ音;
-
-				case Eシステムサウンド.SOUND曲読込開始音:
-					return this.sound曲読込開始音;
-
-				case Eシステムサウンド.SOUNDタイトル音:
-					return this.bgmタイトル;
-
-				case Eシステムサウンド.BGM起動画面:
-					return this.bgm起動画面;
-
-				case Eシステムサウンド.BGMオプション画面:
-					return this.bgmオプション画面;
-
-				case Eシステムサウンド.BGMコンフィグ画面:
-					return this.bgmコンフィグ画面;
-
-				case Eシステムサウンド.BGM選曲画面:
-					return this.bgm選曲画面;
-
-				//case Eシステムサウンド.SOUND赤:
-				//    return this.soundRed;
-
-				//case Eシステムサウンド.SOUND青:
-				//    return this.soundBlue;
-
-				case Eシステムサウンド.SOUND風船:
-					return this.soundBalloon;
-
-				case Eシステムサウンド.SOUND曲決定音:
-					return this.sound曲決定音;
-
-				case Eシステムサウンド.SOUND成績発表:
-					return this.bgmリザルトイン音;
-
-				case Eシステムサウンド.SOUND特訓再生:
-					return this.sound特訓再生音;
-
-				case Eシステムサウンド.SOUND特訓停止:
-					return this.sound特訓停止音;
-
-				case Eシステムサウンド.sound特訓ジャンプポイント:
-					return this.soundTrainingToggleBookmarkSFX;
-
-				case Eシステムサウンド.sound特訓スキップ音:
-					return this.sound特訓スキップ音;
-
-				case Eシステムサウンド.SOUND特訓スクロール:
-					return this.soundTrainingModeScrollSFX;
-
-			}
-			throw new IndexOutOfRangeException();
-		}
-	}
-	public CSystemSound this[int index] {
-		get {
-			switch (index) {
-				case 0:
-					return this.soundカーソル移動音;
-
-				case 1:
-					return this.soundDecideSFX;
-
-				case 2:
-					return this.soundChangeSFX;
-
-				case 3:
-					return this.soundCancelSFX;
-
-				case 4:
-					return this.sound歓声音;
-
-				case 5:
-					return this.soundSTAGEFAILED音;
-
-				case 6:
-					return this.soundゲーム開始音;
-
-				case 7:
-					return this.soundゲーム終了音;
-
-				case 8:
-					return this.soundステージクリア音;
-
-				case 9:
-					return this.soundフルコンボ音;
-
-				case 10:
-					return this.sound曲読込開始音;
-
-				case 11:
-					return this.bgmタイトル;
-
-				case 12:
-					return this.bgm起動画面;
-
-				case 13:
-					return this.bgmオプション画面;
-
-				case 14:
-					return this.bgmコンフィグ画面;
-
-				case 15:
-					return this.bgm選曲画面;
-
-				case 16:
-					return this.soundBalloon;
-
-				case 17:
-					return this.sound曲決定音;
-
-				case 18:
-					return this.bgmリザルトイン音;
-
-				case 19:
-					return this.sound特訓再生音;
-
-				case 20:
-					return this.sound特訓停止音;
-
-				case 21:
-					return this.soundTrainingModeScrollSFX;
-
-				case 22:
-					return this.soundTrainingToggleBookmarkSFX;
-
-				case 23:
-					return this.sound特訓スキップ音;
-			}
-			throw new IndexOutOfRangeException();
-		}
+	internal CSystemSound SndCAbsolute(string FileName, bool bLoop, bool bExclusive, bool bCompact対象, ESoundGroup soundGroup) {
+		CSystemSound snd = new(FileName, bLoop, bExclusive, bCompact対象, soundGroup);
+		listSystemSound.Add(snd);
+		return snd;
 	}
 
 
@@ -683,91 +527,92 @@ internal class CSkin : IDisposable {
 				strBoxDefSkinSubfolderFullName
 		);
 
-		for (int i = 0; i < nシステムサウンド数; i++) {
-			if (this[i] != null && this[i].bLoadedSuccessfuly) {
-				this[i].tStop();
-				this[i].Dispose();
+		foreach (var snd in this.listSystemSound) {
+			if (snd.bLoadedSuccessfuly) {
+				snd.tStop();
+				snd.Dispose();
 			}
 		}
+		this.listSystemSound.Clear();
 
-		this.soundカーソル移動音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Move.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundDecideSFX = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Decide.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundChangeSFX = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Change.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundCancelSFX = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Cancel.ogg", false, false, true, ESoundGroup.SoundEffect);
-		this.sound歓声音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Audience.ogg", false, false, true, ESoundGroup.SoundEffect);
-		this.soundSTAGEFAILED音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Stage failed.ogg", false, true, true, ESoundGroup.Voice);
-		this.soundゲーム開始音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Game start.ogg", false, false, false, ESoundGroup.Voice);
-		this.soundゲーム終了音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Game end.ogg", false, true, false, ESoundGroup.Voice);
-		this.soundステージクリア音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Stage clear.ogg", false, true, true, ESoundGroup.Voice);
-		this.soundフルコンボ音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Full combo.ogg", false, false, true, ESoundGroup.Voice);
-		this.sound曲読込開始音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Now loading.ogg", false, true, true, ESoundGroup.Unknown);
+		this.soundカーソル移動音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Move.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundDecideSFX = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Decide.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundChangeSFX = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Change.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundCancelSFX = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Cancel.ogg", false, false, true, ESoundGroup.SoundEffect);
+		this.sound歓声音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Audience.ogg", false, false, true, ESoundGroup.SoundEffect);
+		this.soundSTAGEFAILED音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Stage failed.ogg", false, true, true, ESoundGroup.Voice);
+		this.soundゲーム開始音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Game start.ogg", false, false, false, ESoundGroup.Voice);
+		this.soundゲーム終了音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Game end.ogg", false, true, false, ESoundGroup.Voice);
+		this.soundステージクリア音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Stage clear.ogg", false, true, true, ESoundGroup.Voice);
+		this.soundフルコンボ音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Full combo.ogg", false, false, true, ESoundGroup.Voice);
+		this.sound曲読込開始音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Now loading.ogg", false, true, true, ESoundGroup.Unknown);
 		//this.bgm選曲画面 = new Cシステムサウンド(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Select BGM.ogg", true, true, false, ESoundGroup.SongPlayback);
 		//this.soundSongSelectChara = new Cシステムサウンド(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongSelect Chara.ogg", false, false, false, ESoundGroup.SongPlayback);
-		this.soundSkip = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Skip.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.SoundBanapas = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Banapas.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundEntry = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Entry.ogg", true, false, false, ESoundGroup.Voice);
-		this.soundError = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Error.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundSkip = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Skip.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.SoundBanapas = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Banapas.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundEntry = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Entry.ogg", true, false, false, ESoundGroup.Voice);
+		this.soundError = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Error.ogg", false, false, false, ESoundGroup.SoundEffect);
 		//this.soundsanka = new Cシステムサウンド(@$"Sounds{System.IO.Path.DirectorySeparatorChar}sanka.ogg", false, false, false, ESoundGroup.Voice);
-		this.soundBomb = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Bomb.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundBomb = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Bomb.ogg", false, false, false, ESoundGroup.SoundEffect);
 
 		//this.soundRed               = new Cシステムサウンド( @$"Sounds{System.IO.Path.DirectorySeparatorChar}dong.ogg",            false, false, true, ESoundType.SoundEffect );
 		//this.soundBlue              = new Cシステムサウンド( @$"Sounds{System.IO.Path.DirectorySeparatorChar}ka.ogg",              false, false, true, ESoundType.SoundEffect );
-		this.soundBalloon = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}balloon.ogg", false, false, true, ESoundGroup.SoundEffect);
-		this.soundKusudama = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Kusudama.ogg", false, false, true, ESoundGroup.SoundEffect);
-		this.soundKusudamaMiss = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}KusudamaMiss.ogg", false, false, true, ESoundGroup.SoundEffect);
-		this.sound曲決定音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongDecide.ogg", false, false, true, ESoundGroup.Voice);
-		this.soundSongDecide_AI = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongDecide_AI.ogg", false, false, true, ESoundGroup.Voice);
+		this.soundBalloon = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}balloon.ogg", false, false, true, ESoundGroup.SoundEffect);
+		this.soundKusudama = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Kusudama.ogg", false, false, true, ESoundGroup.SoundEffect);
+		this.soundKusudamaMiss = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}KusudamaMiss.ogg", false, false, true, ESoundGroup.SoundEffect);
+		this.sound曲決定音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongDecide.ogg", false, false, true, ESoundGroup.Voice);
+		this.soundSongDecide_AI = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongDecide_AI.ogg", false, false, true, ESoundGroup.Voice);
 
-		this.bgm起動画面 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Setup.ogg", true, true, false, ESoundGroup.SongPlayback);
-		this.bgmタイトルイン = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Title_Start.ogg", false, false, true, ESoundGroup.SongPlayback);
-		this.bgmタイトル = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Title.ogg", true, false, true, ESoundGroup.SongPlayback);
-		this.bgmオプション画面 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Option.ogg", true, true, false, ESoundGroup.SongPlayback);
-		this.bgmコンフィグ画面 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Config.ogg", true, true, false, ESoundGroup.SongPlayback);
-		this.bgm選曲画面イン = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect_Start.ogg", false, false, true, ESoundGroup.SongPlayback);
-		this.bgm選曲画面 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect.ogg", true, false, true, ESoundGroup.SongPlayback);
-		this.bgmSongSelect_AI_In = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect_AI_Start.ogg", false, false, true, ESoundGroup.SongPlayback);
-		this.bgmSongSelect_AI = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect_AI.ogg", true, false, true, ESoundGroup.SongPlayback);
-		this.bgmリザルトイン音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result_In.ogg", false, false, true, ESoundGroup.SongPlayback);
-		this.bgmリザルト音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result.ogg", true, false, true, ESoundGroup.SongPlayback);
-		this.bgmResultIn_AI = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result_In_AI.ogg", false, false, true, ESoundGroup.SongPlayback);
-		this.bgmResult_AI = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result_AI.ogg", true, false, true, ESoundGroup.SongPlayback);
+		this.bgm起動画面 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Setup.ogg", true, true, false, ESoundGroup.SongPlayback);
+		this.bgmタイトルイン = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Title_Start.ogg", false, false, true, ESoundGroup.SongPlayback);
+		this.bgmタイトル = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Title.ogg", true, false, true, ESoundGroup.SongPlayback);
+		this.bgmオプション画面 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Option.ogg", true, true, false, ESoundGroup.SongPlayback);
+		this.bgmコンフィグ画面 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Config.ogg", true, true, false, ESoundGroup.SongPlayback);
+		this.bgm選曲画面イン = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect_Start.ogg", false, false, true, ESoundGroup.SongPlayback);
+		this.bgm選曲画面 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect.ogg", true, false, true, ESoundGroup.SongPlayback);
+		this.bgmSongSelect_AI_In = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect_AI_Start.ogg", false, false, true, ESoundGroup.SongPlayback);
+		this.bgmSongSelect_AI = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}SongSelect_AI.ogg", true, false, true, ESoundGroup.SongPlayback);
+		this.bgmリザルトイン音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result_In.ogg", false, false, true, ESoundGroup.SongPlayback);
+		this.bgmリザルト音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result.ogg", true, false, true, ESoundGroup.SongPlayback);
+		this.bgmResultIn_AI = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result_In_AI.ogg", false, false, true, ESoundGroup.SongPlayback);
+		this.bgmResult_AI = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}BGM{System.IO.Path.DirectorySeparatorChar}Result_AI.ogg", true, false, true, ESoundGroup.SongPlayback);
 
-		this.bgmDanResult = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}Dan_Result.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.bgmDanResult = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}Dan_Result.ogg", true, false, false, ESoundGroup.SongPlayback);
 
-		this.bgmTowerResult = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Tower{System.IO.Path.DirectorySeparatorChar}Tower_Result.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.bgmTowerResult = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Tower{System.IO.Path.DirectorySeparatorChar}Tower_Result.ogg", true, false, false, ESoundGroup.SongPlayback);
 
-		this.soundCrownIn = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}ResultScreen{System.IO.Path.DirectorySeparatorChar}CrownIn.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundRankIn = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}ResultScreen{System.IO.Path.DirectorySeparatorChar}RankIn.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundCrownIn = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}ResultScreen{System.IO.Path.DirectorySeparatorChar}CrownIn.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundRankIn = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}ResultScreen{System.IO.Path.DirectorySeparatorChar}RankIn.ogg", false, false, false, ESoundGroup.SoundEffect);
 
-		this.sound特訓再生音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Resume.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.sound特訓停止音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Pause.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundTrainingModeScrollSFX = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Scroll.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundTrainingToggleBookmarkSFX = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Jump Point.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.sound特訓スキップ音 = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Traning Skip.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundPon = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Pon.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundGauge = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Gauge.ogg", false, false, false, ESoundGroup.SoundEffect);
-		this.soundScoreDon = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}ScoreDon.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.sound特訓再生音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Resume.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.sound特訓停止音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Pause.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundTrainingModeScrollSFX = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Scroll.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundTrainingToggleBookmarkSFX = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Jump Point.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.sound特訓スキップ音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Traning Skip.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundPon = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Pon.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundGauge = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Gauge.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundScoreDon = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}ScoreDon.ogg", false, false, false, ESoundGroup.SoundEffect);
 
-		this.soundDanSongSelectIn = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}Dan_In.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundDanSongSelectIn = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}Dan_In.ogg", false, false, false, ESoundGroup.SoundEffect);
 
-		this.soundDanSelectBGM = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}DanSelectBGM.ogg", true, false, false, ESoundGroup.SongPlayback);
-		this.soundDanSongSelect = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}DanSongSelect.ogg", false, false, false, ESoundGroup.SoundEffect);
+		this.soundDanSelectBGM = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}DanSelectBGM.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.soundDanSongSelect = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Dan{System.IO.Path.DirectorySeparatorChar}DanSongSelect.ogg", false, false, false, ESoundGroup.SoundEffect);
 
-		this.soundHeyaBGM = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Heya{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
-		this.soundOnlineLoungeBGM = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}OnlineLounge{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
-		this.soundEncyclopediaBGM = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Encyclopedia{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
-		this.soundTowerSelectBGM = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Tower{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.soundHeyaBGM = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Heya{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.soundOnlineLoungeBGM = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}OnlineLounge{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.soundEncyclopediaBGM = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Encyclopedia{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
+		this.soundTowerSelectBGM = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Tower{System.IO.Path.DirectorySeparatorChar}BGM.ogg", true, false, false, ESoundGroup.SongPlayback);
 
-		soundExToExtra = new CSystemSound[1] { new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongSelect{System.IO.Path.DirectorySeparatorChar}0{System.IO.Path.DirectorySeparatorChar}ExToExtra.ogg", false, false, false, ESoundGroup.SoundEffect) }; // Placeholder until Komi decides
-		soundExtraToEx = new CSystemSound[1] { new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongSelect{System.IO.Path.DirectorySeparatorChar}0{System.IO.Path.DirectorySeparatorChar}ExtraToEx.ogg", false, false, false, ESoundGroup.SoundEffect) }; // what to do with it lol
+		soundExToExtra = new[] { SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongSelect{System.IO.Path.DirectorySeparatorChar}0{System.IO.Path.DirectorySeparatorChar}ExToExtra.ogg", false, false, false, ESoundGroup.SoundEffect) }; // Placeholder until Komi decides
+		soundExtraToEx = new[] { SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}SongSelect{System.IO.Path.DirectorySeparatorChar}0{System.IO.Path.DirectorySeparatorChar}ExtraToEx.ogg", false, false, false, ESoundGroup.SoundEffect) }; // what to do with it lol
 
-		calibrationTick = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Calibrate.ogg", false, false, false, ESoundGroup.SoundEffect);
+		calibrationTick = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Calibrate.ogg", false, false, false, ESoundGroup.SoundEffect);
 
 		soundModal = new CSystemSound[6];
 		for (int i = 0; i < soundModal.Length - 1; i++) {
-			soundModal[i] = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}" + i.ToString() + ".ogg", false, false, false, ESoundGroup.SoundEffect);
+			soundModal[i] = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}" + i.ToString() + ".ogg", false, false, false, ESoundGroup.SoundEffect);
 		}
-		soundModal[soundModal.Length - 1] = new CSystemSound(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}Coin.ogg", false, false, false, ESoundGroup.SoundEffect);
+		soundModal[soundModal.Length - 1] = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}Coin.ogg", false, false, false, ESoundGroup.SoundEffect);
 
 		ReloadSkin();
 		tReadSkinConfig();
@@ -777,10 +622,10 @@ internal class CSkin : IDisposable {
 	}
 
 	public void ReloadSkin() {
-		for (int i = 0; i < nシステムサウンド数; i++) {
-			if (!this[i].bExclusive)   // BGM系以外のみ読み込む。(BGM系は必要になったときに読み込む)
+		foreach (var snd in this.listSystemSound) {
+			if (!snd.bExclusive)   // BGM系以外のみ読み込む。(BGM系は必要になったときに読み込む)
 			{
-				CSystemSound cシステムサウンド = this[i];
+				CSystemSound cシステムサウンド = snd;
 				if (cシステムサウンド.bCompact対象) {
 					try {
 						cシステムサウンド.tLoading();
@@ -939,10 +784,10 @@ internal class CSkin : IDisposable {
 
 
 	public void tRemoveMixerAll() {
-		for (int i = 0; i < nシステムサウンド数; i++) {
-			if (this[i] != null && this[i].bLoadedSuccessfuly) {
-				this[i].tStop();
-				this[i].tRemoveMixer();
+		foreach (var snd in this.listSystemSound) {
+			if (snd.bLoadedSuccessfuly) {
+				snd.tStop();
+				snd.tRemoveMixer();
 			}
 		}
 
@@ -7577,8 +7422,9 @@ internal class CSkin : IDisposable {
 	//-----------------
 	public void Dispose() {
 		if (!this.bDisposed済み) {
-			for (int i = 0; i < this.nシステムサウンド数; i++)
-				this[i].Dispose();
+			foreach (var snd in this.listSystemSound)
+				snd.Dispose();
+			this.listSystemSound.Clear();
 
 			this.bDisposed済み = true;
 		}

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -44,7 +44,7 @@ internal class CSkin : IDisposable {
 
 		public static CSkin.CSystemSound r最後に再生した排他システムサウンド;
 
-		private readonly ESoundGroup _soundGroup;
+		public ESoundGroup SoundGroup { get; private init; }
 
 		// フィールド、プロパティ
 
@@ -97,9 +97,20 @@ internal class CSkin : IDisposable {
 			this.bLoop = bLoop;
 			this.bExclusive = bExclusive;
 			this.bCompact対象 = bCompact対象;
-			_soundGroup = soundGroup;
+			SoundGroup = soundGroup;
 			this.bNotLoadedYet = true;
 			this.bPlayed = false;
+		}
+
+		public void UpdateSound(CSystemSound sound) {
+			if (sound.bDisposed)
+				return;
+			this.Dispose();
+			this.rSound = sound.rSound;
+			this.strFileName = sound.strFileName;
+
+			this.bLoadedSuccessfuly = sound.bLoadedSuccessfuly;
+			this.bDisposed = sound.bDisposed;
 		}
 
 
@@ -119,7 +130,7 @@ internal class CSkin : IDisposable {
 			for (int i = 0; i < 2; i++)     // 一旦Cloneを止めてASIO対応に専念
 			{
 				try {
-					this.rSound[i] = OpenTaiko.SoundManager?.tCreateSound(CSkin.Path(this.strFileName), _soundGroup);
+					this.rSound[i] = OpenTaiko.SoundManager?.tCreateSound(CSkin.Path(this.strFileName), SoundGroup);
 				} catch {
 					this.rSound[i] = null;
 					throw;

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -155,6 +155,7 @@ internal class CSkin : IDisposable {
 				}
 			}
 			this.bLoadedSuccessfuly = true;
+			this.bDisposed = false;
 		}
 		public void tPlay() {
 			if (this.bNotLoadedYet) {
@@ -517,8 +518,8 @@ internal class CSkin : IDisposable {
 	/// Skin(Sounds)を再読込する準備をする(再生停止,Dispose,ファイル名再設定)。
 	/// あらかじめstrSkinSubfolderを適切に設定しておくこと。
 	/// その後、ReloadSkinPaths()を実行し、strSkinSubfolderの正当性を確認した上で、本メソッドを呼び出すこと。
-	/// 本メソッド呼び出し後に、ReloadSkin()を実行することで、システムサウンドを読み込み直す。
-	/// ReloadSkin()の内容は本メソッド内に含めないこと。起動時はReloadSkin()相当の処理をCEnumSongsで行っているため。
+	/// 本メソッド呼び出し後に、PreloadSystemSounds()を実行することで、システムサウンドを読み込み直す。
+	/// PreloadSystemSounds()の内容は本メソッド内に含めないこと。起動時はPreloadSystemSounds()相当の処理をCEnumSongsで行っているため。
 	/// </summary>
 	public void PrepareReloadSkin() {
 		Trace.TraceInformation("SkinPath設定: {0}",
@@ -527,13 +528,7 @@ internal class CSkin : IDisposable {
 				strBoxDefSkinSubfolderFullName
 		);
 
-		foreach (var snd in this.listSystemSound) {
-			if (snd.bLoadedSuccessfuly) {
-				snd.tStop();
-				snd.Dispose();
-			}
-		}
-		this.listSystemSound.Clear();
+		UnloadSystemSounds();
 
 		this.soundカーソル移動音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Move.ogg", false, false, false, ESoundGroup.SoundEffect);
 		this.soundDecideSFX = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Decide.ogg", false, false, false, ESoundGroup.SoundEffect);
@@ -614,14 +609,23 @@ internal class CSkin : IDisposable {
 		}
 		soundModal[soundModal.Length - 1] = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}Coin.ogg", false, false, false, ESoundGroup.SoundEffect);
 
-		ReloadSkin();
 		tReadSkinConfig();
 
 		//hsHitSoundsInformations = new CHitSounds(Path(@$"Sounds{System.IO.Path.DirectorySeparatorChar}HitSounds{System.IO.Path.DirectorySeparatorChar}HitSounds.json"));
 		hsHitSoundsInformations = new CHitSounds(@$"Global{System.IO.Path.DirectorySeparatorChar}HitSounds");
 	}
 
-	public void ReloadSkin() {
+	public void UnloadSystemSounds() {
+		foreach (var snd in this.listSystemSound) {
+			if (snd.bLoadedSuccessfuly) {
+				snd.tStop();
+				snd.Dispose();
+			}
+		}
+		this.listSystemSound.Clear();
+	}
+
+	public void PreloadSystemSounds() {
 		foreach (var snd in this.listSystemSound) {
 			if (!snd.bExclusive)   // BGM系以外のみ読み込む。(BGM系は必要になったときに読み込む)
 			{

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -528,6 +528,14 @@ internal class CSkin : IDisposable {
 				strBoxDefSkinSubfolderFullName
 		);
 
+		ReloadSystemSounds();
+		tReadSkinConfig();
+
+		//hsHitSoundsInformations = new CHitSounds(Path(@$"Sounds{System.IO.Path.DirectorySeparatorChar}HitSounds{System.IO.Path.DirectorySeparatorChar}HitSounds.json"));
+		hsHitSoundsInformations = new CHitSounds(@$"Global{System.IO.Path.DirectorySeparatorChar}HitSounds");
+	}
+
+	public void ReloadSystemSounds() {
 		UnloadSystemSounds();
 
 		this.soundカーソル移動音 = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Move.ogg", false, false, false, ESoundGroup.SoundEffect);
@@ -608,11 +616,6 @@ internal class CSkin : IDisposable {
 			soundModal[i] = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}" + i.ToString() + ".ogg", false, false, false, ESoundGroup.SoundEffect);
 		}
 		soundModal[soundModal.Length - 1] = SndCAbsolute(@$"Sounds{System.IO.Path.DirectorySeparatorChar}Modals{System.IO.Path.DirectorySeparatorChar}Coin.ogg", false, false, false, ESoundGroup.SoundEffect);
-
-		tReadSkinConfig();
-
-		//hsHitSoundsInformations = new CHitSounds(Path(@$"Sounds{System.IO.Path.DirectorySeparatorChar}HitSounds{System.IO.Path.DirectorySeparatorChar}HitSounds.json"));
-		hsHitSoundsInformations = new CHitSounds(@$"Global{System.IO.Path.DirectorySeparatorChar}HitSounds");
 	}
 
 	public void UnloadSystemSounds() {

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -55,62 +55,33 @@ internal class CSkin : IDisposable {
 		public bool bLoadedSuccessfuly;
 		public bool bExclusive;
 		public string strFileName = "";
+		private CSound nowSound => this.rSound[1 - this.nNextPlayingSoundNumber];
+		private CSound nextSound => this.rSound[this.nNextPlayingSoundNumber];
 		public bool bIsPlaying {
-			get {
-				if (this.rSound[1 - this.nNextPlayingSoundNumber] == null)
-					return false;
-
-				return this.rSound[1 - this.nNextPlayingSoundNumber].IsPlaying;
-			}
+			get => this.nowSound?.IsPlaying ?? false;
 		}
 		public int nPosition_CurrentlyPlayingSound {
-			get {
-				return this.rSound[1 - this.nNextPlayingSoundNumber]?.SoundPosition ?? 0;
-			}
-			set {
-				this.rSound[1 - this.nNextPlayingSoundNumber]?.SetPanning(value);
-			}
+			get => this.nowSound?.SoundPosition ?? 0;
+			set => this.nowSound?.SetPanning(value);
 		}
 		public int nPosition_NextPlayingSound {
-			get {
-				return this.rSound[this.nNextPlayingSoundNumber]?.SoundPosition ?? 0;
-			}
-			set {
-				this.rSound[this.nNextPlayingSoundNumber]?.SetPanning(value);
-			}
+			get => nextSound?.SoundPosition ?? 0;
+			set => nextSound?.SetPanning(value);
 		}
 		public int nAutomationLevel_現在のサウンド {
-			get {
-				CSound sound = this.rSound[1 - this.nNextPlayingSoundNumber];
-				if (sound == null)
-					return 0;
-
-				return sound.AutomationLevel;
-			}
+			get => this.nowSound?.AutomationLevel ?? 0;
 			set {
-				CSound sound = this.rSound[1 - this.nNextPlayingSoundNumber];
+				CSound sound = this.nowSound;
 				if (sound != null) {
 					sound.AutomationLevel = value;
 				}
 			}
 		}
 		public int n長さ_現在のサウンド {
-			get {
-				CSound sound = this.rSound[1 - this.nNextPlayingSoundNumber];
-				if (sound == null) {
-					return 0;
-				}
-				return sound.TotalPlayTime;
-			}
+			get => this.nowSound?.TotalPlayTime ?? 0;
 		}
 		public int n長さ_次に鳴るサウンド {
-			get {
-				CSound sound = this.rSound[this.nNextPlayingSoundNumber];
-				if (sound == null) {
-					return 0;
-				}
-				return sound.TotalPlayTime;
-			}
+			get => nextSound?.TotalPlayTime ?? 0;
 		}
 
 
@@ -173,9 +144,7 @@ internal class CSkin : IDisposable {
 
 				r最後に再生した排他システムサウンド = this;
 			}
-			CSound sound = this.rSound[this.nNextPlayingSoundNumber];
-			if (sound != null)
-				sound.PlayStart(this.bLoop);
+			this.nextSound?.PlayStart(this.bLoop);
 
 			this.bPlayed = true;
 			this.nNextPlayingSoundNumber = 1 - this.nNextPlayingSoundNumber;

--- a/OpenTaiko/src/Common/CSkin.cs
+++ b/OpenTaiko/src/Common/CSkin.cs
@@ -77,12 +77,28 @@ internal class CSkin : IDisposable {
 				}
 			}
 		}
-		public int n長さ_現在のサウンド {
-			get => this.nowSound?.TotalPlayTime ?? 0;
+		public double msTimeStamp_nowSound {
+			get {
+				double msTimeStamp = 0;
+				this.nowSound?.tGetPlayPositon(out var bytesTimeStamp, out msTimeStamp);
+				return msTimeStamp;
+			}
 		}
-		public int n長さ_次に鳴るサウンド {
-			get => nextSound?.TotalPlayTime ?? 0;
+		public double msTimeStamp_nextSound {
+			get {
+				double msTimeStamp = 0;
+				this.nextSound?.tGetPlayPositon(out var bytesTimeStamp, out msTimeStamp);
+				return msTimeStamp;
+			}
 		}
+		public double n長さ_現在のサウンド {
+			get => this.nowSound?.dbTotalPlayTime ?? 0;
+		}
+		public double n長さ_次に鳴るサウンド {
+			get => nextSound?.dbTotalPlayTime ?? 0;
+		}
+
+		public uint Pointer { get => this.rSound[0]?.Pointer ?? 0; }
 
 
 		/// <summary>

--- a/OpenTaiko/src/Common/ImGuiDebugWindow.cs
+++ b/OpenTaiko/src/Common/ImGuiDebugWindow.cs
@@ -825,7 +825,7 @@ public static class ImGuiDebugWindow {
 	}
 	private static long TextureListPopup(ScriptBG script, string label, string id) {
 		if (script == null) return 0;
-		return CTextureListPopup([.. script.Textures.Values, .. script.TextureList], label, id);
+		return CTextureListPopup(script.Textures.Values.Concat(script.TextureList), label, id);
 	}
 	private static void DrawForImGui(CTexture texture, int max_width, int max_height) {
 		DrawForImGui(texture, 0, 0,

--- a/OpenTaiko/src/Common/ImGuiDebugWindow.cs
+++ b/OpenTaiko/src/Common/ImGuiDebugWindow.cs
@@ -873,7 +873,8 @@ public static class ImGuiDebugWindow {
 	private static long ResourceListPopup<T>(string resourceType, ScriptBG script, string label, string id) {
 		if (script == null) return 0;
 		if (typeof(T) == typeof(CTexture))
-			return CResourceListPopup(resourceType, script.Textures.Values.Concat(script.TextureList), label, id);
+			return CResourceListPopup(resourceType, script.Textures.Values
+				.Concat(script.TextureList.Select(x => x._texture)), label, id);
 		return 0;
 	}
 	private static void DrawForImGui(CTexture texture, int max_width, int max_height) {

--- a/OpenTaiko/src/Common/ImGuiDebugWindow.cs
+++ b/OpenTaiko/src/Common/ImGuiDebugWindow.cs
@@ -780,7 +780,7 @@ public static class ImGuiDebugWindow {
 				CTexture new_tex = new CTexture(reloadResourcePath, false);
 				texture.UpdateTexture(new_tex, new_tex.sz画像サイズ.Width, new_tex.sz画像サイズ.Height);
 			}
-			if (texture != null) {
+			if (texture != null && texture.Pointer != 0) {
 				if (ImGui.BeginCombo($"Texture Wrap Mode", texture.WrapMode.ToString())) {
 					foreach (var mode in Enum.GetValues<Silk.NET.OpenGLES.TextureWrapMode>().Distinct()) {
 						if (ImGui.Selectable(mode.ToString(), texture.WrapMode == mode)) {
@@ -795,7 +795,7 @@ public static class ImGuiDebugWindow {
 		}
 		if (ImGui.IsItemHovered(ImGuiHoveredFlags.DelayNone)) {
 			if (ImGui.BeginItemTooltip()) {
-				if (texture != null) {
+				if (texture != null && texture.Pointer != 0) {
 					DrawForImGui(texture, 800, 800);
 					ImGui.Text("Pointer: " + texture.Pointer);
 					ImGui.Text("Size: x" + texture.szTextureSize.Width + ",y" + texture.szTextureSize.Height);
@@ -906,7 +906,7 @@ public static class ImGuiDebugWindow {
 	#region Helpers
 	private static float GetMemAllocationInMegabytes(long bytes) { return (float)bytes / (1024 * 1024); }
 	private static long GetResourceMemAllocation(CTexture? texture, long orDefault = 0) {
-		return texture != null ? (texture.szTextureSize.Width * texture.szTextureSize.Height * 4) : orDefault;
+		return (texture != null && texture.Pointer != 0) ? (texture.szTextureSize.Width * texture.szTextureSize.Height * 4) : orDefault;
 	}
 	private static Vector4 ColorToVector4(Color color) {
 		return new Vector4((float)color.R / 255, (float)color.G / 255, (float)color.B / 255, (float)color.A / 255);

--- a/OpenTaiko/src/Common/ImGuiDebugWindow.cs
+++ b/OpenTaiko/src/Common/ImGuiDebugWindow.cs
@@ -772,11 +772,11 @@ public static class ImGuiDebugWindow {
 	#endregion
 
 	#region ImGui Items
-	private static void CResourcePopup(CTexture texture, string label) {
+	private static void CResourcePopup(CTexture? texture, string label) {
 		if (ImGui.TreeNodeEx(label, ImGuiTreeNodeFlags.Framed)) {
-
+			ImGui.BeginDisabled(texture == null);
 			ImGui.InputText("Path", ref reloadResourcePath, 2048);
-			if (ImGui.Button($"Update via. Path###TEXTURE_UPDATE_{label}")) {
+			if (ImGui.Button($"Update via. Path###TEXTURE_UPDATE_{label}") && texture != null) {
 				CTexture new_tex = new CTexture(reloadResourcePath, false);
 				texture.UpdateTexture(new_tex, new_tex.sz画像サイズ.Width, new_tex.sz画像サイズ.Height);
 			}
@@ -790,6 +790,7 @@ public static class ImGuiDebugWindow {
 					ImGui.EndCombo();
 				}
 			}
+			ImGui.EndDisabled();
 
 			ImGui.TreePop();
 		}
@@ -809,21 +810,22 @@ public static class ImGuiDebugWindow {
 	}
 
 	private static uint lastPlayedSoundPointer = 0;
-	private static void CResourcePopup(CSkin.CSystemSound sound, string label) {
+	private static void CResourcePopup(CSkin.CSystemSound? sound, string label) {
 		if (ImGui.TreeNodeEx(label, ImGuiTreeNodeFlags.Framed)) {
-
+			ImGui.BeginDisabled(sound == null);
 			ImGui.InputText("Path", ref reloadResourcePath, 2048);
 			if (ImGui.Button($"Update via. Path###SOUND_UPDATE_{label}")) {
 				CSkin.CSystemSound new_snd = new(reloadResourcePath, sound.bLoop, sound.bExclusive, sound.bCompact対象, sound.SoundGroup);
 				sound.UpdateSound(new_snd);
 			}
+			ImGui.EndDisabled();
 
 			ImGui.TreePop();
 		}
 		if (ImGui.IsItemHovered(ImGuiHoveredFlags.DelayNone)) {
 			bool shouldPlay = ImGui.IsItemHovered(ImGuiHoveredFlags.DelayNormal);
 			if (ImGui.BeginItemTooltip()) {
-				if (sound.bLoadedSuccessfuly) {
+				if (sound?.bLoadedSuccessfuly ?? false) {
 					DrawForImGui(sound, shouldPlay);
 					ImGui.Text($"Length: {sound.n長さ_現在のサウンド:0.###},{sound.n長さ_次に鳴るサウンド:0.###}");
 					ImGui.Text("Memory allocated: " + String.Format("{0:0.###}", GetMemAllocationInMegabytes(GetResourceMemAllocation(sound))) + "MB");
@@ -832,14 +834,14 @@ public static class ImGuiDebugWindow {
 				}
 				ImGui.EndTooltip();
 			}
-		} else if (sound.Pointer == lastPlayedSoundPointer) {
+		} else if (sound?.Pointer == lastPlayedSoundPointer) {
 			if (sound.bIsPlaying) {
 				sound.tStop();
 				lastPlayedSoundPointer = 0;
 			}
 		}
 	}
-	private static long CResourceListPopup<T>(string resourceType, IEnumerable<T> resourceList, string label, string id) where T : IDisposable {
+	private static long CResourceListPopup<T>(string resourceType, IEnumerable<T> resourceList, string label, string id) where T : IDisposable? {
 		if (resourceList == null) return 0;
 
 		Action<IDisposable, string> popup =

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -2289,6 +2289,7 @@ internal class OpenTaiko : Game {
 		OpenTaiko.Skin.Dispose();
 		OpenTaiko.Skin = null;
 		OpenTaiko.Skin = new CSkin(OpenTaiko.ConfigIni.strSystemSkinSubfolderFullName, false);
+		OpenTaiko.Skin.PreloadSystemSounds();
 		OpenTaiko.Skin.FetchMenusAndModules();
 
 		OpenTaiko.Tx.DisposeTexture();

--- a/OpenTaiko/src/Common/TitleTextureKey.cs
+++ b/OpenTaiko/src/Common/TitleTextureKey.cs
@@ -6,7 +6,7 @@ namespace OpenTaiko;
 public sealed class TitleTextureKey {
 
 	// Static
-	private static readonly Dictionary<TitleTextureKey, CTexture> _titledictionary
+	internal static readonly Dictionary<TitleTextureKey, CTexture> _titledictionary
 		= new Dictionary<TitleTextureKey, CTexture>();
 
 	public static CTexture ResolveTitleTexture(TitleTextureKey titleTextureKey) {

--- a/OpenTaiko/src/Lua/CLuaScript.cs
+++ b/OpenTaiko/src/Lua/CLuaScript.cs
@@ -11,10 +11,10 @@ class CLuaScript : IDisposable {
 
 	#region [For the new Lua module methods]
 
-	public List<CTexture> TextureList = [];
-	public List<LuaSound> SoundList = [];
-	public List<CVideoDecoder> VideoList = [];
-	public List<LuaText> TextList = [];
+	public HashSet<LuaTexture> TextureList = [];
+	public HashSet<LuaSound> SoundList = [];
+	public HashSet<LuaVideo> VideoList = [];
+	public HashSet<LuaText> TextList = [];
 	public Dictionary<string, LuaSharedResource<LuaTexture>> SharedTextures = new();
 	public Dictionary<string, LuaSharedResource<LuaSound>> SharedSounds = new();
 
@@ -283,10 +283,16 @@ class CLuaScript : IDisposable {
 	public void Dispose() {
 		if (bDisposed) return;
 
-		foreach (IDisposable disposable in listDisposables) {
-			disposable.Dispose();
+		void freeDisposableList<T>(ICollection<T> list) where T : IDisposable? {
+			foreach (var disposable in list)
+				disposable?.Dispose();
+			list.Clear();
 		}
-		listDisposables.Clear();
+		freeDisposableList(this.listDisposables);
+		freeDisposableList(this.TextureList);
+		freeDisposableList(this.SoundList);
+		freeDisposableList(this.VideoList);
+		freeDisposableList(this.TextList);
 
 		LuaScript.Dispose();
 

--- a/OpenTaiko/src/Lua/Classes/LuaSound.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaSound.cs
@@ -3,6 +3,7 @@
 namespace OpenTaiko {
 	public class LuaSound : IDisposable {
 		private CSkin.CSystemSound? _sound;
+		internal HashSet<LuaSound>? _disposeList = null;
 
 		public string Path { get; private set; } = "";
 		public LuaSound() {
@@ -57,6 +58,7 @@ namespace OpenTaiko {
 				}
 				_sound?.Dispose();
 				_sound = null;
+				_disposeList?.Remove(this);
 
 				_disposedValue = true;
 			}
@@ -69,10 +71,10 @@ namespace OpenTaiko {
 		#endregion
 	}
 	public class LuaSoundFunc {
-		private List<LuaSound> Sounds;
+		private HashSet<LuaSound> Sounds;
 		private string DirPath;
 
-		public LuaSoundFunc(List<LuaSound> sounds, string dirPath) {
+		public LuaSoundFunc(HashSet<LuaSound> sounds, string dirPath) {
 			Sounds = sounds;
 			DirPath = dirPath;
 		}
@@ -93,6 +95,7 @@ namespace OpenTaiko {
 			try {
 				sound = new(full_path, group);
 				Sounds.Add(sound);
+				sound._disposeList = this.Sounds;
 			} catch (Exception e) {
 				LogNotification.PopError($"Lua Sound failed to load: {e}");
 				sound?.Dispose();
@@ -109,6 +112,7 @@ namespace OpenTaiko {
 			try {
 				sound = new(full_path, group);
 				Sounds.Add(sound);
+				sound._disposeList = this.Sounds;
 			} catch (Exception e) {
 				LogNotification.PopError($"Lua Sound failed to load: {e}");
 				sound?.Dispose();

--- a/OpenTaiko/src/Lua/Classes/LuaSound.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaSound.cs
@@ -2,7 +2,7 @@
 
 namespace OpenTaiko {
 	public class LuaSound : IDisposable {
-		private CSkin.CSystemSound? _sound;
+		internal CSkin.CSystemSound? _sound;
 		internal HashSet<LuaSound>? _disposeList = null;
 
 		public string Path { get; private set; } = "";

--- a/OpenTaiko/src/Lua/Classes/LuaText.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaText.cs
@@ -10,7 +10,7 @@ using System.IO;
 namespace OpenTaiko {
 	public class LuaText : IDisposable {
 		private CCachedFontRenderer? _fontRenderer;
-		private Dictionary<TitleTextureKey, LuaTexture> _titles = [];
+		internal Dictionary<TitleTextureKey, LuaTexture> _titles = [];
 		internal HashSet<LuaText>? _disposeList = null;
 
 		public LuaText() {

--- a/OpenTaiko/src/Lua/Classes/LuaText.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaText.cs
@@ -11,6 +11,7 @@ namespace OpenTaiko {
 	public class LuaText : IDisposable {
 		private CCachedFontRenderer? _fontRenderer;
 		private Dictionary<TitleTextureKey, LuaTexture> _titles = [];
+		internal HashSet<LuaText>? _disposeList = null;
 
 		public LuaText() {
 			_fontRenderer = null;
@@ -84,6 +85,7 @@ namespace OpenTaiko {
 
 				_titles.Clear();
 				_fontRenderer?.Dispose();
+				_disposeList?.Remove(this);
 				_disposedValue = true;
 			}
 		}
@@ -95,10 +97,10 @@ namespace OpenTaiko {
 		#endregion
 	}
 	public class LuaTextFunc {
-		public List<LuaText> Texts;
+		public HashSet<LuaText> Texts;
 		public string DirPath;
 
-		public LuaTextFunc(List<LuaText> texts, string dirPath) {
+		public LuaTextFunc(HashSet<LuaText> texts, string dirPath) {
 			Texts = texts;
 			DirPath = dirPath;
 		}
@@ -109,6 +111,7 @@ namespace OpenTaiko {
 			try {
 				text = new(true, size, style);
 				Texts.Add(text);
+				text._disposeList = this.Texts;
 			}
 			catch (Exception e) {
 				LogNotification.PopError($"Lua Text failed to load: {e}");

--- a/OpenTaiko/src/Lua/Classes/LuaTexture.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaTexture.cs
@@ -2,7 +2,8 @@
 
 namespace OpenTaiko {
 	public class LuaTexture : IDisposable {
-		private CTexture? _texture = null;
+		internal CTexture? _texture = null;
+		internal HashSet<LuaTexture>? _disposeList = null;
 		public uint Pointer => _texture != null ? _texture.Pointer : 0;
 
 		public LuaTexture() {
@@ -121,6 +122,7 @@ namespace OpenTaiko {
 		protected virtual void Dispose(bool disposing) {
 			if (!_disposedValue) {
 				OpenTaiko.tDisposeSafely(ref _texture);
+				_disposeList?.Remove(this);
 				_disposedValue = true;
 			}
 		}
@@ -131,10 +133,10 @@ namespace OpenTaiko {
 		#endregion
 	}
 	public class LuaTextureFunc {
-		private List<CTexture> Textures;
+		private HashSet<LuaTexture> Textures;
 		private string DirPath;
 
-		public LuaTextureFunc(List<CTexture> textures, string dirPath) {
+		public LuaTextureFunc(HashSet<LuaTexture> textures, string dirPath) {
 			Textures = textures;
 			DirPath = dirPath;
 		}
@@ -147,7 +149,8 @@ namespace OpenTaiko {
 				try {
 					var tex = OpenTaiko.tテクスチャの生成(full_path);
 					luatex = new LuaTexture(tex);
-					Textures.Add(tex);
+					Textures.Add(luatex);
+					luatex._disposeList = this.Textures;
 				} catch (Exception e) {
 					LogNotification.PopWarning($"Lua Texture failed to load: {e}");
 					luatex?.Dispose();
@@ -167,7 +170,8 @@ namespace OpenTaiko {
 				try {
 					var tex = OpenTaiko.tテクスチャの生成(full_path);
 					luatex = new LuaTexture(tex);
-					Textures.Add(tex);
+					Textures.Add(luatex);
+					luatex._disposeList = this.Textures;
 				} catch (Exception e) {
 					LogNotification.PopWarning($"Lua Texture failed to load: {e}");
 					luatex?.Dispose();

--- a/OpenTaiko/src/Lua/Classes/LuaVideo.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaVideo.cs
@@ -9,6 +9,7 @@ namespace OpenTaiko {
 	public class LuaVideo : IDisposable {
 		private CVideoDecoder? _video = null;
 		private CTexture? _tmpTex = null;
+		internal HashSet<LuaVideo>? _disposeList = null;
 
 		public LuaVideo() {
 			_video = null;
@@ -83,6 +84,7 @@ namespace OpenTaiko {
 			if (!_disposedValue) {
 				OpenTaiko.tDisposeSafely(ref _video);
 				OpenTaiko.tDisposeSafely(ref _tmpTex);
+				_disposeList?.Remove(this);
 				_disposedValue = true;
 			}
 		}
@@ -93,10 +95,10 @@ namespace OpenTaiko {
 		#endregion
 	}
 	public class LuaVideoFunc {
-		private List<CVideoDecoder> Videos;
+		private HashSet<LuaVideo> Videos;
 		private string DirPath;
 
-		public LuaVideoFunc(List<CVideoDecoder> videos, string dirPath) {
+		public LuaVideoFunc(HashSet<LuaVideo> videos, string dirPath) {
 			Videos = videos;
 			DirPath = dirPath;
 		}
@@ -110,7 +112,8 @@ namespace OpenTaiko {
 					var vid = new CVideoDecoder(full_path);
 					vid.InitRead();
 					luavid = new LuaVideo(vid);
-					Videos.Add(vid);
+					Videos.Add(luavid);
+					luavid._disposeList = this.Videos;
 				} catch (Exception e) {
 					LogNotification.PopWarning($"Lua Video failed to load: {e}");
 					luavid?.Dispose();

--- a/OpenTaiko/src/Lua/Classes/LuaVideo.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaVideo.cs
@@ -8,7 +8,7 @@ using FDK;
 namespace OpenTaiko {
 	public class LuaVideo : IDisposable {
 		private CVideoDecoder? _video = null;
-		private CTexture? _tmpTex = null;
+		internal CTexture? _tmpTex = null;
 		internal HashSet<LuaVideo>? _disposeList = null;
 
 		public LuaVideo() {

--- a/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
+++ b/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
@@ -215,27 +215,7 @@ internal class CEnumSongs                           // #27060 2011.2.7 yyagi 曲
 
 			try {
 				OpenTaiko.Skin.bgm起動画面.tPlay();
-				foreach (var snd in OpenTaiko.Skin.listSystemSound) {
-					if (!snd.bExclusive) // BGM系以外のみ読み込む。(BGM系は必要になったときに読み込む)
-					{
-						CSkin.CSystemSound cシステムサウンド = snd;
-						if (cシステムサウンド.bCompact対象) {
-							try {
-								cシステムサウンド.tLoading();
-								Trace.TraceInformation("システムサウンドを読み込みました。({0})", cシステムサウンド.strFileName);
-								//if ( ( cシステムサウンド == CDTXMania.Skin.bgm起動画面 ) && cシステムサウンド.b読み込み成功 )
-								//{
-								//	cシステムサウンド.t再生する();
-								//}
-							} catch (FileNotFoundException) {
-								Trace.TraceWarning("システムサウンドが存在しません。({0})", cシステムサウンド.strFileName);
-							} catch (Exception e) {
-								Trace.TraceWarning(e.ToString());
-								Trace.TraceWarning("システムサウンドの読み込みに失敗しました。({0})", cシステムサウンド.strFileName);
-							}
-						}
-					}
-				}
+				OpenTaiko.Skin.PreloadSystemSounds();
 				lock (OpenTaiko.stageStartup.list進行文字列) {
 					OpenTaiko.stageStartup.list進行文字列.Add("SYSTEM SOUND...OK");
 				}

--- a/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
+++ b/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
@@ -215,10 +215,10 @@ internal class CEnumSongs                           // #27060 2011.2.7 yyagi 曲
 
 			try {
 				OpenTaiko.Skin.bgm起動画面.tPlay();
-				for (int i = 0; i < OpenTaiko.Skin.nシステムサウンド数; i++) {
-					if (!OpenTaiko.Skin[i].bExclusive) // BGM系以外のみ読み込む。(BGM系は必要になったときに読み込む)
+				foreach (var snd in OpenTaiko.Skin.listSystemSound) {
+					if (!snd.bExclusive) // BGM系以外のみ読み込む。(BGM系は必要になったときに読み込む)
 					{
-						CSkin.CSystemSound cシステムサウンド = OpenTaiko.Skin[i];
+						CSkin.CSystemSound cシステムサウンド = snd;
 						if (cシステムサウンド.bCompact対象) {
 							try {
 								cシステムサウンド.tLoading();

--- a/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
@@ -1084,7 +1084,8 @@ internal class CActConfigList : CActivity {
 					this.iSystemASIODevice.n現在選択されている項目番号,
 					this.iSystemSoundTimerType.bON);
 				OpenTaiko.app.ShowWindowTitle();
-				OpenTaiko.Skin.ReloadSkin();// 音声の再読み込みをすることによって、音量の初期化を防ぐ
+				OpenTaiko.Skin.UnloadSystemSounds();
+				OpenTaiko.Skin.PreloadSystemSounds();// 音声の再読み込みをすることによって、音量の初期化を防ぐ
 			}
 		} else {
 			if (this.iSystemBassBufferSizeMs_initial != this.iSystemBassBufferSizeMs.n現在の値 ||

--- a/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
+++ b/OpenTaiko/src/Stages/04.Config/CActConfigList.cs
@@ -1084,8 +1084,8 @@ internal class CActConfigList : CActivity {
 					this.iSystemASIODevice.n現在選択されている項目番号,
 					this.iSystemSoundTimerType.bON);
 				OpenTaiko.app.ShowWindowTitle();
-				OpenTaiko.Skin.UnloadSystemSounds();
-				OpenTaiko.Skin.PreloadSystemSounds();// 音声の再読み込みをすることによって、音量の初期化を防ぐ
+				OpenTaiko.Skin.ReloadSystemSounds();
+				OpenTaiko.Skin.PreloadSystemSounds();
 			}
 		} else {
 			if (this.iSystemBassBufferSizeMs_initial != this.iSystemBassBufferSizeMs.n現在の値 ||

--- a/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -47,12 +47,12 @@ internal class CActSelect曲リスト : CActivity {
 		get;
 		private set;
 	}
-	public CSongListNode rPrevSelectedSong {
+	public CSongListNode? rPrevSelectedSong {
 		get;
 		private set;
 	}
-	private CSongListNode _rNowSelectedSong;
-	public CSongListNode rCurrentlySelectedSong {
+	private CSongListNode? _rNowSelectedSong;
+	public CSongListNode? rCurrentlySelectedSong {
 		get {
 			return _rNowSelectedSong;
 		}
@@ -66,7 +66,7 @@ internal class CActSelect曲リスト : CActivity {
 
 	public void ResetSongIndex() {
 		nSelectSongIndex = 0;
-		this.rCurrentlySelectedSong = OpenTaiko.Songs管理.list曲ルート[nSelectSongIndex];
+		this.rCurrentlySelectedSong = OpenTaiko.Songs管理.list曲ルート.ElementAtOrDefault(nSelectSongIndex);
 	}
 
 	public int nスクロールバー相対y座標 {

--- a/OpenTaiko/src/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/OpenTaiko/src/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -145,7 +145,7 @@ internal class CStage曲読み込み : CStage {
 			} else {
 				OpenTaiko.Skin.sound曲読込開始音.tPlay();
 				this.nBGM再生開始時刻 = SoundManager.PlayTimer.NowTimeMs;
-				this.nBGMの総再生時間ms = OpenTaiko.Skin.sound曲読込開始音.n長さ_現在のサウンド;
+				this.nBGMの総再生時間ms = (long)Math.Ceiling(OpenTaiko.Skin.sound曲読込開始音.n長さ_現在のサウンド);
 			}
 			//this.actFI.tフェードイン開始();							// #27787 2012.3.10 yyagi 曲読み込み画面のフェードインの省略
 			base.ePhaseID = CStage.EPhase.Common_FADEIN;

--- a/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/ScriptBG.cs
@@ -111,9 +111,9 @@ class ScriptBGFunc {
 }
 class ScriptBG : IDisposable {
 	public Dictionary<string, CTexture> Textures = [];
-	public List<CTexture> TextureList = [];
-	public List<LuaSound> SoundList = [];
-	public List<LuaText> TextList = [];
+	public HashSet<LuaTexture> TextureList = [];
+	public HashSet<LuaSound> SoundList = [];
+	public HashSet<LuaText> TextList = [];
 
 	protected Lua? LuaScript;
 
@@ -172,31 +172,18 @@ class ScriptBG : IDisposable {
 		LuaScript = null;
 	}
 	public void Dispose() {
-		List<CTexture> texs = Textures.Values.ToList();
-		for (int i = 0; i < texs.Count; i++) {
-			var tex = texs[i];
-			OpenTaiko.tテクスチャの解放(ref tex);
-		}
-
-		for (int i = 0; i < TextureList.Count; i++) {
-			var luatex = TextureList[i];
-			OpenTaiko.tDisposeSafely(ref luatex);
-		}
-
-		for (int i = SoundList.Count - 1; i >= 0; i--) {
-			var sound = SoundList[i];
-			OpenTaiko.tDisposeSafely(ref sound);
-		}
-
-		for (int i = TextList.Count - 1; i >= 0; i--) {
-			var text = TextList[i];
-			OpenTaiko.tDisposeSafely(ref text);
-		}
-
+		foreach (var (key, tex) in this.Textures)
+			tex?.Dispose();
 		Textures.Clear();
-		TextureList.Clear();
-		SoundList.Clear();
-		TextList.Clear();
+
+		void freeDisposableList<T>(ICollection<T> list) where T : IDisposable? {
+			foreach (var disposable in list)
+				disposable?.Dispose();
+			list.Clear();
+		}
+		freeDisposableList(this.TextureList);
+		freeDisposableList(this.SoundList);
+		freeDisposableList(this.TextList);
 
 		LuaScript?.Dispose();
 


### PR DESCRIPTION
## Features

* feat: add "Sound" tab to ImGui debug panel for viewing/listening loaded skin sounds
* feat: show `CLuaScript` & Lua resource usage in ImGui debug tab

<img width="629" height="406" alt="OpenTaiko, ImGui debug window, Sounds tab" src="https://github.com/user-attachments/assets/62152956-2018-424d-a301-c2e2856cc060" />

## Fixes

* fix reloading song list with no songs caused crash
* fix resource leak when reloading skin's sounds
* fix non-BGM skin sounds were loaded twice and could be more
* fix switching sound devices muted some system sounds until reloading skin
* fix: use ceiled duration for sounds to prevent sub-ms truncation when looping
* fix freed textures had straying point and recounted in ImGui debug window
* fix Lua resource disposing lists grew infinitely