### PR TITLE
[0.6.1] fix wrong or missing and refactor CharaConfig.txt loading, remove player slot from CCharacter

### DIFF
--- a/OpenTaiko/CharaScript.lua
+++ b/OpenTaiko/CharaScript.lua
@@ -406,11 +406,6 @@ local function load_config()
 		chara_config.game_motion_gogostart_max = csarray_to_motiontable(ini_game_motion_gogostart_max)
 	end
 
-	local ini_game_motion_gogostart_max = chara_config_ini:GetIntArray("Game_Chara_Motion_GoGoStart_Max")
-	if ini_game_motion_gogostart_max.Length >= 1 then
-		chara_config.game_motion_gogostart_max = csarray_to_motiontable(ini_game_motion_gogostart_max)
-	end
-
 	local ini_game_motion_return = chara_config_ini:GetIntArray("Game_Chara_Motion_Return")
 	if ini_game_motion_return.Length >= 1 then
 		chara_config.game_motion_return = csarray_to_motiontable(ini_game_motion_return)
@@ -496,8 +491,8 @@ local function load_config()
 	chara_config.game_beat_clear_max = chara_config.game_beat_clear
 	chara_config.game_beat_clear_max = chara_config_ini:GetDouble("Game_Chara_Beat_ClearMax", chara_config.game_beat_clear_max)
 	chara_config.game_beat_gogo = chara_config_ini:GetDouble("Game_Chara_Beat_GoGo", chara_config.game_beat_gogo)
-	chara_config.game_beat_gogo_max = chara_config_ini:GetDouble("Game_Chara_Beat_GoGo", chara_config.game_beat_gogo)
 	chara_config.game_beat_gogo_max = chara_config.game_beat_gogo
+	chara_config.game_beat_gogo_max = chara_config_ini:GetDouble("Game_Chara_Beat_GoGoMax", chara_config.game_beat_gogo_max)
 	chara_config.game_beat_miss = chara_config_ini:GetDouble("Game_Chara_Beat_Miss", chara_config.game_beat_miss)
 	chara_config.game_beat_miss_down = chara_config_ini:GetDouble("Game_Chara_Beat_MissDown", chara_config.game_beat_miss_down)
 	chara_config.game_beat_10combo = chara_config_ini:GetDouble("Game_Chara_Beat_10Combo", chara_config.game_beat_10combo)

--- a/OpenTaiko/CharaScript.lua
+++ b/OpenTaiko/CharaScript.lua
@@ -35,173 +35,190 @@ local voice_files = {
 	[CHARACTER.VOICE_RESULT_DANGOLDPASS] = "Sounds/Result/DanGoldPass.ogg";
 }
 
-local animation_dirs = {
-	[CHARACTER.ANIM_GAME_NORMAL] = "Normal";
-	[CHARACTER.ANIM_GAME_CLEAR] = "Clear";
-	[CHARACTER.ANIM_GAME_MAX] = "Clear_Max";
-	[CHARACTER.ANIM_GAME_GOGO] = "GoGo";
-	[CHARACTER.ANIM_GAME_GOGO_MAX] = "GoGo_Max";
-	[CHARACTER.ANIM_GAME_MISS] = "Miss";
-	[CHARACTER.ANIM_GAME_MISS_DOWN] = "MissDown";
-	[CHARACTER.ANIM_GAME_10COMBO] = "10combo"; -- Title-cased in 0.6.0 TextureLoader
-	[CHARACTER.ANIM_GAME_10COMBO_MAX] = "10combo_Max"; -- Title-cased in 0.6.0 TextureLoader
-	[CHARACTER.ANIM_GAME_CLEARED] = "Cleared";
-	[CHARACTER.ANIM_GAME_FAILED] = "Failed";
-	[CHARACTER.ANIM_GAME_CLEAR_OUT] = "ClearOut";
-	[CHARACTER.ANIM_GAME_CLEAR_IN] = "Clearin"; -- Title-cased in 0.6.0 TextureLoader
-	[CHARACTER.ANIM_GAME_MAX_OUT] = "SoulOut";
-	[CHARACTER.ANIM_GAME_MAX_IN] = "Soulin"; -- Title-cased in 0.6.0 TextureLoader
-	[CHARACTER.ANIM_GAME_MISS_IN] = "MissIn";
-	[CHARACTER.ANIM_GAME_MISS_DOWN_IN] = "MissDownIn";
-	[CHARACTER.ANIM_GAME_RETURN] = "Return";
-	[CHARACTER.ANIM_GAME_GOGOSTART] = "GoGoStart";
-	[CHARACTER.ANIM_GAME_GOGOSTART_CLEAR] = "GoGoStart_Clear";
-	[CHARACTER.ANIM_GAME_GOGOSTART_MAX] = "GoGoStart_Max";
-	[CHARACTER.ANIM_GAME_BALLOON_BREAKING] = "Balloon_Breaking";
-	[CHARACTER.ANIM_GAME_BALLOON_BROKE] = "Balloon_Broke";
-	[CHARACTER.ANIM_GAME_BALLOON_MISS] = "Balloon_Miss";
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BREAKING] = "Kusudama_Breaking";
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BROKE] = "Kusudama_Broke";
-	[CHARACTER.ANIM_GAME_KUSUDAMA_MISS] = "Kusudama_Miss";
-	[CHARACTER.ANIM_GAME_KUSUDAMA_IDLE] = "Kusudama_Idle";
+local animations = {}
+local animation_defs = {}
+local function load_animation_defs(C --[[chara_config]], B --[[animation_builder]]) return {
+	[CHARACTER.ANIM_PREVIEW] = { builder = B.preview };
+	[CHARACTER.ANIM_RENDER] = { builder = B.render };
 
-	[CHARACTER.ANIM_GAME_TOWER_STANDING] = "Tower_Char/Standing";
-	[CHARACTER.ANIM_GAME_TOWER_STANDING_TIRED] = "Tower_Char/Standing_Tired";
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING] = "Tower_Char/Climbing";
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING_TIRED] = "Tower_Char/Climbing_Tired";
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING] = "Tower_Char/Running";
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING_TIRED] = "Tower_Char/Running_Tired";
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR] = "Tower_Char/Clear";
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR_TIRED] = "Tower_Char/Clear_Tired";
-	[CHARACTER.ANIM_GAME_TOWER_FAIL] = "Tower_Char/Fail";
+	[CHARACTER.ANIM_GAME_NORMAL] = { dir = "Normal", offset = C.game_offset, motion = C.game_motion_normal, beat = C.game_beat_normal, builder = B.animation };
+	[CHARACTER.ANIM_GAME_CLEAR] = { dir = "Clear", offset = C.game_offset, motion = C.game_motion_clear, beat = C.game_beat_clear, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MAX] = { dir = "Clear_Max", offset = C.game_offset, motion = C.game_motion_clear_max, beat = C.game_beat_clear_max, builder = B.animation };
+	[CHARACTER.ANIM_GAME_GOGO] = { dir = "GoGo", offset = C.game_offset, motion = C.game_motion_gogo, beat = C.game_beat_gogo, builder = B.animation };
+	[CHARACTER.ANIM_GAME_GOGO_MAX] = { dir = "GoGo_Max", offset = C.game_offset, motion = C.game_motion_gogo_max, beat = C.game_beat_gogo_max, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MISS] = { dir = "Miss", offset = C.game_offset, motion = C.game_motion_miss, beat = C.game_beat_miss, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MISS_DOWN] = { dir = "MissDown", offset = C.game_offset, motion = C.game_motion_miss_down, beat = C.game_beat_miss_down, builder = B.animation };
+	[CHARACTER.ANIM_GAME_10COMBO] = { dir = "10combo" --[[Title-cased in 0.6.0]], offset = C.game_offset, motion = C.game_motion_10combo, beat = C.game_beat_10combo, builder = B.animation };
+	[CHARACTER.ANIM_GAME_10COMBO_MAX] = { dir = "10combo_Max" --[[Title-cased in 0.6.0]], offset = C.game_offset, motion = C.game_motion_10combo_max, beat = C.game_beat_10combo_max, builder = B.animation };
+	[CHARACTER.ANIM_GAME_CLEARED] = { dir = "Cleared", offset = C.game_offset, motion = C.game_motion_cleared, beat = C.game_beat_cleared, builder = B.animation };
+	[CHARACTER.ANIM_GAME_FAILED] = { dir = "Failed", offset = C.game_offset, motion = C.game_motion_failed, beat = C.game_beat_failed, builder = B.animation };
+	[CHARACTER.ANIM_GAME_CLEAR_OUT] = { dir = "ClearOut", offset = C.game_offset, motion = C.game_motion_clearout, beat = C.game_beat_clearout, builder = B.animation };
+	[CHARACTER.ANIM_GAME_CLEAR_IN] = { dir = "Clearin" --[[Title-cased in 0.6.0]], offset = C.game_offset, motion = C.game_motion_clearin, beat = C.game_beat_clearin, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MAX_OUT] = { dir = "SoulOut", offset = C.game_offset, motion = C.game_motion_soulout, beat = C.game_beat_soulout, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MAX_IN] = { dir = "Soulin" --[[Title-cased in 0.6.0]], offset = C.game_offset, motion = C.game_motion_soulin, beat = C.game_beat_soulin, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MISS_IN] = { dir = "MissIn", offset = C.game_offset, motion = C.game_motion_missin, beat = C.game_beat_missin, builder = B.animation };
+	[CHARACTER.ANIM_GAME_MISS_DOWN_IN] = { dir = "MissDownIn", offset = C.game_offset, motion = C.game_motion_missdownin, beat = C.game_beat_missdownin, builder = B.animation };
+	[CHARACTER.ANIM_GAME_RETURN] = { dir = "Return", offset = C.game_offset, motion = C.game_motion_return, beat = C.game_beat_return, builder = B.animation };
+	[CHARACTER.ANIM_GAME_GOGOSTART] = { dir = "GoGoStart", offset = C.game_offset, motion = C.game_motion_gogostart, beat = C.game_beat_gogostart, builder = B.animation };
+	[CHARACTER.ANIM_GAME_GOGOSTART_CLEAR] = { dir = "GoGoStart_Clear", offset = C.game_offset, motion = C.game_motion_gogostart_clear, beat = C.game_beat_gogostart_clear, builder = B.animation };
+	[CHARACTER.ANIM_GAME_GOGOSTART_MAX] = { dir = "GoGoStart_Max", offset = C.game_offset, motion = C.game_motion_gogostart_max, beat = C.game_beat_gogostart_max, builder = B.animation };
+	[CHARACTER.ANIM_GAME_BALLOON_BREAKING] = { dir = "Balloon_Breaking", offset = C.game_balloon_offset, motion = C.game_motion_balloon_breaking, beat = C.game_beat_balloon_breaking, builder = B.animation };
+	[CHARACTER.ANIM_GAME_BALLOON_BROKE] = { dir = "Balloon_Broke", offset = C.game_balloon_offset, motion = C.game_motion_balloon_broke, beat = C.game_beat_balloon_broke, builder = B.animation };
+	[CHARACTER.ANIM_GAME_BALLOON_MISS] = { dir = "Balloon_Miss", offset = C.game_balloon_offset, motion = C.game_motion_balloon_miss, beat = C.game_beat_balloon_miss, builder = B.animation };
+	[CHARACTER.ANIM_GAME_KUSUDAMA_BREAKING] = { dir = "Kusudama_Breaking", offset = C.game_kusudama_offset, motion = C.game_motion_kusudama_breaking, beat = C.game_beat_kusudama_breaking, builder = B.animation };
+	[CHARACTER.ANIM_GAME_KUSUDAMA_BROKE] = { dir = "Kusudama_Broke", offset = C.game_kusudama_offset, motion = C.game_motion_kusudama_broke, beat = C.game_beat_kusudama_broke, builder = B.animation };
+	[CHARACTER.ANIM_GAME_KUSUDAMA_MISS] = { dir = "Kusudama_Miss", offset = C.game_kusudama_offset, motion = C.game_motion_kusudama_miss, beat = C.game_beat_kusudama_miss, builder = B.animation };
+	[CHARACTER.ANIM_GAME_KUSUDAMA_IDLE] = { dir = "Kusudama_Idle", offset = C.game_kusudama_offset, motion = C.game_motion_kusudama_idle, beat = C.game_beat_kusudama_idle, builder = B.animation };
 
-	[CHARACTER.ANIM_MENU_WAIT] = "Menu_Wait";
-	[CHARACTER.ANIM_MENU_START] = "Menu_Start";
-	[CHARACTER.ANIM_MENU_NORMAL] = "Menu_Loop";
-	[CHARACTER.ANIM_MENU_SELECT] = "Menu_Select";
-	[CHARACTER.ANIM_ENTRY_NORMAL] = "Title_Normal";
-	[CHARACTER.ANIM_ENTRY_JUMP] = "Title_Entry";
+	[CHARACTER.ANIM_GAME_TOWER_STANDING] = { dir = "Tower_Char/Standing", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_standing, beat = C.game_beat_tower_standing, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_STANDING_TIRED] = { dir = "Tower_Char/Standing_Tired", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_standing_tired, beat = C.game_beat_tower_standing_tired, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_CLIMBING] = { dir = "Tower_Char/Climbing", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_climbing, beat = C.game_beat_tower_climbing, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_CLIMBING_TIRED] = { dir = "Tower_Char/Climbing_Tired", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_climbing_tired, beat = C.game_beat_tower_climbing_tired, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_RUNNING] = { dir = "Tower_Char/Running", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_running, beat = C.game_beat_tower_running, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_RUNNING_TIRED] = { dir = "Tower_Char/Running_Tired", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_running_tired, beat = C.game_beat_tower_running_tired, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_CLEAR] = { dir = "Tower_Char/Clear", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_clear, beat = C.game_beat_tower_clear, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_CLEAR_TIRED] = { dir = "Tower_Char/Clear_Tired", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_clear_tired, beat = C.game_beat_tower_clear_tired, builder = B.animation };
+	[CHARACTER.ANIM_GAME_TOWER_FAIL] = { dir = "Tower_Char/Fail", offset = C.game_chara_tower_offset, motion = C.game_motion_tower_fail, beat = C.game_beat_tower_fail, builder = B.animation };
 
-	[CHARACTER.ANIM_RESULT_NORMAL] = "Result_Normal";
-	[CHARACTER.ANIM_RESULT_CLEAR] = "Result_Clear";
-	[CHARACTER.ANIM_RESULT_FAILED_IN] = "Result_Failed_In";
-	[CHARACTER.ANIM_RESULT_FAILED] = "Result_Failed";
-}
+	[CHARACTER.ANIM_MENU_WAIT] = { dir = "Menu_Wait", offset = C.menu_offset, motion = C.menu_motion_normal, beat = C.menu_beat_normal, builder = B.animation };
+	[CHARACTER.ANIM_MENU_START] = { dir = "Menu_Start", offset = C.menu_offset, motion = C.menu_motion_start, beat = C.menu_beat_start, builder = B.animation };
+	[CHARACTER.ANIM_MENU_NORMAL] = { dir = "Menu_Loop", offset = C.menu_offset, motion = C.menu_motion_normal, beat = C.menu_beat_normal, builder = B.animation };
+	[CHARACTER.ANIM_MENU_SELECT] = { dir = "Menu_Select", offset = C.menu_offset, motion = C.menu_motion_select, beat = C.menu_beat_select, builder = B.animation };
+	[CHARACTER.ANIM_ENTRY_NORMAL] = { dir = "Title_Normal", offset = C.menu_offset, motion = C.title_motion_normal, beat = C.title_beat_normal, builder = B.animation };
+	[CHARACTER.ANIM_ENTRY_JUMP] = { dir = "Title_Entry", offset = C.menu_offset, motion = C.title_motion_entry, beat = C.title_beat_entry, builder = B.animation };
 
-local chara_config = {
-	chara_version = "";
-	resolution = VECTOR2:CreateVector2(1280, 720);
-	legacy_mode = true;
-	heya_render_offset = VECTOR2:CreateVector2(0, 0);
-	menu_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_MENU; v1_scale = 1.0; };
-	menu_motion_normal = nil;
-	menu_motion_wait = nil;
-	menu_motion_start = nil;
-	menu_motion_select = nil;
-	menu_beat_normal = 2;
-	menu_beat_wait = 1;
-	menu_beat_start = 1;
-	menu_beat_select = 2;
+	[CHARACTER.ANIM_RESULT_NORMAL] = { dir = "Result_Normal", offset = C.result_offset, motion = C.result_motion_normal, beat = C.result_beat_normal, builder = B.animation };
+	[CHARACTER.ANIM_RESULT_CLEAR] = { dir = "Result_Clear", offset = C.result_offset, motion = C.result_motion_clear, beat = C.result_beat_clear, builder = B.animation };
+	[CHARACTER.ANIM_RESULT_FAILED_IN] = { dir = "Result_Failed_In", offset = C.result_offset, motion = C.result_motion_failed_in, beat = C.result_beat_failed_in, builder = B.animation };
+	[CHARACTER.ANIM_RESULT_FAILED] = { dir = "Result_Failed", offset = C.result_offset, motion = C.result_motion_failed, beat = C.result_beat_failed, builder = B.animation };
+} end
 
-	title_motion_normal = nil;
-	title_motion_entry = nil;
-	title_beat_normal = 1;
-	title_beat_entry = 1;
+local chara_config = {}
+local function load_chara_config_defs(L --[[chara_config_loader]]) return { -- need to be an ordered array for fallback dependencies
+	{ key = "chara_version", default = "", config = "Chara_Version", loader = L.string };
+	{ key = "resolution", default = VECTOR2:CreateVector2(1280, 720), config = "Chara_Resolution", loader = L.int_xy };
+	{ key = "legacy_mode", default = true, config = "Chara_LegacyMode", loader = L.bool };
+	{ key = "heya_render_offset", default = VECTOR2:CreateVector2(0, 0), config = "Heya_Chara_Render_Offset", loader = L.int_xy };
 
-	game_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME; v1_scale = 1.25 --[[1 / Game_Chara_Scale]]; };
-	game_ai_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_AI; v1_scale = 1.25 --[[0.58 / Game_Chara_Scale_AI]]; };
-	game_balloon_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_BALLOON; v1_scale = 1; };
-	game_kusudama_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_KUSUDAMA; v1_scale = 1; };
-	game_chara_tower_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_TOWER; v1_scale = 1; };
-	game_motion_normal = nil;
-	game_motion_clear = nil;
-	game_motion_clear_max = nil;
-	game_motion_gogo = nil;
-	game_motion_gogo_max = nil;
-	game_motion_miss = nil;
-	game_motion_miss_down = nil;
-	game_motion_10combo = nil;
-	game_motion_10combo_max = nil;
-	game_motion_cleared = nil;
-	game_motion_failed = nil;
-	game_motion_clearout = nil;
-	game_motion_clearin = nil;
-	game_motion_soulout = nil;
-	game_motion_soulin = nil;
-	game_motion_missin = nil;
-	game_motion_missdownin = nil;
-	game_motion_return = nil;
-	game_motion_gogostart = nil;
-	game_motion_gogostart_clear = nil;
-	game_motion_gogostart_max = nil;
-	game_motion_balloon_breaking = nil;
-	game_motion_balloon_broke = nil;
-	game_motion_balloon_miss = nil;
-	game_motion_kusudama_breaking = nil;
-	game_motion_kusudama_idle = nil;
-	game_motion_kusudama_broke = nil;
-	game_motion_kusudama_miss = nil;
+	{ key = "menu_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_MENU; v1_scale = 1.0; },
+		config = "Menu_Offset", loader = L.offset, v1_scale = "Menu_Chara_Scale" };
 
-	game_motion_tower_standing = nil;
-	game_motion_tower_standing_tired = nil;
-	game_motion_tower_climbing = nil;
-	game_motion_tower_climbing_tired = nil;
-	game_motion_tower_running = nil;
-	game_motion_tower_running_tired = nil;
-	game_motion_tower_clear = nil;
-	game_motion_tower_clear_tired = nil;
-	game_motion_tower_fail = nil;
+	{ key = "menu_motion_normal", default = nil, config = "Menu_Chara_Motion_Loop", loader = L.motion };
+	{ key = "menu_motion_wait", default = nil, config = "Menu_Chara_Motion_Wait", loader = L.motion };
+	{ key = "menu_motion_start", default = nil, config = "Menu_Chara_Motion_Start", loader = L.motion };
+	{ key = "menu_motion_select", default = nil, config = "Menu_Chara_Motion_Select", loader = L.motion };
+	{ key = "menu_beat_normal", default = 2, config = "Menu_Chara_Beat_Normal", loader = L.beat, duration = "Chara_Menu_Loop_AnimationDuration", ms_per_beat = 500.0 };
+	{ key = "menu_beat_wait", default = 1, config = "Menu_Chara_Beat_Wait", loader = L.beat, duration = "Chara_Menu_Wait_AnimationDuration", ms_per_beat = 500.0 };
+	{ key = "menu_beat_start", default = 1, config = "Menu_Chara_Beat_Start", loader = L.beat, duration = "Chara_Menu_Start_AnimationDuration", ms_per_beat = 500.0 };
+	{ key = "menu_beat_select", default = 2, config = "Menu_Chara_Beat_Select", loader = L.beat, duration = "Chara_Menu_Select_AnimationDuration", ms_per_beat = 500.0 };
 
-	game_beat_normal = 1;
-	game_beat_clear = 1;
-	game_beat_clear_max = 1;
-	game_beat_gogo = 1;
-	game_beat_gogo_max = 1;
-	game_beat_miss = 1;
-	game_beat_miss_down = 1;
-	game_beat_10combo = 1.5;
-	game_beat_10combo_max = 1.5;
-	game_beat_cleared = 1.5;
-	game_beat_failed = 1.5;
-	game_beat_clearout = 1.5;
-	game_beat_clearin = 1.5;
-	game_beat_soulout = 1.5;
-	game_beat_soulin = 1.5;
-	game_beat_missin = 1;
-	game_beat_missdownin = 1;
-	game_beat_return = 1.5;
-	game_beat_gogostart = 1.5;
-	game_beat_gogostart_clear = 1.5;
-	game_beat_gogostart_max = 1.5;
-	game_beat_balloon_breaking = 0.25;
-	game_beat_balloon_broke = 2.0;
-	game_beat_balloon_miss = 2.0;
-	game_beat_kusudama_breaking = 0.25;
-	game_beat_kusudama_idle = 1.0;
-	game_beat_kusudama_broke = 2.0;
-	game_beat_kusudama_miss = 2.0;
+	{ key = "title_motion_normal", default = nil, config = "Title_Chara_Motion_Normal", loader = L.motion };
+	{ key = "title_motion_entry", default = nil, config = "Title_Chara_Motion_Entry", loader = L.motion };
+	{ key = "title_beat_normal", default = 1, config = "Title_Chara_Beat_Normal", loader = L.beat, duration = "Chara_Normal_AnimationDuration" };
+	{ key = "title_beat_entry", default = 1, config = "Title_Chara_Beat_Entry", loader = L.beat, duration = "Chara_Entry_AnimationDuration" };
 
-	game_beat_tower_standing = 1.0;
-	game_beat_tower_standing_tired = 1.0;
-	game_beat_tower_climbing = 1.0;
-	game_beat_tower_climbing_tired = 1.0;
-	game_beat_tower_running = 1.0;
-	game_beat_tower_running_tired = 1.0;
-	game_beat_tower_clear = 1.0;
-	game_beat_tower_clear_tired = 1.0;
-	game_beat_tower_fail = 1.0;
+	{ key = "game_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME; v1_scale = 1.25 --[[1 / Game_Chara_Scale]]; },
+		config = "Game_Chara_Offset", loader = L.offset, x_P1 = "Game_Chara_X", y_P1 = "Game_Chara_Y" };
+	{ key = "game_ai_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_AI; v1_scale = 1.25 --[[0.58 / Game_Chara_Scale_AI]]; } };
+	{ key = "ai_positions_x", default = nil, config = "Game_Chara_X_AI", loader = L.ints };
+	{ key = "ai_positions_y", default = nil, config = "Game_Chara_Y_AI", loader = L.ints };
+	{ key = "game_balloon_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_BALLOON; v1_scale = 1; },
+		config = "Game_Chara_Balloon_Offset", loader = L.offset, x_P1 = "Game_Chara_Balloon_X", y_P1 = "Game_Chara_Balloon_Y" };
+	{ key = "game_kusudama_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_KUSUDAMA; v1_scale = 1; },
+		config = "Game_Chara_Kusudama_Offset", loader = L.offset, x_P1 = "Game_Chara_Kusudama_X", y_P1 = "Game_Chara_Kusudama_Y" };
+	{ key = "game_chara_tower_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_GAME_TOWER; v1_scale = 1; },
+		config = "Game_Chara_Tower_Offset", loader = L.offset };
 
+	{ key = "game_motion_normal", default = nil, config = "Game_Chara_Motion_Normal", loader = L.motion };
+	{ key = "game_motion_clear", default = nil, config = "Game_Chara_Motion_Clear", loader = L.motion };
+	{ key = "game_motion_clear_max", default = nil, config = "Game_Chara_Motion_Clear_Max", loader = L.motion, fallbacks = { "game_motion_clear" } };
+	{ key = "game_motion_gogo", default = nil, config = "Game_Chara_Motion_GoGo", loader = L.motion };
+	{ key = "game_motion_gogo_max", default = nil, config = "Game_Chara_Motion_GoGo_Max", loader = L.motion, fallbacks = { "game_motion_gogo" } };
+	{ key = "game_motion_miss", default = nil, config = "Game_Chara_Motion_Miss", loader = L.motion };
+	{ key = "game_motion_miss_down", default = nil, config = "Game_Chara_Motion_Miss_Down", loader = L.motion };
+	{ key = "game_motion_10combo", default = nil, config = "Game_Chara_Motion_10Combo", loader = L.motion };
+	{ key = "game_motion_10combo_max", default = nil, config = "Game_Chara_Motion_10Combo_Max", loader = L.motion };
+	{ key = "game_motion_cleared", default = nil, config = "Game_Chara_Motion_Cleared", loader = L.motion };
+	{ key = "game_motion_failed", default = nil, config = "Game_Chara_Motion_Failed", loader = L.motion };
+	{ key = "game_motion_clearout", default = nil, config = "Game_Chara_Motion_ClearOut", loader = L.motion };
+	{ key = "game_motion_clearin", default = nil, config = "Game_Chara_Motion_ClearIn", loader = L.motion };
+	{ key = "game_motion_soulout", default = nil, config = "Game_Chara_Motion_SoulOut", loader = L.motion };
+	{ key = "game_motion_soulin", default = nil, config = "Game_Chara_Motion_SoulIn", loader = L.motion };
+	{ key = "game_motion_missin", default = nil, config = "Game_Chara_Motion_MissIn", loader = L.motion };
+	{ key = "game_motion_missdownin", default = nil, config = "Game_Chara_Motion_MissDownIn", loader = L.motion };
+	{ key = "game_motion_return", default = nil, config = "Game_Chara_Motion_Return" };
+	{ key = "game_motion_gogostart", default = nil, config = "Game_Chara_Motion_GoGoStart", loader = L.motion };
+	{ key = "game_motion_gogostart_clear", default = nil, config = "Game_Chara_Motion_GoGoStart_Clear", loader = L.motion, fallbacks = { "game_motion_gogostart" } };
+	{ key = "game_motion_gogostart_max", default = nil, config = "Game_Chara_Motion_GoGoStart_Max", loader = L.motion, fallbacks = { "game_motion_gogostart" } };
+	{ key = "game_motion_balloon_breaking", default = nil, config = "Game_Chara_Motion_Balloon_Breaking", loader = L.motion };
+	{ key = "game_motion_balloon_broke", default = nil, config = "Game_Chara_Motion_Balloon_Broke", loader = L.motion };
+	{ key = "game_motion_balloon_miss", default = nil, config = "Game_Chara_Motion_Balloon_Miss", loader = L.motion };
+	{ key = "game_motion_kusudama_breaking", default = nil, config = "Game_Chara_Motion_Kusudama_Breaking", loader = L.motion };
+	{ key = "game_motion_kusudama_idle", default = nil, config = "Game_Chara_Motion_Kusudama_Idle", loader = L.motion };
+	{ key = "game_motion_kusudama_broke", default = nil, config = "Game_Chara_Motion_Kusudama_Broke", loader = L.motion };
+	{ key = "game_motion_kusudama_miss", default = nil, config = "Game_Chara_Motion_Kusudama_Miss", loader = L.motion };
 
-	result_offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_RESULT; v1_scale = 1; };
-	result_motion_normal = nil;
-	result_motion_clear = nil;
-	result_motion_failed_in = nil;
-	result_motion_failed = nil;
-	result_beat_normal = 1;
-	result_beat_clear = 1;
-	result_beat_failed_in = 1;
-	result_beat_failed = 1;
-}
+	{ key = "game_motion_tower_standing", default = nil, config = "Game_Chara_Motion_Tower_Standing", loader = L.motion };
+	{ key = "game_motion_tower_standing_tired", default = nil, config = "Game_Chara_Motion_Tower_Standing_Tired", loader = L.motion, fallbacks = { "game_motion_tower_standing" } };
+	{ key = "game_motion_tower_climbing", default = nil, config = "Game_Chara_Motion_Tower_Climbing", loader = L.motion };
+	{ key = "game_motion_tower_climbing_tired", default = nil, config = "Game_Chara_Motion_Tower_Climbing_Tired", loader = L.motion, fallbacks = { "game_motion_tower_climbing" } };
+	{ key = "game_motion_tower_running", default = nil };
+	{ key = "game_motion_tower_running_tired", default = nil };
+	{ key = "game_motion_tower_clear", default = nil, config = "Game_Chara_Motion_Tower_Clear", loader = L.motion };
+	{ key = "game_motion_tower_clear_tired", default = nil, config = "Game_Chara_Motion_Tower_Clear_Tired", loader = L.motion, fallbacks = { "game_motion_tower_clear" } };
+	{ key = "game_motion_tower_fail", default = nil };
+
+	{ key = "game_beat_normal", default = 1, config = "Game_Chara_Beat_Normal", loader = L.beat };
+	{ key = "game_beat_clear", default = 1, config = "Game_Chara_Beat_Clear", loader = L.beat };
+	{ key = "game_beat_clear_max", default = 1, config = "Game_Chara_Beat_ClearMax", loader = L.beat, fallbacks = { "game_beat_clear" } };
+	{ key = "game_beat_gogo", default = 1, config = "Game_Chara_Beat_GoGo", loader = L.beat };
+	{ key = "game_beat_gogo_max", default = 1, config = "Game_Chara_Beat_GoGoMax", loader = L.beat, fallbacks = { "game_beat_gogo" } };
+	{ key = "game_beat_miss", default = 1, config = "Game_Chara_Beat_Miss", loader = L.beat };
+	{ key = "game_beat_miss_down", default = 1, config = "Game_Chara_Beat_MissDown", loader = L.beat };
+	{ key = "game_beat_10combo", default = 1.5, config = "Game_Chara_Beat_10Combo", loader = L.beat };
+	{ key = "game_beat_10combo_max", default = 1.5, config = "Game_Chara_Beat_10ComboMax", loader = L.beat };
+	{ key = "game_beat_cleared", default = 1.5, config = "Game_Chara_Beat_Cleared", loader = L.beat };
+	{ key = "game_beat_failed", default = 1.5, config = "Game_Chara_Beat_Failed", loader = L.beat };
+	{ key = "game_beat_clearout", default = 1.5, config = "Game_Chara_Beat_ClearOut", loader = L.beat };
+	{ key = "game_beat_clearin", default = 1.5, config = "Game_Chara_Beat_ClearIn", loader = L.beat };
+	{ key = "game_beat_soulout", default = 1.5, config = "Game_Chara_Beat_SoulOut", loader = L.beat };
+	{ key = "game_beat_soulin", default = 1.5, config = "Game_Chara_Beat_SoulIn", loader = L.beat };
+	{ key = "game_beat_missin", default = 1, config = "Game_Chara_Beat_MissIn", loader = L.beat };
+	{ key = "game_beat_missdownin", default = 1, config = "Game_Chara_Beat_MissDownIn", loader = L.beat };
+	{ key = "game_beat_return", default = 1.5, config = "Game_Chara_Beat_Return", loader = L.beat };
+	{ key = "game_beat_gogostart", default = 1.5, config = "Game_Chara_Beat_GoGoStart", loader = L.beat };
+	{ key = "game_beat_gogostart_clear", default = 1.5, config = "Game_Chara_Beat_GoGoStartClear", loader = L.beat };
+	{ key = "game_beat_gogostart_max", default = 1.5, config = "Game_Chara_Beat_GoGoStartMax", loader = L.beat };
+	{ key = "game_beat_balloon_breaking", default = 0.25, config = "Game_Chara_Beat_Balloon_Breaking", loader = L.beat };
+	{ key = "game_beat_balloon_broke", default = 2.0, config = "Game_Chara_Beat_Balloon_Broke", loader = L.beat };
+	{ key = "game_beat_balloon_miss", default = 2.0, config = "Game_Chara_Beat_Balloon_Miss", loader = L.beat };
+	{ key = "game_beat_kusudama_breaking", default = 0.25, config = "Game_Chara_Beat_Kusudama_Breaking", loader = L.beat };
+	{ key = "game_beat_kusudama_idle", default = 1.0, config = "Game_Chara_Beat_Kusudama_Idle", loader = L.beat };
+	{ key = "game_beat_kusudama_broke", default = 2.0, config = "Game_Chara_Beat_Kusudama_Broke", loader = L.beat };
+	{ key = "game_beat_kusudama_miss", default = 2.0, config = "Game_Chara_Beat_Kusudama_Miss", loader = L.beat };
+
+	{ key = "game_beat_tower_standing", default = 1.0, config = "Game_Chara_Beat_Tower_Standing", loader = L.beat };
+	{ key = "game_beat_tower_standing_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Standing_Tired", loader = L.beat };
+	{ key = "game_beat_tower_climbing", default = 1.0, config = "Game_Chara_Beat_Tower_Climbing", loader = L.beat };
+	{ key = "game_beat_tower_climbing_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Climbing_Tired", loader = L.beat };
+	{ key = "game_beat_tower_running", default = 1.0 };
+	{ key = "game_beat_tower_running_tired", default = 1.0 };
+	{ key = "game_beat_tower_clear", default = 1.0, config = "Game_Chara_Beat_Tower_Clear", loader = L.beat };
+	{ key = "game_beat_tower_clear_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Clear_Tired", loader = L.beat };
+	{ key = "game_beat_tower_fail", default = 1.0, config = "Game_Chara_Beat_Tower_Fail", loader = L.beat };
+
+	{ key = "result_offset", default = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_RESULT; v1_scale = 1; },
+		config = "Result_Offset", loader = L.offset };
+
+	{ key = "result_motion_normal", default = nil, config = "Result_Chara_Motion_Normal", loader = L.motion };
+	{ key = "result_motion_clear", default = nil, config = "Result_Chara_Motion_Clear", loader = L.motion };
+	{ key = "result_motion_failed_in", default = nil, config = "Result_Chara_Motion_Failed_In", loader = L.motion };
+	{ key = "result_motion_failed", default = nil, config = "Result_Chara_Motion_Failed", loader = L.motion };
+	{ key = "result_beat_normal", default = 1, config = "Result_Chara_Beat_Normal", loader = L.beat, duration = "Chara_Result_Normal_AnimationDuration" };
+	{ key = "result_beat_clear", default = 1, config = "Result_Chara_Beat_Clear", loader = L.beat, duration = "Chara_Result_Clear_AnimationDuration" };
+	{ key = "result_beat_failed_in", default = 1, config = "Result_Chara_Beat_Failed_In", loader = L.beat, duration = "Chara_Result_Failed_In_AnimationDuration" };
+	{ key = "result_beat_failed", default = 1, config = "Result_Chara_Beat_Failed", loader = L.beat, duration = "Chara_Result_Failed_AnimationDuration" };
+} end
 
 local function csarray_to_motiontable(csarray)
 	local luatable = {}
@@ -211,565 +228,67 @@ local function csarray_to_motiontable(csarray)
 	return luatable
 end
 
+local chara_config_loader = {} -- (Def, Ini, ValueDefault)
+function chara_config_loader.bool(D, I, V) return I:GetBool(D.config, V) end
+function chara_config_loader.double(D, I, V) return I:GetDouble(D.config, V) end
+function chara_config_loader.string(D, I, V) return I:GetString(D.config, V) end
+function chara_config_loader.motion(D, I, V)
+	local array = I:GetIntArray(D.config)
+	return (array.Length >= 1) and csarray_to_motiontable(array) or V
+end
+function chara_config_loader.beat(D, I, V)
+	local R = V
+	if D.duration ~= nil then
+		ms_per_beat = D.ms_per_beat
+		if ms_per_beat == nil then ms_per_beat = 1000.0 end
+		R = I:GetDouble(D.duration, V * ms_per_beat) / ms_per_beat
+	end
+	return I:GetDouble(D.config, R)
+end
+function chara_config_loader.int_xy(D, I, V)
+	local array = I:GetIntArray(D.config)
+	return (array.Length == 2) and VECTOR2:CreateVector2(array[0], array[1]) or V
+end
+function chara_config_loader.ints(D, I, V)
+	local array = I:GetIntArray(D.config)
+	return (array.Length >= 1) and array or V
+end
+function chara_config_loader.int_P1(D, I, V)
+	local array = I:GetIntArray(D.config)
+	if array.Length >= 1 then return array[0] end
+	return V
+end
+function chara_config_loader.offset(D, I, V)
+	-- make a copy to keep the def table intact
+	local R = { pos = VECTOR2:CreateVector2(V.pos.X, V.pos.Y); mode = V.mode; v1_scale = V.v1_scale; }
+	R.pos = chara_config_loader.int_xy({ config = D.config }, I, R.pos)
+	if D.x_P1 ~= nil then R.pos.X = chara_config_loader.int_P1({ config = D.x_P1 }, I, R.pos.X) end
+	if D.y_P1 ~= nil then R.pos.Y = chara_config_loader.int_P1({ config = D.y_P1 }, I, R.pos.Y) end
+	if D.v1_scale ~= nil then R.v1_scale = I:GetDouble(D.v1_scale, R.v1_scale) end
+	return R
+end
+
 local function load_config()
+	local chara_config_defs = load_chara_config_defs(chara_config_loader)
 	local chara_config_ini = INILOADER:LoadIni("CharaConfig.txt")
-
-	chara_config.chara_version = chara_config_ini:GetString("Chara_Version", chara_config.chara_version)
-	chara_config.legacy_mode = chara_config_ini:GetBool("Chara_LegacyMode", chara_config.legacy_mode)
-
-	local ini_chara_resolution = chara_config_ini:GetIntArray("Chara_Resolution")
-	if ini_chara_resolution.Length == 2 then
-		chara_config.resolution = VECTOR2:CreateVector2(ini_chara_resolution[0], ini_chara_resolution[1])
+	for i, v in ipairs(chara_config_defs) do
+		-- query all fallback configs from the most falled back config
+		-- because there is no Lua API to detect whether the config is defined
+		local value = v.default
+		local fallbacks = v.fallbacks or {}
+		for i = #fallbacks, 1, -1 do
+			local fallback = chara_config[fallbacks[i]]
+			if fallback ~= nil then
+				value = fallback
+			end
+		end
+		if v.loader ~= nil then
+			value = v:loader(chara_config_ini, value)
+		end
+		chara_config[v.key] = value
 	end
-
-	local ini_heya_chara_render_offset = chara_config_ini:GetIntArray("Heya_Chara_Render_Offset")
-	if ini_heya_chara_render_offset.Length == 2 then
-		chara_config.heya_render_offset = VECTOR2:CreateVector2(ini_heya_chara_render_offset[0], ini_heya_chara_render_offset[1])
-	end
-
-	--Title+++++++++++++
-	local ini_title_motion_normal = chara_config_ini:GetIntArray("Title_Chara_Motion_Normal")
-	if ini_title_motion_normal.Length >= 1 then
-		chara_config.title_motion_normal = csarray_to_motiontable(ini_title_motion_normal)
-	end
-
-	local ini_title_motion_entry = chara_config_ini:GetIntArray("Title_Chara_Motion_Entry")
-	if ini_title_motion_entry.Length >= 1 then
-		chara_config.title_motion_entry = csarray_to_motiontable(ini_title_motion_entry)
-	end
-
-	chara_config.title_beat_normal = chara_config_ini:GetDouble("Chara_Normal_AnimationDuration", chara_config.title_beat_normal * 1000.0) / 1000.0
-	chara_config.title_beat_normal = chara_config_ini:GetDouble("Title_Chara_Beat_Normal", chara_config.title_beat_normal)
-
-	chara_config.title_beat_entry = chara_config_ini:GetDouble("Chara_Entry_AnimationDuration", chara_config.title_beat_entry * 1000.0) / 1000.0
-	chara_config.title_beat_entry = chara_config_ini:GetDouble("Title_Chara_Beat_Entry", chara_config.title_beat_entry)
-	--+++++++++++++
-
-	---Game+++++++++++++
-	local ini_game_offset = chara_config_ini:GetIntArray("Game_Chara_Offset")
-	if ini_game_offset.Length == 2 then
-		chara_config.game_offset.pos = VECTOR2:CreateVector2(ini_game_offset[0], ini_game_offset[1])
-	end
-
-	local ini_game_chara_x = chara_config_ini:GetIntArray("Game_Chara_X")
-	if ini_game_chara_x.Length >= 1 then
-		chara_config.game_offset.pos.X = ini_game_chara_x[0]
-	end
-
-	local ini_game_chara_y = chara_config_ini:GetIntArray("Game_Chara_Y")
-	if ini_game_chara_y.Length >= 1 then
-		chara_config.game_offset.pos.Y = ini_game_chara_y[0]
-	end
-
-	-- Per-player AI battle positions (Game_Chara_X_AI / Game_Chara_Y_AI).
-	-- When both are present, they override the skin's Game_Chara_AI_X/Y for this character.
-	local ini_ai_x = chara_config_ini:GetIntArray("Game_Chara_X_AI")
-	local ini_ai_y = chara_config_ini:GetIntArray("Game_Chara_Y_AI")
-	if ini_ai_x.Length >= 1 and ini_ai_y.Length >= 1 then
-		chara_config.ai_positions_x = ini_ai_x
-		chara_config.ai_positions_y = ini_ai_y
-	end
-
-	local ini_game_balloon_offset = chara_config_ini:GetIntArray("Game_Chara_Balloon_Offset")
-	if ini_game_balloon_offset.Length == 2 then
-		chara_config.game_balloon_offset.pos = VECTOR2:CreateVector2(ini_game_balloon_offset[0], ini_game_balloon_offset[1])
-	end
-
-	local ini_game_balloon_x = chara_config_ini:GetIntArray("Game_Chara_Balloon_X")
-	if ini_game_balloon_x.Length >= 1 then
-		chara_config.game_balloon_offset.pos.X = ini_game_balloon_x[0]
-	end
-
-	local ini_game_balloon_y = chara_config_ini:GetIntArray("Game_Chara_Balloon_Y")
-	if ini_game_balloon_y.Length >= 1 then
-		chara_config.game_balloon_offset.pos.Y = ini_game_balloon_y[0]
-	end
-
-	local ini_game_kusudama_offset = chara_config_ini:GetIntArray("Game_Chara_Kusudama_Offset")
-	if ini_game_kusudama_offset.Length == 2 then
-		chara_config.game_kusudama_offset.pos = VECTOR2:CreateVector2(ini_game_kusudama_offset[0], ini_game_kusudama_offset[1])
-	end
-
-	local ini_game_kusudama_x = chara_config_ini:GetIntArray("Game_Chara_Kusudama_X")
-	if ini_game_kusudama_x.Length >= 1 then
-		chara_config.game_kusudama_offset.pos.X = ini_game_kusudama_x[0]
-	end
-
-	local ini_game_kusudama_y = chara_config_ini:GetIntArray("Game_Chara_Kusudama_Y")
-	if ini_game_kusudama_y.Length >= 1 then
-		chara_config.game_kusudama_offset.pos.Y = ini_game_kusudama_y[0]
-	end
-
-
-
-	local ini_game_motion_normal = chara_config_ini:GetIntArray("Game_Chara_Motion_Normal")
-	if ini_game_motion_normal.Length >= 1 then
-		chara_config.game_motion_normal = csarray_to_motiontable(ini_game_motion_normal)
-	end
-
-	local ini_game_motion_clear = chara_config_ini:GetIntArray("Game_Chara_Motion_Clear")
-	if ini_game_motion_clear.Length >= 1 then
-		chara_config.game_motion_clear = csarray_to_motiontable(ini_game_motion_clear)
-		chara_config.game_motion_clear_max = chara_config.game_motion_clear
-	end
-
-	local ini_game_motion_clear_max = chara_config_ini:GetIntArray("Game_Chara_Motion_Clear_Max")
-	if ini_game_motion_clear_max.Length >= 1 then
-		chara_config.game_motion_clear_max = csarray_to_motiontable(ini_game_motion_clear_max)
-	end
-
-	local ini_game_motion_gogo = chara_config_ini:GetIntArray("Game_Chara_Motion_GoGo")
-	if ini_game_motion_gogo.Length >= 1 then
-		chara_config.game_motion_gogo = csarray_to_motiontable(ini_game_motion_gogo)
-		chara_config.game_motion_gogo_max = chara_config.game_motion_gogo
-	end
-
-	local ini_game_motion_gogo_max = chara_config_ini:GetIntArray("Game_Chara_Motion_GoGo_Max")
-	if ini_game_motion_gogo_max.Length >= 1 then
-		chara_config.game_motion_gogo_max = csarray_to_motiontable(ini_game_motion_gogo_max)
-	end
-
-	local ini_game_motion_miss = chara_config_ini:GetIntArray("Game_Chara_Motion_Miss")
-	if ini_game_motion_miss.Length >= 1 then
-		chara_config.game_motion_miss = csarray_to_motiontable(ini_game_motion_miss)
-	end
-
-	local ini_game_motion_miss_down = chara_config_ini:GetIntArray("Game_Chara_Motion_Miss_Down")
-	if ini_game_motion_miss_down.Length >= 1 then
-		chara_config.game_motion_miss_down = csarray_to_motiontable(ini_game_motion_miss_down)
-	end
-
-	local ini_game_motion_10combo = chara_config_ini:GetIntArray("Game_Chara_Motion_10Combo")
-	if ini_game_motion_10combo.Length >= 1 then
-		chara_config.game_motion_miss_10combo = csarray_to_motiontable(ini_game_motion_10combo)
-	end
-
-	local ini_game_motion_10combo_max = chara_config_ini:GetIntArray("Game_Chara_Motion_10Combo_Max")
-	if ini_game_motion_10combo_max.Length >= 1 then
-		chara_config.game_motion_10combo_max = csarray_to_motiontable(ini_game_motion_10combo_max)
-	end
-
-	local ini_game_motion_cleared = chara_config_ini:GetIntArray("Game_Chara_Motion_Cleared")
-	if ini_game_motion_cleared.Length >= 1 then
-		chara_config.game_motion_cleared = csarray_to_motiontable(ini_game_motion_cleared)
-	end
-
-	local ini_game_motion_failed = chara_config_ini:GetIntArray("Game_Chara_Motion_Failed")
-	if ini_game_motion_failed.Length >= 1 then
-		chara_config.game_motion_failed = csarray_to_motiontable(ini_game_motion_failed)
-	end
-
-	local ini_game_motion_clearout = chara_config_ini:GetIntArray("Game_Chara_Motion_ClearOut")
-	if ini_game_motion_clearout.Length >= 1 then
-		chara_config.game_motion_clearout = csarray_to_motiontable(ini_game_motion_clearout)
-	end
-
-	local ini_game_motion_clearin = chara_config_ini:GetIntArray("Game_Chara_Motion_ClearIn")
-	if ini_game_motion_clearin.Length >= 1 then
-		chara_config.game_motion_clearin = csarray_to_motiontable(ini_game_motion_clearin)
-	end
-
-	local ini_game_motion_soulout = chara_config_ini:GetIntArray("Game_Chara_Motion_SoulOut")
-	if ini_game_motion_soulout.Length >= 1 then
-		chara_config.game_motion_soulout = csarray_to_motiontable(ini_game_motion_soulout)
-	end
-
-	local ini_game_motion_soulin = chara_config_ini:GetIntArray("Game_Chara_Motion_SoulIn")
-	if ini_game_motion_soulin.Length >= 1 then
-		chara_config.game_motion_soulin = csarray_to_motiontable(ini_game_motion_soulin)
-	end
-
-	local ini_game_motion_missin = chara_config_ini:GetIntArray("Game_Chara_Motion_MissIn")
-	if ini_game_motion_missin.Length >= 1 then
-		chara_config.game_motion_missin = csarray_to_motiontable(ini_game_motion_missin)
-	end
-
-	local ini_game_motion_missdownin = chara_config_ini:GetIntArray("Game_Chara_Motion_MissDownIn")
-	if ini_game_motion_missdownin.Length >= 1 then
-		chara_config.game_motion_missdownin = csarray_to_motiontable(ini_game_motion_missdownin)
-	end
-
-	local ini_game_motion_gogostart = chara_config_ini:GetIntArray("Game_Chara_Motion_GoGoStart")
-	if ini_game_motion_gogostart.Length >= 1 then
-		chara_config.game_motion_gogostart = csarray_to_motiontable(ini_game_motion_gogostart)
-		chara_config.game_motion_gogostart_clear = chara_config.game_motion_gogostart
-		chara_config.game_motion_gogostart_max = chara_config.game_motion_gogostart
-	end
-
-	local ini_game_motion_gogostart_clear = chara_config_ini:GetIntArray("Game_Chara_Motion_GoGoStart_Clear")
-	if ini_game_motion_gogostart_clear.Length >= 1 then
-		chara_config.game_motion_gogostart_clear = csarray_to_motiontable(ini_game_motion_gogostart_clear)
-	end
-
-	local ini_game_motion_gogostart_max = chara_config_ini:GetIntArray("Game_Chara_Motion_GoGoStart_Max")
-	if ini_game_motion_gogostart_max.Length >= 1 then
-		chara_config.game_motion_gogostart_max = csarray_to_motiontable(ini_game_motion_gogostart_max)
-	end
-
-	local ini_game_motion_return = chara_config_ini:GetIntArray("Game_Chara_Motion_Return")
-	if ini_game_motion_return.Length >= 1 then
-		chara_config.game_motion_return = csarray_to_motiontable(ini_game_motion_return)
-	end
-
-	local ini_game_motion_balloon_breaking = chara_config_ini:GetIntArray("Game_Chara_Motion_Balloon_Breaking")
-	if ini_game_motion_balloon_breaking.Length >= 1 then
-		chara_config.game_motion_balloon_breaking = csarray_to_motiontable(ini_game_motion_balloon_breaking)
-	end
-
-	local ini_game_motion_balloon_broke = chara_config_ini:GetIntArray("Game_Chara_Motion_Balloon_Broke")
-	if ini_game_motion_balloon_broke.Length >= 1 then
-		chara_config.game_motion_balloon_broke = csarray_to_motiontable(ini_game_motion_balloon_broke)
-	end
-
-	local ini_game_motion_balloon_miss = chara_config_ini:GetIntArray("Game_Chara_Motion_Balloon_Miss")
-	if ini_game_motion_balloon_miss.Length >= 1 then
-		chara_config.game_motion_balloon_miss = csarray_to_motiontable(ini_game_motion_balloon_miss)
-	end
-
-	local ini_game_motion_kusudama_breaking = chara_config_ini:GetIntArray("Game_Chara_Motion_Kusudama_Breaking")
-	if ini_game_motion_kusudama_breaking.Length >= 1 then
-		chara_config.game_motion_kusudama_breaking = csarray_to_motiontable(ini_game_motion_kusudama_breaking)
-	end
-
-	local ini_game_motion_kusudama_idle = chara_config_ini:GetIntArray("Game_Chara_Motion_Kusudama_Idle")
-	if ini_game_motion_kusudama_idle.Length >= 1 then
-		chara_config.game_motion_kusudama_idle = csarray_to_motiontable(ini_game_motion_kusudama_idle)
-	end
-
-	local ini_game_motion_kusudama_broke = chara_config_ini:GetIntArray("Game_Chara_Motion_Kusudama_Broke")
-	if ini_game_motion_kusudama_broke.Length >= 1 then
-		chara_config.game_motion_kusudama_broke = csarray_to_motiontable(ini_game_motion_kusudama_broke)
-	end
-
-	local ini_game_motion_kusudama_miss = chara_config_ini:GetIntArray("Game_Chara_Motion_Kusudama_Miss")
-	if ini_game_motion_kusudama_miss.Length >= 1 then
-		chara_config.game_motion_kusudama_miss = csarray_to_motiontable(ini_game_motion_kusudama_miss)
-	end
-
-
-	local ini_game_chara_tower_offset = chara_config_ini:GetIntArray("Game_Chara_Tower_Offset")
-	if ini_game_chara_tower_offset.Length == 2 then
-		chara_config.game_chara_tower_offset.pos = VECTOR2:CreateVector2(ini_game_chara_tower_offset[0], ini_game_chara_tower_offset[1])
-	end
-
-	local ini_game_motion_tower_standing = chara_config_ini:GetIntArray("Game_Chara_Motion_Tower_Standing")
-	if ini_game_motion_tower_standing.Length >= 1 then
-		chara_config.game_motion_tower_standing = csarray_to_motiontable(ini_game_motion_tower_standing)
-		chara_config.game_motion_tower_standing_tired = chara_config.game_motion_tower_standing
-	end
-
-	local ini_game_motion_tower_standing_tired = chara_config_ini:GetIntArray("Game_Chara_Motion_Tower_Standing_Tired")
-	if ini_game_motion_tower_standing_tired.Length >= 1 then
-		chara_config.game_motion_tower_standing_tired = csarray_to_motiontable(ini_game_motion_tower_standing_tired)
-	end
-
-	local ini_game_motion_tower_climbing = chara_config_ini:GetIntArray("Game_Chara_Motion_Tower_Climbing")
-	if ini_game_motion_tower_climbing.Length >= 1 then
-		chara_config.game_motion_tower_climbing = csarray_to_motiontable(ini_game_motion_tower_climbing)
-		chara_config.game_motion_tower_climbing_tired = chara_config.game_motion_tower_climbing
-	end
-
-	local ini_game_motion_tower_climbing_tired = chara_config_ini:GetIntArray("Game_Chara_Motion_Tower_Climbing_Tired")
-	if ini_game_motion_tower_climbing_tired.Length >= 1 then
-		chara_config.game_motion_tower_climbing_tired = csarray_to_motiontable(ini_game_motion_tower_climbing_tired)
-	end
-
-	local ini_game_motion_tower_clear = chara_config_ini:GetIntArray("Game_Chara_Motion_Tower_Clear")
-	if ini_game_motion_tower_clear.Length >= 1 then
-		chara_config.game_motion_tower_clear = csarray_to_motiontable(ini_game_motion_tower_clear)
-		chara_config.game_motion_tower_clear_tired = chara_config.game_motion_tower_clear
-	end
-
-	local ini_game_motion_tower_clear_tired = chara_config_ini:GetIntArray("Game_Chara_Motion_Tower_Clear_Tired")
-	if ini_game_motion_tower_clear_tired.Length >= 1 then
-		chara_config.game_motion_tower_clear_tired = csarray_to_motiontable(ini_game_motion_tower_clear_tired)
-	end
-
-
-	chara_config.game_beat_normal = chara_config_ini:GetDouble("Game_Chara_Beat_Normal", chara_config.game_beat_normal)
-	chara_config.game_beat_clear = chara_config_ini:GetDouble("Game_Chara_Beat_Clear", chara_config.game_beat_clear)
-	chara_config.game_beat_clear_max = chara_config.game_beat_clear
-	chara_config.game_beat_clear_max = chara_config_ini:GetDouble("Game_Chara_Beat_ClearMax", chara_config.game_beat_clear_max)
-	chara_config.game_beat_gogo = chara_config_ini:GetDouble("Game_Chara_Beat_GoGo", chara_config.game_beat_gogo)
-	chara_config.game_beat_gogo_max = chara_config.game_beat_gogo
-	chara_config.game_beat_gogo_max = chara_config_ini:GetDouble("Game_Chara_Beat_GoGoMax", chara_config.game_beat_gogo_max)
-	chara_config.game_beat_miss = chara_config_ini:GetDouble("Game_Chara_Beat_Miss", chara_config.game_beat_miss)
-	chara_config.game_beat_miss_down = chara_config_ini:GetDouble("Game_Chara_Beat_MissDown", chara_config.game_beat_miss_down)
-	chara_config.game_beat_10combo = chara_config_ini:GetDouble("Game_Chara_Beat_10Combo", chara_config.game_beat_10combo)
-	chara_config.game_beat_10combo_max = chara_config_ini:GetDouble("Game_Chara_Beat_10ComboMax", chara_config.game_beat_10combo_max)
-	chara_config.game_beat_cleared = chara_config_ini:GetDouble("Game_Chara_Beat_Cleared", chara_config.game_beat_cleared)
-	chara_config.game_beat_failed = chara_config_ini:GetDouble("Game_Chara_Beat_Failed", chara_config.game_beat_failed)
-	chara_config.game_beat_clearout = chara_config_ini:GetDouble("Game_Chara_Beat_ClearOut", chara_config.game_beat_clearout)
-	chara_config.game_beat_clearin = chara_config_ini:GetDouble("Game_Chara_Beat_ClearIn", chara_config.game_beat_clearin)
-	chara_config.game_beat_soulout = chara_config_ini:GetDouble("Game_Chara_Beat_SoulOut", chara_config.game_beat_soulout)
-	chara_config.game_beat_soulin = chara_config_ini:GetDouble("Game_Chara_Beat_SoulIn", chara_config.game_beat_soulin)
-	chara_config.game_beat_missin = chara_config_ini:GetDouble("Game_Chara_Beat_MissIn", chara_config.game_beat_missin)
-	chara_config.game_beat_missdownin = chara_config_ini:GetDouble("Game_Chara_Beat_MissDownIn", chara_config.game_beat_missdownin)
-	chara_config.game_beat_return = chara_config_ini:GetDouble("Game_Chara_Beat_Return", chara_config.game_beat_return)
-	chara_config.game_beat_gogostart = chara_config_ini:GetDouble("Game_Chara_Beat_GoGoStart", chara_config.game_beat_gogostart)
-	chara_config.game_beat_gogostart_clear = chara_config_ini:GetDouble("Game_Chara_Beat_GoGoStartClear", chara_config.game_beat_gogostart_clear)
-	chara_config.game_beat_gogostart_max = chara_config_ini:GetDouble("Game_Chara_Beat_GoGoStartMax", chara_config.game_beat_gogostart_max)
-	chara_config.game_beat_balloon_breaking = chara_config_ini:GetDouble("Game_Chara_Beat_Balloon_Breaking", chara_config.game_beat_balloon_breaking)
-	chara_config.game_beat_balloon_broke = chara_config_ini:GetDouble("Game_Chara_Beat_Balloon_Broke", chara_config.game_beat_balloon_broke)
-	chara_config.game_beat_balloon_miss = chara_config_ini:GetDouble("Game_Chara_Beat_Balloon_Miss", chara_config.game_beat_balloon_miss)
-	chara_config.game_beat_kusudama_breaking = chara_config_ini:GetDouble("Game_Chara_Beat_Kusudama_Breaking", chara_config.game_beat_kusudama_breaking)
-	chara_config.game_beat_kusudama_idle = chara_config_ini:GetDouble("Game_Chara_Beat_Kusudama_Idle", chara_config.game_beat_kusudama_idle)
-	chara_config.game_beat_kusudama_broke = chara_config_ini:GetDouble("Game_Chara_Beat_Kusudama_Broke", chara_config.game_beat_kusudama_broke)
-	chara_config.game_beat_kusudama_miss = chara_config_ini:GetDouble("Game_Chara_Beat_Kusudama_Miss", chara_config.game_beat_kusudama_miss)
-
-	chara_config.game_beat_tower_standing = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Standing", chara_config.game_beat_tower_standing)
-	chara_config.game_beat_tower_standing_tired = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Standing_Tired", chara_config.game_beat_tower_standing_tired)
-	chara_config.game_beat_tower_climbing = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Climbing", chara_config.game_beat_tower_climbing)
-	chara_config.game_beat_tower_climbing_tired = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Climbing_Tired", chara_config.game_beat_tower_climbing_tired)
-	chara_config.game_beat_tower_fail = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Fail", chara_config.game_beat_tower_fail)
-	chara_config.game_beat_tower_clear = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Clear", chara_config.game_beat_tower_clear)
-	chara_config.game_beat_tower_clear_tired = chara_config_ini:GetDouble("Game_Chara_Beat_Tower_Clear_Tired", chara_config.game_beat_tower_clear_tired)
-	--+++++++++++++
-
-	---Menu+++++++++++++
-	local ini_menu_offset = chara_config_ini:GetIntArray("Menu_Offset")
-	if ini_menu_offset.Length == 2 then
-		chara_config.menu_offset.pos = VECTOR2:CreateVector2(ini_menu_offset[0], ini_menu_offset[1])
-	end
-
-	chara_config.menu_offset.v1_scale = chara_config_ini:GetDouble("Menu_Chara_Scale", chara_config.menu_offset.v1_scale)
-
-	local ini_menu_motion_normal = chara_config_ini:GetIntArray("Menu_Chara_Motion_Loop")
-	if ini_menu_motion_normal.Length >= 1 then
-		chara_config.menu_motion_normal = csarray_to_motiontable(ini_menu_motion_normal)
-	end
-
-	local ini_menu_motion_wait = chara_config_ini:GetIntArray("Menu_Chara_Motion_Wait")
-	if ini_menu_motion_wait.Length >= 1 then
-		chara_config.menu_motion_wait = csarray_to_motiontable(ini_menu_motion_wait)
-	end
-
-	local ini_menu_motion_start = chara_config_ini:GetIntArray("Menu_Chara_Motion_Start")
-	if ini_menu_motion_start.Length >= 1 then
-		chara_config.menu_motion_start = csarray_to_motiontable(ini_menu_motion_start)
-	end
-
-	local ini_menu_motion_select = chara_config_ini:GetIntArray("Menu_Chara_Motion_Select")
-	if ini_menu_motion_select.Length >= 1 then
-		chara_config.menu_motion_select = csarray_to_motiontable(ini_menu_motion_select)
-	end
-
-	chara_config.menu_beat_normal = chara_config_ini:GetDouble("Chara_Menu_Loop_AnimationDuration", chara_config.menu_beat_normal * 500.0) / 500.0
-	chara_config.menu_beat_normal = chara_config_ini:GetDouble("Menu_Chara_Beat_Normal", chara_config.menu_beat_normal)
-
-	chara_config.menu_beat_wait = chara_config_ini:GetDouble("Chara_Menu_Wait_AnimationDuration", chara_config.menu_beat_wait * 500.0) / 500.0
-	chara_config.menu_beat_wait = chara_config_ini:GetDouble("Menu_Chara_Beat_Wait", chara_config.menu_beat_wait)
-
-	chara_config.menu_beat_start = chara_config_ini:GetDouble("Chara_Menu_Start_AnimationDuration", chara_config.menu_beat_start * 500.0) / 500.0
-	chara_config.menu_beat_start = chara_config_ini:GetDouble("Menu_Chara_Beat_Start", chara_config.menu_beat_start)
-
-	chara_config.menu_beat_select = chara_config_ini:GetDouble("Chara_Menu_Select_AnimationDuration", chara_config.menu_beat_select * 500.0) / 500.0
-	chara_config.menu_beat_select = chara_config_ini:GetDouble("Menu_Chara_Beat_Select", chara_config.menu_beat_select)
-	--+++++++++++++
-
-	--Result+++++++++++++
-	local ini_result_offset = chara_config_ini:GetIntArray("Result_Offset")
-	if ini_result_offset.Length == 2 then
-		chara_config.result_offset.pos = VECTOR2:CreateVector2(ini_result_offset[0], ini_result_offset[1])
-	end
-
-	local ini_result_motion_normal = chara_config_ini:GetIntArray("Result_Chara_Motion_Normal")
-	if ini_result_motion_normal.Length >= 1 then
-		chara_config.result_motion_normal = csarray_to_motiontable(ini_result_motion_normal)
-	end
-
-	local ini_result_motion_clear = chara_config_ini:GetIntArray("Result_Chara_Motion_Clear")
-	if ini_result_motion_clear.Length >= 1 then
-		chara_config.result_motion_clear = csarray_to_motiontable(ini_result_motion_clear)
-	end
-
-	local ini_result_motion_failed_in = chara_config_ini:GetIntArray("Result_Chara_Motion_Failed_In")
-	if ini_result_motion_failed_in.Length >= 1 then
-		chara_config.result_motion_failed_in = csarray_to_motiontable(ini_result_motion_failed_in)
-	end
-
-	local ini_result_motion_failed = chara_config_ini:GetIntArray("Result_Chara_Motion_Failed")
-	if ini_result_motion_failed.Length >= 1 then
-		chara_config.result_motion_failed = csarray_to_motiontable(ini_result_motion_failed)
-	end
-
-	chara_config.result_beat_normal = chara_config_ini:GetDouble("Chara_Result_Normal_AnimationDuration", chara_config.result_beat_normal * 1000.0) / 1000.0
-	chara_config.result_beat_normal = chara_config_ini:GetDouble("Result_Chara_Beat_Normal", chara_config.result_beat_normal)
-
-	chara_config.result_beat_clear = chara_config_ini:GetDouble("Chara_Result_Clear_AnimationDuration", chara_config.result_beat_clear * 1000.0) / 1000.0
-	chara_config.result_beat_clear = chara_config_ini:GetDouble("Result_Chara_Beat_Clear", chara_config.result_beat_clear)
-
-	chara_config.result_beat_failed_in = chara_config_ini:GetDouble("Chara_Result_Failed_In_AnimationDuration", chara_config.result_beat_failed_in * 1000.0) / 1000.0
-	chara_config.result_beat_failed_in = chara_config_ini:GetDouble("Result_Chara_Beat_Failed_In", chara_config.result_beat_failed_in)
-
-	chara_config.result_beat_failed = chara_config_ini:GetDouble("Chara_Result_Failed_AnimationDuration", chara_config.result_beat_failed * 1000.0) / 1000.0
-	chara_config.result_beat_failed = chara_config_ini:GetDouble("Result_Chara_Beat_Failed", chara_config.result_beat_failed)
-	--+++++++++++++
 end
 load_config()
-
-
-local animation_offsets = {
-	[CHARACTER.ANIM_GAME_NORMAL] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_CLEAR] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MAX] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_GOGO] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_GOGO_MAX] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MISS] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MISS_DOWN] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_10COMBO] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_10COMBO_MAX] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_CLEARED] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_FAILED] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_CLEAR_OUT] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_CLEAR_IN] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MAX_OUT] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MAX_IN] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MISS_IN] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_MISS_DOWN_IN] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_RETURN] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_GOGOSTART] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_GOGOSTART_CLEAR] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_GOGOSTART_MAX] = chara_config.game_offset;
-	[CHARACTER.ANIM_GAME_BALLOON_BREAKING] = chara_config.game_balloon_offset;
-	[CHARACTER.ANIM_GAME_BALLOON_BROKE] = chara_config.game_balloon_offset;
-	[CHARACTER.ANIM_GAME_BALLOON_MISS] = chara_config.game_balloon_offset;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BREAKING] = chara_config.game_kusudama_offset;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BROKE] = chara_config.game_kusudama_offset;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_MISS] = chara_config.game_kusudama_offset;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_IDLE] = chara_config.game_kusudama_offset;
-
-	[CHARACTER.ANIM_GAME_TOWER_STANDING] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_STANDING_TIRED] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING_TIRED] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING_TIRED] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR_TIRED] = chara_config.game_chara_tower_offset;
-	[CHARACTER.ANIM_GAME_TOWER_FAIL] = chara_config.game_chara_tower_offset;
-
-	[CHARACTER.ANIM_MENU_WAIT] = chara_config.menu_offset;
-	[CHARACTER.ANIM_MENU_START] = chara_config.menu_offset;
-	[CHARACTER.ANIM_MENU_NORMAL] = chara_config.menu_offset;
-	[CHARACTER.ANIM_MENU_SELECT] = chara_config.menu_offset;
-	[CHARACTER.ANIM_ENTRY_NORMAL] = chara_config.menu_offset;
-	[CHARACTER.ANIM_ENTRY_JUMP] = chara_config.menu_offset;
-
-	[CHARACTER.ANIM_RESULT_NORMAL] = chara_config.result_offset;
-	[CHARACTER.ANIM_RESULT_CLEAR] = chara_config.result_offset;
-	[CHARACTER.ANIM_RESULT_FAILED_IN] = chara_config.result_offset;
-	[CHARACTER.ANIM_RESULT_FAILED] = chara_config.result_offset;
-}
-
-local animation_motions = {
-	[CHARACTER.ANIM_GAME_NORMAL] = chara_config.game_motion_normal;
-	[CHARACTER.ANIM_GAME_CLEAR] = chara_config.game_motion_clear;
-	[CHARACTER.ANIM_GAME_MAX] = chara_config.game_motion_clear_max;
-	[CHARACTER.ANIM_GAME_GOGO] = chara_config.game_motion_gogo;
-	[CHARACTER.ANIM_GAME_GOGO_MAX] = chara_config.game_motion_gogo_max;
-	[CHARACTER.ANIM_GAME_MISS] = chara_config.game_motion_miss;
-	[CHARACTER.ANIM_GAME_MISS_DOWN] = chara_config.game_motion_miss_down;
-	[CHARACTER.ANIM_GAME_10COMBO] = chara_config.game_motion_10combo;
-	[CHARACTER.ANIM_GAME_10COMBO_MAX] = chara_config.game_motion_10combo_max;
-	[CHARACTER.ANIM_GAME_CLEARED] = chara_config.game_motion_cleared;
-	[CHARACTER.ANIM_GAME_FAILED] = chara_config.game_motion_failed;
-	[CHARACTER.ANIM_GAME_CLEAR_OUT] = chara_config.game_motion_clearout;
-	[CHARACTER.ANIM_GAME_CLEAR_IN] = chara_config.game_motion_clearin;
-	[CHARACTER.ANIM_GAME_MAX_OUT] = chara_config.game_motion_soulout;
-	[CHARACTER.ANIM_GAME_MAX_IN] = chara_config.game_motion_soulin;
-	[CHARACTER.ANIM_GAME_MISS_IN] = chara_config.game_motion_missin;
-	[CHARACTER.ANIM_GAME_MISS_DOWN_IN] = chara_config.game_motion_missdownin;
-	[CHARACTER.ANIM_GAME_RETURN] = chara_config.game_motion_return;
-	[CHARACTER.ANIM_GAME_GOGOSTART] = chara_config.game_motion_gogostart;
-	[CHARACTER.ANIM_GAME_GOGOSTART_CLEAR] = chara_config.game_motion_gogostart_clear;
-	[CHARACTER.ANIM_GAME_GOGOSTART_MAX] = chara_config.game_motion_gogostart_max;
-	[CHARACTER.ANIM_GAME_BALLOON_BREAKING] = chara_config.game_motion_balloon_breaking;
-	[CHARACTER.ANIM_GAME_BALLOON_BROKE] = chara_config.game_motion_balloon_broke;
-	[CHARACTER.ANIM_GAME_BALLOON_MISS] = chara_config.game_motion_balloon_miss;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BREAKING] = chara_config.game_motion_kusudama_breaking;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BROKE] = chara_config.game_motion_kusudama_broke;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_MISS] = chara_config.game_motion_kusudama_miss;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_IDLE] = chara_config.game_motion_kusudama_idle;
-
-	[CHARACTER.ANIM_GAME_TOWER_STANDING] = chara_config.game_motion_tower_standing;
-	[CHARACTER.ANIM_GAME_TOWER_STANDING_TIRED] = chara_config.game_motion_tower_standing_tired;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING] = chara_config.game_motion_tower_climbing;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING_TIRED] = chara_config.game_motion_tower_climbing_tired;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING] = chara_config.game_motion_tower_running;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING_TIRED] = chara_config.game_motion_tower_running_tired;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR] = chara_config.game_motion_tower_clear;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR_TIRED] = chara_config.game_motion_tower_clear_tired;
-	[CHARACTER.ANIM_GAME_TOWER_FAIL] = chara_config.game_motion_tower_fail;
-
-	[CHARACTER.ANIM_MENU_WAIT] = chara_config.menu_motion_normal;
-	[CHARACTER.ANIM_MENU_START] = chara_config.menu_motion_start;
-	[CHARACTER.ANIM_MENU_NORMAL] = chara_config.menu_motion_normal;
-	[CHARACTER.ANIM_MENU_SELECT] = chara_config.menu_motion_select;
-	[CHARACTER.ANIM_ENTRY_NORMAL] = chara_config.title_motion_normal;
-	[CHARACTER.ANIM_ENTRY_JUMP] = chara_config.title_motion_entry;
-
-	[CHARACTER.ANIM_RESULT_NORMAL] = chara_config.result_motion_normal;
-	[CHARACTER.ANIM_RESULT_CLEAR] = chara_config.result_motion_clear;
-	[CHARACTER.ANIM_RESULT_FAILED_IN] = chara_config.result_motion_failed_in;
-	[CHARACTER.ANIM_RESULT_FAILED] = chara_config.result_motion_failed;
-}
-
-local animation_beats = {
-	[CHARACTER.ANIM_GAME_NORMAL] = chara_config.game_beat_normal;
-	[CHARACTER.ANIM_GAME_CLEAR] = chara_config.game_beat_clear;
-	[CHARACTER.ANIM_GAME_MAX] = chara_config.game_beat_clear_max;
-	[CHARACTER.ANIM_GAME_GOGO] = chara_config.game_beat_gogo;
-	[CHARACTER.ANIM_GAME_GOGO_MAX] = chara_config.game_beat_gogo_max;
-	[CHARACTER.ANIM_GAME_MISS] = chara_config.game_beat_miss;
-	[CHARACTER.ANIM_GAME_MISS_DOWN] = chara_config.game_beat_miss_down;
-	[CHARACTER.ANIM_GAME_10COMBO] = chara_config.game_beat_10combo;
-	[CHARACTER.ANIM_GAME_10COMBO_MAX] = chara_config.game_beat_10combo_max;
-	[CHARACTER.ANIM_GAME_CLEARED] = chara_config.game_beat_cleared;
-	[CHARACTER.ANIM_GAME_FAILED] = chara_config.game_beat_failed;
-	[CHARACTER.ANIM_GAME_CLEAR_OUT] = chara_config.game_beat_clearout;
-	[CHARACTER.ANIM_GAME_CLEAR_IN] = chara_config.game_beat_clearin;
-	[CHARACTER.ANIM_GAME_MAX_OUT] = chara_config.game_beat_soulout;
-	[CHARACTER.ANIM_GAME_MAX_IN] = chara_config.game_beat_soulin;
-	[CHARACTER.ANIM_GAME_MISS_IN] = chara_config.game_beat_missin;
-	[CHARACTER.ANIM_GAME_MISS_DOWN_IN] = chara_config.game_beat_missdownin;
-	[CHARACTER.ANIM_GAME_RETURN] = chara_config.game_beat_return;
-	[CHARACTER.ANIM_GAME_GOGOSTART] = chara_config.game_beat_gogostart;
-	[CHARACTER.ANIM_GAME_GOGOSTART_CLEAR] = chara_config.game_beat_gogostart_clear;
-	[CHARACTER.ANIM_GAME_GOGOSTART_MAX] = chara_config.game_beat_gogostart_max;
-	[CHARACTER.ANIM_GAME_BALLOON_BREAKING] = chara_config.game_beat_balloon_breaking;
-	[CHARACTER.ANIM_GAME_BALLOON_BROKE] = chara_config.game_beat_balloon_broke;
-	[CHARACTER.ANIM_GAME_BALLOON_MISS] = chara_config.game_beat_balloon_miss;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BREAKING] = chara_config.game_beat_kusudama_breaking;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BROKE] = chara_config.game_beat_kusudama_broke;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_MISS] = chara_config.game_beat_kusudama_miss;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_IDLE] = chara_config.game_beat_kusudama_idle;
-
-	[CHARACTER.ANIM_GAME_TOWER_STANDING] = chara_config.game_beat_tower_standing;
-	[CHARACTER.ANIM_GAME_TOWER_STANDING_TIRED] = chara_config.game_beat_tower_standing_tired;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING] = chara_config.game_beat_tower_climbing;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING_TIRED] = chara_config.game_beat_tower_climbing_tired;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING] = chara_config.game_beat_tower_running;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING_TIRED] = chara_config.game_beat_tower_running_tired;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR] = chara_config.game_beat_tower_clear;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR_TIRED] = chara_config.game_beat_tower_clear_tired;
-	[CHARACTER.ANIM_GAME_TOWER_FAIL] = chara_config.game_beat_tower_fail;
-
-	[CHARACTER.ANIM_MENU_WAIT] = chara_config.menu_beat_normal;
-	[CHARACTER.ANIM_MENU_START] = chara_config.menu_beat_start;
-	[CHARACTER.ANIM_MENU_NORMAL] = chara_config.menu_beat_normal;
-	[CHARACTER.ANIM_MENU_SELECT] = chara_config.menu_beat_select;
-	[CHARACTER.ANIM_ENTRY_NORMAL] = chara_config.title_beat_normal;
-	[CHARACTER.ANIM_ENTRY_JUMP] = chara_config.title_beat_entry;
-
-	[CHARACTER.ANIM_RESULT_NORMAL] = chara_config.result_beat_normal;
-	[CHARACTER.ANIM_RESULT_CLEAR] = chara_config.result_beat_clear;
-	[CHARACTER.ANIM_RESULT_FAILED_IN] = chara_config.result_beat_failed_in;
-	[CHARACTER.ANIM_RESULT_FAILED] = chara_config.result_beat_failed;
-}
-
-
-local available_animations = {}
 
 local AnimationData = {
 	new = function()
@@ -789,8 +308,6 @@ local AnimationData = {
 		return obj
 	end;
 }
-
-local animationdata_array = {}
 
 -- flip is negative scale and flipping anchor point
 local function flip_anchor(anchor, flipX, flipY)
@@ -812,24 +329,26 @@ local function flip_anchor(anchor, flipX, flipY)
 	return anchor
 end
 
-local function create_animation(animationType)
-	local dir = animation_dirs[animationType]
+local animation_builder = {}
+
+function animation_builder.animation(animation_def)
+	local dir = animation_def.dir
 	if dir == nil then
 		return nil
 	end
 
 
-	local motion = animation_motions[animationType]
-	local beat = animation_beats[animationType]
+	local motion = animation_def.motion
+	local beat = animation_def.beat
 	if beat == nil then
 		beat = 1
 	end
-	local offset = animation_offsets[animationType]
+	local offset = animation_def.offset
 	if offset == nil then
 		offset = { pos = VECTOR2:CreateVector2(0, 0); mode = OFFSET_MODE_MENU; v1_scale = 1.0; }
 	end
 
-	local dir_name = animation_dirs[animationType]
+	local dir_name = animation_def.dir
 
 	local animation_data = nil
 	if STORAGE:DirectoryExists(dir_name) then
@@ -975,7 +494,7 @@ local function create_animation(animationType)
 	return animation_data
 end
 
-local function create_preview()
+function animation_builder.preview()
 	animation_data = AnimationData.new()
 
 	local preview = nil
@@ -1015,7 +534,7 @@ local function create_preview()
 	return animation_data
 end
 
-local function create_render()
+function animation_builder.render()
 	animation_data = AnimationData.new()
 	if STORAGE:FileExists("Render.png") then
 		animation_data.render = TEXTURE:CreateTexture("Render.png")
@@ -1062,61 +581,9 @@ local function create_render()
 	return animation_data
 end
 
-local animation_builders = {
-	[CHARACTER.ANIM_PREVIEW] = create_preview;
-	[CHARACTER.ANIM_RENDER] = create_render;
+animation_defs = load_animation_defs(chara_config, animation_builder)
 
-	[CHARACTER.ANIM_GAME_NORMAL] = create_animation;
-	[CHARACTER.ANIM_GAME_CLEAR] = create_animation;
-	[CHARACTER.ANIM_GAME_MAX] = create_animation;
-	[CHARACTER.ANIM_GAME_GOGO] = create_animation;
-	[CHARACTER.ANIM_GAME_GOGO_MAX] = create_animation;
-	[CHARACTER.ANIM_GAME_MISS] = create_animation;
-	[CHARACTER.ANIM_GAME_MISS_DOWN] = create_animation;
-	[CHARACTER.ANIM_GAME_10COMBO] = create_animation;
-	[CHARACTER.ANIM_GAME_10COMBO_MAX] = create_animation;
-	[CHARACTER.ANIM_GAME_CLEARED] = create_animation;
-	[CHARACTER.ANIM_GAME_FAILED] = create_animation;
-	[CHARACTER.ANIM_GAME_CLEAR_OUT] = create_animation;
-	[CHARACTER.ANIM_GAME_CLEAR_IN] = create_animation;
-	[CHARACTER.ANIM_GAME_MAX_OUT] = create_animation;
-	[CHARACTER.ANIM_GAME_MAX_IN] = create_animation;
-	[CHARACTER.ANIM_GAME_MISS_IN] = create_animation;
-	[CHARACTER.ANIM_GAME_MISS_DOWN_IN] = create_animation;
-	[CHARACTER.ANIM_GAME_RETURN] = create_animation;
-	[CHARACTER.ANIM_GAME_GOGOSTART] = create_animation;
-	[CHARACTER.ANIM_GAME_GOGOSTART_CLEAR] = create_animation;
-	[CHARACTER.ANIM_GAME_GOGOSTART_MAX] = create_animation;
-	[CHARACTER.ANIM_GAME_BALLOON_BREAKING] = create_animation;
-	[CHARACTER.ANIM_GAME_BALLOON_BROKE] = create_animation;
-	[CHARACTER.ANIM_GAME_BALLOON_MISS] = create_animation;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BREAKING] = create_animation;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_BROKE] = create_animation;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_MISS] = create_animation;
-	[CHARACTER.ANIM_GAME_KUSUDAMA_IDLE] = create_animation;
-
-	[CHARACTER.ANIM_GAME_TOWER_STANDING] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_STANDING_TIRED] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_CLIMBING_TIRED] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_RUNNING_TIRED] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_CLEAR_TIRED] = create_animation;
-	[CHARACTER.ANIM_GAME_TOWER_FAIL] = create_animation;
-
-	[CHARACTER.ANIM_MENU_WAIT] = create_animation;
-	[CHARACTER.ANIM_MENU_START] = create_animation;
-	[CHARACTER.ANIM_MENU_NORMAL] = create_animation;
-	[CHARACTER.ANIM_MENU_SELECT] = create_animation;
-	[CHARACTER.ANIM_ENTRY_NORMAL] = create_animation;
-	[CHARACTER.ANIM_ENTRY_JUMP] = create_animation;
-
-	[CHARACTER.ANIM_RESULT_NORMAL] = create_animation;
-	[CHARACTER.ANIM_RESULT_CLEAR] = create_animation;
-	[CHARACTER.ANIM_RESULT_FAILED_IN] = create_animation;
-	[CHARACTER.ANIM_RESULT_FAILED] = create_animation;
-}
+local available_animations = {}
 
 function availableAnimation(animationType)
 	local flag = available_animations[animationType]
@@ -1128,15 +595,15 @@ function availableAnimation(animationType)
 end
 
 function loadAnimation(animationType)
-	animationdata_array[animationType] = animation_builders[animationType](animationType)
+	animations[animationType] = animation_defs[animationType]:builder()
 
-	if animationdata_array[animationType] ~= nil then
+	if animations[animationType] ~= nil then
 		available_animations[animationType] = true
 	end
 end
 
 function disposeAnimation(animationType)
-	local animation_data = animationdata_array[animationType]
+	local animation_data = animations[animationType]
 	if animation_data ~= nil then
 		animation_data:dispose()
 	end
@@ -1145,14 +612,14 @@ function disposeAnimation(animationType)
 end
 
 function setAnimationDuration(animationType, duration)
-	local animation_data = animationdata_array[animationType]
+	local animation_data = animations[animationType]
 	if animation_data ~= nil then
 		animation_data.duration = duration
 	end
 end
 
 function resetAnimationCounter(animationType)
-	local animation_data = animationdata_array[animationType]
+	local animation_data = animations[animationType]
 	if animation_data ~= nil then
 		animation_data.value = 0
 	end
@@ -1183,7 +650,7 @@ function update(delta, animationType, looping)
 		return false
 	end
 
-	local animation = animationdata_array[animationType]
+	local animation = animations[animationType]
 	if animation ~= nil then
 		return animation:update(delta, looping)
 	else
@@ -1199,11 +666,11 @@ function draw(animationType, x, y, scaleX, scaleY, opacity, color, contextType, 
 		return
 	end
 
-	local animation = animationdata_array[animationType]
+	local animation = animations[animationType]
 	if animation ~= nil then
 		local overrideOffset = nil
 		if contextType ~= nil and contextType ~= animationType then
-			overrideOffset = animation_offsets[contextType]
+			overrideOffset = animation_defs[contextType].offset
 		end
 		if gradientMap ~= nil then GRADIENT:SetActive(gradientMap) end
 		animation:draw(x, y, scaleX, scaleY, opacity, color, overrideOffset, anchor, clip_w, clip_h, clip_x, clip_y, rotation, blendMode, wrapMode, player_count, ai_battle_mode)
@@ -1217,7 +684,7 @@ function getDrawSize(animationType)
 	if not availableAnimation(animationType) then
 		return 0, 0
 	end
-	local animation = animationdata_array[animationType]
+	local animation = animations[animationType]
 	if animation == nil then return 0, 0 end
 
 	local theme_resolution = THEME:GetResolution()

--- a/OpenTaiko/CharaScript.lua
+++ b/OpenTaiko/CharaScript.lua
@@ -162,11 +162,11 @@ local function load_chara_config_defs(L --[[chara_config_loader]]) return { -- n
 	{ key = "game_motion_tower_standing_tired", default = nil, config = "Game_Chara_Motion_Tower_Standing_Tired", loader = L.motion, fallbacks = { "game_motion_tower_standing" } };
 	{ key = "game_motion_tower_climbing", default = nil, config = "Game_Chara_Motion_Tower_Climbing", loader = L.motion };
 	{ key = "game_motion_tower_climbing_tired", default = nil, config = "Game_Chara_Motion_Tower_Climbing_Tired", loader = L.motion, fallbacks = { "game_motion_tower_climbing" } };
-	{ key = "game_motion_tower_running", default = nil };
-	{ key = "game_motion_tower_running_tired", default = nil };
+	{ key = "game_motion_tower_running", default = nil, config = "Game_Chara_Motion_Tower_Running", loader = L.motion };
+	{ key = "game_motion_tower_running_tired", default = nil, config = "Game_Chara_Motion_Tower_Running_Tired", loader = L.motion, fallbacks = { "game_motion_tower_running" } };
 	{ key = "game_motion_tower_clear", default = nil, config = "Game_Chara_Motion_Tower_Clear", loader = L.motion };
 	{ key = "game_motion_tower_clear_tired", default = nil, config = "Game_Chara_Motion_Tower_Clear_Tired", loader = L.motion, fallbacks = { "game_motion_tower_clear" } };
-	{ key = "game_motion_tower_fail", default = nil };
+	{ key = "game_motion_tower_fail", default = nil, config = "Game_Chara_Motion_Tower_Fail", loader = L.motion };
 
 	{ key = "game_beat_normal", default = 1, config = "Game_Chara_Beat_Normal", loader = L.beat };
 	{ key = "game_beat_clear", default = 1, config = "Game_Chara_Beat_Clear", loader = L.beat };
@@ -201,8 +201,8 @@ local function load_chara_config_defs(L --[[chara_config_loader]]) return { -- n
 	{ key = "game_beat_tower_standing_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Standing_Tired", loader = L.beat };
 	{ key = "game_beat_tower_climbing", default = 1.0, config = "Game_Chara_Beat_Tower_Climbing", loader = L.beat };
 	{ key = "game_beat_tower_climbing_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Climbing_Tired", loader = L.beat };
-	{ key = "game_beat_tower_running", default = 1.0 };
-	{ key = "game_beat_tower_running_tired", default = 1.0 };
+	{ key = "game_beat_tower_running", default = 1.0, config = "Game_Chara_Beat_Tower_Running", loader = L.beat };
+	{ key = "game_beat_tower_running_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Running_Tired", loader = L.beat };
 	{ key = "game_beat_tower_clear", default = 1.0, config = "Game_Chara_Beat_Tower_Clear", loader = L.beat };
 	{ key = "game_beat_tower_clear_tired", default = 1.0, config = "Game_Chara_Beat_Tower_Clear_Tired", loader = L.beat };
 	{ key = "game_beat_tower_fail", default = 1.0, config = "Game_Chara_Beat_Tower_Fail", loader = L.beat };

--- a/OpenTaiko/CharaScript.lua
+++ b/OpenTaiko/CharaScript.lua
@@ -583,23 +583,12 @@ end
 
 animation_defs = load_animation_defs(chara_config, animation_builder)
 
-local available_animations = {}
-
 function availableAnimation(animationType)
-	local flag = available_animations[animationType]
-	if flag ~= nil and flag == true then
-		return true
-	else
-		return false
-	end
+	return animations[animationType] ~= nil
 end
 
 function loadAnimation(animationType)
 	animations[animationType] = animation_defs[animationType]:builder()
-
-	if animations[animationType] ~= nil then
-		available_animations[animationType] = true
-	end
 end
 
 function disposeAnimation(animationType)
@@ -607,8 +596,7 @@ function disposeAnimation(animationType)
 	if animation_data ~= nil then
 		animation_data:dispose()
 	end
-
-	available_animations[animationType] = false
+	animations[animationType] = nil
 end
 
 function setAnimationDuration(animationType, duration)
@@ -636,6 +624,7 @@ function disposeVoice(voiceType)
 	if voice ~= nil then
 		voice:Dispose()
 	end
+	voices[voiceType] = nil
 end
 
 function playVoice(voiceType)

--- a/OpenTaiko/src/Character/CCharacter.cs
+++ b/OpenTaiko/src/Character/CCharacter.cs
@@ -143,7 +143,7 @@ abstract class CCharacter : IDisposable {
 
 	private static void AddRemovePreviewResource(string resourceName, Action<CCharacter, string> addRemoveResource) {
 		foreach (var characterLua in OpenTaiko.Tx.Characters)
-			addRemoveResource(characterLua[0], resourceName); // use P1's instances for preview
+			addRemoveResource(characterLua.Preview, resourceName);
 	}
 
 	private void LoadResource(string name, Dictionary<string, int> refCounts, Dictionary<string, int> resolvedLoadCounts,

--- a/OpenTaiko/src/Character/CCharacter.cs
+++ b/OpenTaiko/src/Character/CCharacter.cs
@@ -121,18 +121,19 @@ abstract class CCharacter : IDisposable {
 	}.ToFrozenDictionary();
 
 	public const int DEFAULT_DURATION = 500;
+	public const int ALTERNATIVE_MAX_TRY = 5;
 
-	// reference trackers
-	public static readonly Dictionary<string, int>[] PlayerToAnimationToRefCount = Enumerable.Range(0, OpenTaiko.MAX_PLAYERS)
-		.Select(i => new Dictionary<string, int>())
-		.ToArray();
+	// reference count of requested resources for previews
+	protected readonly Dictionary<string, int> animationPreviewRefCounts = new();
+	protected readonly Dictionary<string, int> voicePreviewRefCounts = new();
 
-	public static readonly Dictionary<string, int>[] PlayerToVoiceToRefCount = Enumerable.Range(0, OpenTaiko.MAX_PLAYERS)
-		.Select(i => new Dictionary<string, int>())
-		.ToArray();
+	// reference count of requested resources for players, only used for switching characters
+	protected Dictionary<string, int> animationRefCounts = new();
+	protected Dictionary<string, int> voiceRefCounts = new();
 
-	protected readonly Dictionary<string, int> animationLoadCounts = new();
-	protected readonly Dictionary<string, int> voiceLoadCounts = new();
+	// reference count of actually loaded resolved resources
+	protected readonly Dictionary<string, int> animationResolvedLoadCounts = new();
+	protected readonly Dictionary<string, int> voiceResolvedLoadCounts = new();
 
 	public static CCharacter GetCharacter(int player) {
 		int _charaId = CVirtualSlotManager.GetCharacterIndex(player);
@@ -143,108 +144,132 @@ abstract class CCharacter : IDisposable {
 	private static void AddRemovePreviewResource(string resourceName, Action<CCharacter, string> addRemoveResource) {
 		foreach (var characterLua in OpenTaiko.Tx.Characters)
 			addRemoveResource(characterLua[0], resourceName); // use P1's instances for preview
+	}
+
+	private void LoadResource(string name, Dictionary<string, int> refCounts, Dictionary<string, int> resolvedLoadCounts,
+		Func<CCharacter, string, bool> available, Func<CCharacter, string, string> getAlternative, Action<CCharacter, string> loadResolved,
+		string? noneName = null, int count = 1
+		) {
+		refCounts.TryAdd(name, 0);
+		refCounts[name] += count;
+		// try alternatives until successfully loaded (available)
+		for (int t = 0; t < ALTERNATIVE_MAX_TRY; ++t) {
+			if (name == noneName)
+				return;
+			if (resolvedLoadCounts.TryAdd(name, 0))
+				loadResolved(this, name);
+			if (available(this, name)) {
+				resolvedLoadCounts[name] += count;
+				break;
+			}
+			resolvedLoadCounts.Remove(name);
+			name = getAlternative(this, name);
 		}
-
-	private static void AddEssentialResource(int player, string resourceName, Dictionary<string, int>[] playerToResourceToRefCount, Action<CCharacter, string> addResource) {
-		var resourceToRefCount = playerToResourceToRefCount[player];
-		if (!resourceToRefCount.ContainsKey(resourceName))
-			resourceToRefCount.Add(resourceName, 0);
-		if (resourceToRefCount[resourceName] == 0)
-			addResource(GetCharacter(player), resourceName);
-		resourceToRefCount[resourceName]++;
 	}
 
-	private static void RemoveEssentialResource(int player, string resourceName, Dictionary<string, int>[] playerToResourceToRefCount, Action<CCharacter, string> removeResource) {
-		var resourceToRefCount = playerToResourceToRefCount[player];
-		if (!resourceToRefCount.ContainsKey(resourceName))
-			return;
-
-		resourceToRefCount[resourceName]--;
-		if (resourceToRefCount[resourceName] == 0) {
-			removeResource(GetCharacter(player), resourceName);
-			resourceToRefCount.Remove(resourceName);
+	private void DisposeResource(string name, Dictionary<string, int> refCounts, Dictionary<string, int> resolvedLoadCounts,
+		Func<CCharacter, string, string> resolveAlternatives, Action<CCharacter, string> disposeResolved,
+		int count = 1
+		) {
+		if (refCounts.TryGetValue(name, out int prevRefCount)) {
+			refCounts[name] -= count;
+			if (prevRefCount <= count)
+				refCounts.Remove(name);
 		}
-	}
-
-	private void AddResource(string resourceName, Dictionary<string, int> resourceLoadCounts, Action<CCharacter, string> loadResource, int count = 1) {
-		if (!resourceLoadCounts.ContainsKey(resourceName))
-			resourceLoadCounts.Add(resourceName, 0);
-		if (resourceLoadCounts[resourceName] == 0)
-			loadResource(this, resourceName);
-		resourceLoadCounts[resourceName] += count;
-	}
-
-	private void RemoveResource(string resourceName, Dictionary<string, int> resourceLoadCounts, Action<CCharacter, string> disposeResource, int count = 1) {
-		if (!resourceLoadCounts.ContainsKey(resourceName))
-			return;
-		resourceLoadCounts[resourceName] -= count;
-		if (resourceLoadCounts[resourceName] <= 0) {
-			disposeResource(this, resourceName);
-			resourceLoadCounts.Remove(resourceName);
+		var resolvedName = resolveAlternatives(this, name);
+		if (resolvedLoadCounts.TryGetValue(resolvedName, out int prevResolvedLoadCount)) {
+			resolvedLoadCounts[resolvedName] -= count;
+			if (prevResolvedLoadCount <= count) {
+				resolvedLoadCounts.Remove(resolvedName);
+				disposeResolved(this, resolvedName);
+			}
 		}
 	}
 
 
 	public static void AddPreviewAnimation(string animationName) =>
-		AddRemovePreviewResource(animationName, (chara, name) => chara.AddAnimation(name));
+		AddRemovePreviewResource(animationName, (chara, name) => chara.LoadAnimation(name, forPreview: true));
 	public static void RemovePreviewAnimation(string animationName) =>
-		AddRemovePreviewResource(animationName, (chara, name) => chara.RemoveAnimation(name));
+		AddRemovePreviewResource(animationName, (chara, name) => chara.DisposeAnimation(name, forPreview: true));
 
 	public static void AddEssentialAnimation(int player, string animationName)
-		=> AddEssentialResource(player, animationName, PlayerToAnimationToRefCount, (chara, name) => chara.AddAnimation(name));
+		=> GetCharacter(player).LoadAnimation(animationName);
 	public static void RemoveEssentialAnimation(int player, string animationName)
-		=> RemoveEssentialResource(player, animationName, PlayerToAnimationToRefCount, (chara, name) => chara.RemoveAnimation(name));
+		=> GetCharacter(player).DisposeAnimation(animationName);
 
-	private void AddAnimation(string animationName, int count = 1)
-		=> AddResource(animationName, animationLoadCounts, (chara, name) => chara.ImplLoadAnimation(name), count: count);
-	private void RemoveAnimation(string animationName, int count = 1)
-		=> RemoveResource(animationName, animationLoadCounts, (chara, name) => chara.ImplDisposeAnimation(name), count: count);
+	public void LoadAnimation(string animationName, int count = 1, bool forPreview = false)
+		=> LoadResource(animationName, forPreview ? animationPreviewRefCounts : animationRefCounts, animationResolvedLoadCounts,
+			(chara, name) => chara.AvailableResolvedAnimation(name), (chara, name) => GetAlternativeAnimation(name), (chara, name) => chara.LoadResolvedAnimation(name),
+			noneName: ANIM_NONE, count: count);
+	public void DisposeAnimation(string animationName, int count = 1, bool forPreview = false)
+		=> DisposeResource(animationName, forPreview ? animationPreviewRefCounts : animationRefCounts, animationResolvedLoadCounts,
+			(chara, name) => chara.GetAnimation(name), (chara, name) => chara.DisposeResolvedAnimation(name),
+			count: count);
 
 
 	public static void AddPreviewVoice(string voiceName) =>
-		AddRemovePreviewResource(voiceName, (chara, name) => chara.AddVoice(name));
+		AddRemovePreviewResource(voiceName, (chara, name) => chara.LoadVoice(name, forPreview: true));
 	public static void RemovePreviewVoice(string voiceName) =>
-		AddRemovePreviewResource(voiceName, (chara, name) => chara.RemoveVoice(name));
+		AddRemovePreviewResource(voiceName, (chara, name) => chara.DisposeVoice(name, forPreview: true));
 
 	public static void AddEssentialVoice(int player, string voiceName)
-		=> AddEssentialResource(player, voiceName, PlayerToVoiceToRefCount, (chara, name) => chara.AddVoice(name));
+		=> GetCharacter(player).LoadVoice(voiceName);
 	public static void RemoveEssentialVoice(int player, string voiceName)
-		=> RemoveEssentialResource(player, voiceName, PlayerToVoiceToRefCount, (chara, name) => chara.RemoveVoice(name));
+		=> GetCharacter(player).DisposeVoice(voiceName);
 
-	private void AddVoice(string voiceName, int count = 1)
-		=> AddResource(voiceName, voiceLoadCounts, (chara, name) => chara.ImplLoadVoice(name), count: count);
-	private void RemoveVoice(string voiceName, int count = 1)
-		=> RemoveResource(voiceName, voiceLoadCounts, (chara, name) => chara.ImplDisposeVoice(name), count: count);
+	public void LoadVoice(string voiceName, int count = 1, bool forPreview = false)
+		=> LoadResource(voiceName, forPreview ? voicePreviewRefCounts : voiceRefCounts, voiceResolvedLoadCounts,
+			(chara, name) => true, (chara, name) => name, (chara, name) => chara.LoadResolvedVoice(name), count: count);
+	public void DisposeVoice(string voiceName, int count = 1, bool forPreview = false)
+		=> DisposeResource(voiceName, forPreview ? voicePreviewRefCounts : voiceRefCounts, voiceResolvedLoadCounts,
+			(chara, name) => name, (chara, name) => chara.DisposeResolvedVoice(name), count: count);
 
+	public record struct ResourceRefCounts(IReadOnlyDictionary<string, int> animation, IReadOnlyDictionary<string, int> voice);
 
-	public void CharaLoadFor(int player) {
-		foreach (var (name, count) in PlayerToAnimationToRefCount[player])
-			this.AddAnimation(name, count);
-		foreach (var (name, count) in PlayerToVoiceToRefCount[player])
-			this.AddVoice(name, count);
+	public void CharaLoad(ResourceRefCounts? refCounts) {
+		if (refCounts == null)
+			return;
+		foreach (var (name, count) in refCounts.Value.animation)
+			this.LoadAnimation(name, count);
+		foreach (var (name, count) in refCounts.Value.voice)
+			this.LoadVoice(name, count);
 	}
 
-	public void CharaUnloadFor(int player) {
-		foreach (var (name, count) in PlayerToAnimationToRefCount[player])
-			this.RemoveAnimation(name, count);
-		foreach (var (name, count) in PlayerToVoiceToRefCount[player])
-			this.RemoveVoice(name, count);
+	public ResourceRefCounts CharaUnload() {
+		ResourceRefCounts res = new(animationRefCounts, voiceRefCounts);
+		animationRefCounts = [];
+		voiceRefCounts = [];
+		foreach (var (name, count) in res.animation)
+			this.DisposeAnimation(name, count);
+		foreach (var (name, count) in res.voice)
+			this.DisposeVoice(name, count);
+		return res;
 	}
 
-	public static string GetAlternativeAnimation(string animation) {
+	protected static string GetAlternativeAnimation(string animation) {
 		if (!AlternativeAnimations.ContainsKey(animation)) return ANIM_NONE;
 		string nextAnimation = AlternativeAnimations[animation];
 		return nextAnimation;
 	}
 
-	public string GetAnimation(string animation) {
-		for (int i = 0; i < 5; i++) {
-			bool available = this.AvailableAnimation(animation, false);
-			if (available) return animation;
-			string nextAnimation = GetAlternativeAnimation(animation);
-			animation = nextAnimation;
+	protected string GetAnimation(string animation) {
+		for (int i = 0; i < ALTERNATIVE_MAX_TRY; i++) {
+			if (animation == ANIM_NONE || this.AvailableResolvedAnimation(animation))
+				return animation;
+			animation = GetAlternativeAnimation(animation);
 		}
 		return ANIM_NONE;
+	}
+
+	public bool AvailableAnimation(string animationType) {
+		for (int i = 0; i < ALTERNATIVE_MAX_TRY; i++) {
+			if (animationType == ANIM_NONE)
+				return false;
+			if (this.AvailableResolvedAnimation(animationType))
+				return true;
+			animationType = GetAlternativeAnimation(animationType);
+		}
+		return false;
 	}
 
 	public class Info {
@@ -327,14 +352,16 @@ abstract class CCharacter : IDisposable {
 	}
 
 	public virtual void Dispose() {
-		for (int p = 0; p < OpenTaiko.MAX_PLAYERS; ++p) {
-			foreach (var (name, count) in PlayerToAnimationToRefCount[p])
-				this.ImplDisposeAnimation(name);
-			foreach (var (name, count) in PlayerToVoiceToRefCount[p])
-				this.ImplDisposeVoice(name);
-		}
-		animationLoadCounts.Clear();
-		voiceLoadCounts.Clear();
+			foreach (var (name, count) in animationResolvedLoadCounts)
+				this.DisposeResolvedAnimation(name);
+			foreach (var (name, count) in voiceResolvedLoadCounts)
+				this.DisposeResolvedVoice(name);
+		animationPreviewRefCounts.Clear();
+		animationRefCounts.Clear();
+		animationResolvedLoadCounts.Clear();
+		voicePreviewRefCounts.Clear();
+		voiceRefCounts.Clear();
+		voiceResolvedLoadCounts.Clear();
 	}
 
 	public virtual bool Update(string animationType, bool looping = true) {
@@ -360,21 +387,13 @@ abstract class CCharacter : IDisposable {
 	/// </summary>
 	public virtual (float x, float y)? GetAIBattlePosition(int player, float charaScale = 1.0f) => null;
 
-	public virtual void LoadAnimation(string voice) {
-
+	protected virtual void LoadResolvedAnimation(string animationType) {
 	}
 
-	public virtual void DisposeAnimation(string voice) {
-
+	protected virtual void DisposeResolvedAnimation(string animationType) {
 	}
 
-	protected virtual void ImplLoadAnimation(string animationType) {
-	}
-
-	protected virtual void ImplDisposeAnimation(string animationType) {
-	}
-
-	public virtual bool AvailableAnimation(string voice, bool useAlternative = true) {
+	protected virtual bool AvailableResolvedAnimation(string animationType) {
 		return false;
 	}
 
@@ -391,18 +410,11 @@ abstract class CCharacter : IDisposable {
 	}
 
 	//voice-------------
-	public virtual void LoadVoice(string voice) {
 
+	protected virtual void LoadResolvedVoice(string voice) {
 	}
 
-	public virtual void DisposeVoice(string voice) {
-
-	}
-
-	protected virtual void ImplLoadVoice(string voice) {
-	}
-
-	protected virtual void ImplDisposeVoice(string voice) {
+	protected virtual void DisposeResolvedVoice(string voice) {
 	}
 
 	public virtual void PlayVoice(string voice) {

--- a/OpenTaiko/src/Character/CCharacter.cs
+++ b/OpenTaiko/src/Character/CCharacter.cs
@@ -118,161 +118,117 @@ abstract class CCharacter : IDisposable {
 		{ ANIM_RESULT_CLEAR, ANIM_GAME_CLEAR },
 		{ ANIM_RESULT_FAILED_IN, ANIM_GAME_MISS_IN },
 		{ ANIM_RESULT_FAILED, ANIM_GAME_MISS }
-}.ToFrozenDictionary();
+	}.ToFrozenDictionary();
 
 	public const int DEFAULT_DURATION = 500;
 
-	public static readonly Dictionary<string, int> listPreviewAnimation = new Dictionary<string, int>();
-	public static readonly Dictionary<string, int>[] listEssentialAnimation = new Dictionary<string, int>[5] {
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>()
-	};
+	// reference trackers
+	public static readonly Dictionary<string, int>[] PlayerToAnimationToRefCount = Enumerable.Range(0, OpenTaiko.MAX_PLAYERS)
+		.Select(i => new Dictionary<string, int>())
+		.ToArray();
 
-	public static readonly Dictionary<string, int> listPreviewVoices = new Dictionary<string, int>();
-	public static readonly Dictionary<string, int>[] listEssentialVoices = new Dictionary<string, int>[5] {
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>()
-	};
+	public static readonly Dictionary<string, int>[] PlayerToVoiceToRefCount = Enumerable.Range(0, OpenTaiko.MAX_PLAYERS)
+		.Select(i => new Dictionary<string, int>())
+		.ToArray();
+
+	protected readonly Dictionary<string, int> animationLoadCounts = new();
+	protected readonly Dictionary<string, int> voiceLoadCounts = new();
 
 	public static CCharacter GetCharacter(int player) {
 		int _charaId = CVirtualSlotManager.GetCharacterIndex(player);
-		return OpenTaiko.Tx.Characters[_charaId];
+		return OpenTaiko.Tx.Characters[_charaId][player];
 	}
 
 
-
-
-	public static void AddPreviewAnimation(string animationName) {
-		if (!listPreviewAnimation.ContainsKey(animationName)) {
-			listPreviewAnimation.Add(animationName, 0);
+	private static void AddRemovePreviewResource(string resourceName, Action<CCharacter, string> addRemoveResource) {
+		foreach (var characterLua in OpenTaiko.Tx.Characters)
+			addRemoveResource(characterLua[0], resourceName); // use P1's instances for preview
 		}
 
-		if (listPreviewAnimation[animationName] == 0) {
-			foreach (CCharacter characterLua in OpenTaiko.Tx.Characters) {
-				characterLua.LoadAnimation(0, animationName);
-			}
-		}
-		listPreviewAnimation[animationName]++;
+	private static void AddEssentialResource(int player, string resourceName, Dictionary<string, int>[] playerToResourceToRefCount, Action<CCharacter, string> addResource) {
+		var resourceToRefCount = playerToResourceToRefCount[player];
+		if (!resourceToRefCount.ContainsKey(resourceName))
+			resourceToRefCount.Add(resourceName, 0);
+		if (resourceToRefCount[resourceName] == 0)
+			addResource(GetCharacter(player), resourceName);
+		resourceToRefCount[resourceName]++;
 	}
 
-	public static void RemovePreviewAnimation(string animationName) {
-		if (!listPreviewAnimation.ContainsKey(animationName)) return;
+	private static void RemoveEssentialResource(int player, string resourceName, Dictionary<string, int>[] playerToResourceToRefCount, Action<CCharacter, string> removeResource) {
+		var resourceToRefCount = playerToResourceToRefCount[player];
+		if (!resourceToRefCount.ContainsKey(resourceName))
+			return;
 
-		listPreviewAnimation[animationName]--;
-		if (listPreviewAnimation[animationName] == 0) {
-			foreach (CCharacter characterLua in OpenTaiko.Tx.Characters) {
-				characterLua.DisposeAnimation(0, animationName);
-			}
-
-			listPreviewAnimation.Remove(animationName);
+		resourceToRefCount[resourceName]--;
+		if (resourceToRefCount[resourceName] == 0) {
+			removeResource(GetCharacter(player), resourceName);
+			resourceToRefCount.Remove(resourceName);
 		}
 	}
 
-	public static void AddEssentialAnimation(int player, string animationName) {
-		Dictionary<string, int> essentialAnimationCounts = listEssentialAnimation[player];
-		if (!essentialAnimationCounts.ContainsKey(animationName)) {
-			essentialAnimationCounts.Add(animationName, 0);
-		}
-
-		if (essentialAnimationCounts[animationName] == 0) {
-			GetCharacter(player).LoadAnimation(player, animationName);
-		}
-		essentialAnimationCounts[animationName]++;
+	private void AddResource(string resourceName, Dictionary<string, int> resourceLoadCounts, Action<CCharacter, string> loadResource, int count = 1) {
+		if (!resourceLoadCounts.ContainsKey(resourceName))
+			resourceLoadCounts.Add(resourceName, 0);
+		if (resourceLoadCounts[resourceName] == 0)
+			loadResource(this, resourceName);
+		resourceLoadCounts[resourceName] += count;
 	}
 
-	public static void RemoveEssentialAnimation(int player, string animationName) {
-		Dictionary<string, int> essentialVoiceCounts = listEssentialAnimation[player];
-		if (!essentialVoiceCounts.ContainsKey(animationName)) return;
-
-		essentialVoiceCounts[animationName]--;
-		if (essentialVoiceCounts[animationName] == 0) {
-			GetCharacter(player).DisposeAnimation(player, animationName);
-
-			essentialVoiceCounts.Remove(animationName);
+	private void RemoveResource(string resourceName, Dictionary<string, int> resourceLoadCounts, Action<CCharacter, string> disposeResource, int count = 1) {
+		if (!resourceLoadCounts.ContainsKey(resourceName))
+			return;
+		resourceLoadCounts[resourceName] -= count;
+		if (resourceLoadCounts[resourceName] <= 0) {
+			disposeResource(this, resourceName);
+			resourceLoadCounts.Remove(resourceName);
 		}
 	}
 
 
+	public static void AddPreviewAnimation(string animationName) =>
+		AddRemovePreviewResource(animationName, (chara, name) => chara.AddAnimation(name));
+	public static void RemovePreviewAnimation(string animationName) =>
+		AddRemovePreviewResource(animationName, (chara, name) => chara.RemoveAnimation(name));
+
+	public static void AddEssentialAnimation(int player, string animationName)
+		=> AddEssentialResource(player, animationName, PlayerToAnimationToRefCount, (chara, name) => chara.AddAnimation(name));
+	public static void RemoveEssentialAnimation(int player, string animationName)
+		=> RemoveEssentialResource(player, animationName, PlayerToAnimationToRefCount, (chara, name) => chara.RemoveAnimation(name));
+
+	private void AddAnimation(string animationName, int count = 1)
+		=> AddResource(animationName, animationLoadCounts, (chara, name) => chara.ImplLoadAnimation(name), count: count);
+	private void RemoveAnimation(string animationName, int count = 1)
+		=> RemoveResource(animationName, animationLoadCounts, (chara, name) => chara.ImplDisposeAnimation(name), count: count);
 
 
-	public static void AddPreviewVoice(string voiceName) {
-		if (!listPreviewVoices.ContainsKey(voiceName)) {
-			listPreviewVoices.Add(voiceName, 0);
-		}
+	public static void AddPreviewVoice(string voiceName) =>
+		AddRemovePreviewResource(voiceName, (chara, name) => chara.AddVoice(name));
+	public static void RemovePreviewVoice(string voiceName) =>
+		AddRemovePreviewResource(voiceName, (chara, name) => chara.RemoveVoice(name));
 
-		if (listPreviewVoices[voiceName] == 0) {
-			foreach (CCharacter characterLua in OpenTaiko.Tx.Characters) {
-				characterLua.LoadVoice(0, voiceName);
-			}
-		}
-		listPreviewVoices[voiceName]++;
+	public static void AddEssentialVoice(int player, string voiceName)
+		=> AddEssentialResource(player, voiceName, PlayerToVoiceToRefCount, (chara, name) => chara.AddVoice(name));
+	public static void RemoveEssentialVoice(int player, string voiceName)
+		=> RemoveEssentialResource(player, voiceName, PlayerToVoiceToRefCount, (chara, name) => chara.RemoveVoice(name));
+
+	private void AddVoice(string voiceName, int count = 1)
+		=> AddResource(voiceName, voiceLoadCounts, (chara, name) => chara.ImplLoadVoice(name), count: count);
+	private void RemoveVoice(string voiceName, int count = 1)
+		=> RemoveResource(voiceName, voiceLoadCounts, (chara, name) => chara.ImplDisposeVoice(name), count: count);
+
+
+	public void CharaLoadFor(int player) {
+		foreach (var (name, count) in PlayerToAnimationToRefCount[player])
+			this.AddAnimation(name, count);
+		foreach (var (name, count) in PlayerToVoiceToRefCount[player])
+			this.AddVoice(name, count);
 	}
 
-	public static void RemovePreviewVoice(string voiceName) {
-		if (!listPreviewVoices.ContainsKey(voiceName)) return;
-
-		listPreviewVoices[voiceName]--;
-		if (listPreviewVoices[voiceName] == 0) {
-			foreach (CCharacter characterLua in OpenTaiko.Tx.Characters) {
-				characterLua.DisposeVoice(0, voiceName);
-			}
-
-			listPreviewVoices.Remove(voiceName);
-		}
-	}
-
-	public static void AddEssentialVoice(int player, string voiceName) {
-		Dictionary<string, int> essentialVoiceCounts = listEssentialVoices[player];
-		if (!essentialVoiceCounts.ContainsKey(voiceName)) {
-			essentialVoiceCounts.Add(voiceName, 0);
-		}
-
-		if (essentialVoiceCounts[voiceName] == 0) {
-			GetCharacter(player).LoadVoice(player, voiceName);
-		}
-		essentialVoiceCounts[voiceName]++;
-	}
-
-	public static void RemoveEssentialVoice(int player, string voiceName) {
-		Dictionary<string, int> essentialVoiceCounts = listEssentialVoices[player];
-		if (!essentialVoiceCounts.ContainsKey(voiceName)) return;
-
-		essentialVoiceCounts[voiceName]--;
-		if (essentialVoiceCounts[voiceName] == 0) {
-			GetCharacter(player).DisposeVoice(player, voiceName);
-
-			essentialVoiceCounts.Remove(voiceName);
-		}
-	}
-
-	public static void CharaLoad(int player, CCharacter character) {
-		Dictionary<string, int> essentialAnimationCounts = listEssentialAnimation[player];
-		foreach (var item in essentialAnimationCounts) {
-			character.LoadAnimation(player, item.Key);
-		}
-
-		Dictionary<string, int> essentialVoiceCounts = listEssentialVoices[player];
-		foreach (var item in essentialVoiceCounts) {
-			character.LoadVoice(player, item.Key);
-		}
-	}
-
-	public static void CharaUnload(int player, CCharacter character) {
-		Dictionary<string, int> essentialAnimationCounts = listEssentialAnimation[player];
-		foreach (var item in essentialAnimationCounts) {
-			character.DisposeAnimation(player, item.Key);
-		}
-
-		Dictionary<string, int> essentialVoiceCounts = listEssentialVoices[player];
-		foreach (var item in essentialVoiceCounts) {
-			character.DisposeVoice(player, item.Key);
-		}
+	public void CharaUnloadFor(int player) {
+		foreach (var (name, count) in PlayerToAnimationToRefCount[player])
+			this.RemoveAnimation(name, count);
+		foreach (var (name, count) in PlayerToVoiceToRefCount[player])
+			this.RemoveVoice(name, count);
 	}
 
 	public static string GetAlternativeAnimation(string animation) {
@@ -281,9 +237,9 @@ abstract class CCharacter : IDisposable {
 		return nextAnimation;
 	}
 
-	public static string GetAnimation(int player, CCharacter character, string animation) {
+	public string GetAnimation(string animation) {
 		for (int i = 0; i < 5; i++) {
-			bool available = character.AvailableAnimation(player, animation, false);
+			bool available = this.AvailableAnimation(animation, false);
 			if (available) return animation;
 			string nextAnimation = GetAlternativeAnimation(animation);
 			animation = nextAnimation;
@@ -291,92 +247,111 @@ abstract class CCharacter : IDisposable {
 		return ANIM_NONE;
 	}
 
-	public DBCharacter.CharacterData metadata;
-	public DBCharacter.CharacterEffect effect;
-	public CUnlockCondition? unlock;
-	public string _path;
-	public int _idx;
-	public string dirName;
+	public class Info {
+		public DBCharacter.CharacterData metadata;
+		public DBCharacter.CharacterEffect effect;
+		public CUnlockCondition? unlock;
+		public string _path;
+		public int _idx;
+		public string dirName;
 
-	public float GetEffectCoinMultiplier(bool gaugeEnabled = true) {
-		float mult = 1f;
+		public float GetEffectCoinMultiplier(bool gaugeEnabled = true) {
+			float mult = 1f;
 
-		mult *= HRarity.tRarityToRarityToCoinMultiplier(metadata.Rarity);
-		mult *= effect.GetCoinMultiplier(1f, gaugeEnabled: gaugeEnabled);
+			mult *= HRarity.tRarityToRarityToCoinMultiplier(metadata.Rarity);
+			mult *= effect.GetCoinMultiplier(1f, gaugeEnabled: gaugeEnabled);
 
-		return mult;
-	}
-
-	public void tGetUnlockedItems(int _player, ModalQueue mq) {
-		int player = _player;
-		var _sf = OpenTaiko.SaveFileInstances[player].data.UnlockedCharacters;
-		bool _edited = false;
-
-		if (!_sf.Contains(dirName)) {
-			var _fulfilled = unlock?.tConditionMet(player, CUnlockCondition.EScreen.Internal).Item1 ?? false;
-
-			if (_fulfilled) {
-				_sf.Add(dirName);
-				_edited = true;
-				mq.tAddModal(
-					new Modal(
-						Modal.EModalType.Character,
-						HRarity.tRarityToModalInt(metadata.Rarity),
-						new LuaCharacter(dirName)
-					),
-					_player);
-
-				DBSaves.RegisterStringUnlockedAsset(OpenTaiko.SaveFileInstances[player].data.SaveId, "unlocked_characters", dirName);
-			}
+			return mult;
 		}
 
-		if (_edited)
-			OpenTaiko.SaveFileInstances[player].tApplyHeyaChanges();
+		public void tGetUnlockedItems(int _player, ModalQueue mq) {
+			int player = _player;
+			var _sf = OpenTaiko.SaveFileInstances[player].data.UnlockedCharacters;
+			bool _edited = false;
+
+			if (!_sf.Contains(dirName)) {
+				var _fulfilled = unlock?.tConditionMet(player, CUnlockCondition.EScreen.Internal).Item1 ?? false;
+
+				if (_fulfilled) {
+					_sf.Add(dirName);
+					_edited = true;
+					mq.tAddModal(
+						new Modal(
+							Modal.EModalType.Character,
+							HRarity.tRarityToModalInt(metadata.Rarity),
+							new LuaCharacter(dirName)
+						),
+						_player);
+
+					DBSaves.RegisterStringUnlockedAsset(OpenTaiko.SaveFileInstances[player].data.SaveId, "unlocked_characters", dirName);
+				}
+			}
+
+			if (_edited)
+				OpenTaiko.SaveFileInstances[player].tApplyHeyaChanges();
+		}
+
+		public Info(string path, int i) {
+			_path = path;
+			dirName = Path.GetFileName(path);
+			_idx = i;
+
+			// Character metadata
+			if (File.Exists($@"{path}{Path.DirectorySeparatorChar}Metadata.json"))
+				metadata = ConfigManager.GetConfig<DBCharacter.CharacterData>($@"{path}{Path.DirectorySeparatorChar}Metadata.json");
+			else
+				metadata = new DBCharacter.CharacterData();
+
+			// Character metadata
+			if (File.Exists($@"{path}{Path.DirectorySeparatorChar}Effects.json"))
+				effect = ConfigManager.GetConfig<DBCharacter.CharacterEffect>($@"{path}{Path.DirectorySeparatorChar}Effects.json");
+			else
+				effect = new DBCharacter.CharacterEffect();
+
+			// Character unlockables
+			if (File.Exists($@"{path}{Path.DirectorySeparatorChar}Unlock.json"))
+				unlock = OpenTaiko.UnlockConditionFactory.GenerateUnlockObjectFromJsonPath($@"{path}{Path.DirectorySeparatorChar}Unlock.json");
+			else
+				unlock = null;
+		}
 	}
 
+	public readonly Info info;
+
 	public CCharacter(string path, int i) {
-		_path = path;
-		dirName = Path.GetFileName(path);
-		_idx = i;
+		info = new(path, i);
+	}
 
-		// Character metadata
-		if (File.Exists($@"{path}{Path.DirectorySeparatorChar}Metadata.json"))
-			metadata = ConfigManager.GetConfig<DBCharacter.CharacterData>($@"{path}{Path.DirectorySeparatorChar}Metadata.json");
-		else
-			metadata = new DBCharacter.CharacterData();
-
-		// Character metadata
-		if (File.Exists($@"{path}{Path.DirectorySeparatorChar}Effects.json"))
-			effect = ConfigManager.GetConfig<DBCharacter.CharacterEffect>($@"{path}{Path.DirectorySeparatorChar}Effects.json");
-		else
-			effect = new DBCharacter.CharacterEffect();
-
-		// Character unlockables
-		if (File.Exists($@"{path}{Path.DirectorySeparatorChar}Unlock.json"))
-			unlock = OpenTaiko.UnlockConditionFactory.GenerateUnlockObjectFromJsonPath($@"{path}{Path.DirectorySeparatorChar}Unlock.json");
-		else
-			unlock = null;
+	public CCharacter(Info info) {
+		this.info = info;
 	}
 
 	public virtual void Dispose() {
-
+		for (int p = 0; p < OpenTaiko.MAX_PLAYERS; ++p) {
+			foreach (var (name, count) in PlayerToAnimationToRefCount[p])
+				this.ImplDisposeAnimation(name);
+			foreach (var (name, count) in PlayerToVoiceToRefCount[p])
+				this.ImplDisposeVoice(name);
+		}
+		animationLoadCounts.Clear();
+		voiceLoadCounts.Clear();
 	}
 
-	public virtual bool Update(int player, string animationType, bool looping = true) {
+	public virtual bool Update(string animationType, bool looping = true) {
 		return false;
 	}
 
-	public virtual void Draw(int player, string animationType, float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
+	public virtual void Draw(string animationType, float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
 
 	}
 
-	public virtual void DrawAtAnchor(int player, string animationType, float x, float y, string anchor, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float? clipW = null, float? clipH = null, float clipX = 0f, float clipY = 0f, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
-		Draw(player, animationType, x, y, scaleX, scaleY, opacity, color, rotation, blendMode, wrapMode, gradientMap);
+	public virtual void DrawAtAnchor(string animationType, float x, float y, string anchor, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float? clipW = null, float? clipH = null, float clipX = 0f, float clipY = 0f, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
+		Draw(animationType, x, y, scaleX, scaleY, opacity, color, rotation, blendMode, wrapMode, gradientMap);
 	}
 
-	public virtual LuaVector2 GetDrawSize(int player, string animationType) => new LuaVector2(0, 0);
+	public virtual LuaVector2 GetDrawSize(string animationType) => new LuaVector2(0, 0);
 
-	public virtual (float x, float y) GetHeyaRenderOffset(int player) => (0f, 0f);
+	public virtual (float x, float y) GetHeyaRenderOffset() => (0f, 0f);
 
 	/// <summary>
 	/// Returns the character-specific AI battle base position (theme pixels) for
@@ -385,41 +360,55 @@ abstract class CCharacter : IDisposable {
 	/// </summary>
 	public virtual (float x, float y)? GetAIBattlePosition(int player, float charaScale = 1.0f) => null;
 
-	public virtual void LoadAnimation(int player, string voice) {
+	public virtual void LoadAnimation(string voice) {
 
 	}
 
-	public virtual void DisposeAnimation(int player, string voice) {
+	public virtual void DisposeAnimation(string voice) {
 
 	}
 
-	public virtual bool AvailableAnimation(int player, string voice, bool useAlternative = true) {
+	protected virtual void ImplLoadAnimation(string animationType) {
+	}
+
+	protected virtual void ImplDisposeAnimation(string animationType) {
+	}
+
+	public virtual bool AvailableAnimation(string voice, bool useAlternative = true) {
 		return false;
 	}
 
-	public virtual void SetAnimationDuration(int player, string animationType, double duration) {
+	public virtual void SetAnimationDuration(string animationType, double duration) {
 
 	}
 
-	public virtual void ResetAnimationCounter(int player, string animationType) {
+	public virtual void ResetAnimationCounter(string animationType) {
 
 	}
 
-	public void SetAnimationCyclesFromBPM(int player, string animationType, double bpm) {
-		SetAnimationDuration(player, animationType, 60000 / Math.Abs(CTja.TjaBeatSpeedToGameBeatSpeed(bpm)));
+	public void SetAnimationCyclesFromBPM(string animationType, double bpm) {
+		SetAnimationDuration(animationType, 60000 / Math.Abs(CTja.TjaBeatSpeedToGameBeatSpeed(bpm)));
 	}
 
 	//voice-------------
-	public virtual void LoadVoice(int player, string voice) {
+	public virtual void LoadVoice(string voice) {
 
 	}
 
-	public virtual void DisposeVoice(int player, string voice) {
+	public virtual void DisposeVoice(string voice) {
 
 	}
 
-	public virtual void PlayVoice(int player, string voice) {
+	protected virtual void ImplLoadVoice(string voice) {
+	}
+
+	protected virtual void ImplDisposeVoice(string voice) {
+	}
+
+	public virtual void PlayVoice(string voice) {
 
 	}
+
+
 	//------------------
 }

--- a/OpenTaiko/src/Character/CCharacterController.cs
+++ b/OpenTaiko/src/Character/CCharacterController.cs
@@ -14,48 +14,48 @@ namespace OpenTaiko {
 		public bool bLooping { get; set; } = true;
 
 		private string strCurrentAnimation => strActionAnimation ?? strLoopAnimation;
-		private bool[] bPlayingAction = new bool[5];
-		private int nBasePlayerIndex;
+		private bool bPlayingAction = false;
+		private int iPlayer;
 
-		public CCharacterController(int basePlayerIndex) {
-			this.nBasePlayerIndex = basePlayerIndex;
+		public CCharacterController(int iPlayer) {
+			this.iPlayer = iPlayer;
 		}
 
-		public void PlayAction(int player, string animationType) {
-			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
+		public void PlayAction(string animationType) {
+			CCharacter character = CCharacter.GetCharacter(iPlayer);
 			if (!character.AvailableAnimation(animationType)) return;
 			strActionAnimation = animationType;
 			character.ResetAnimationCounter(animationType);
 
-			bPlayingAction[player] = true;
+			bPlayingAction = true;
 		}
 
-		public void StopAction(int player) {
+		public void StopAction() {
 			strActionAnimation = null;
-			bPlayingAction[player] = false;
+			bPlayingAction = false;
 		}
 
-		public void ResetCounter(int player) {
-			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
+		public void ResetCounter() {
+			CCharacter character = CCharacter.GetCharacter(iPlayer);
 			character.ResetAnimationCounter(strCurrentAnimation);
 		}
 
-		public void Update(int player) {
-			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
+		public void Update() {
+			CCharacter character = CCharacter.GetCharacter(iPlayer);
 			character.SetAnimationDuration(strCurrentAnimation, dbDuration);
 
-			bool looping = !bPlayingAction[player] && bLooping;
+			bool looping = !bPlayingAction && bLooping;
 			bool animationEnded = character.Update(strCurrentAnimation, looping);
-			if (bPlayingAction[player] && animationEnded) {
-				StopAction(player);
-				ResetCounter(player);
-				Update(player);
+			if (bPlayingAction && animationEnded) {
+				StopAction();
+				ResetCounter();
+				Update();
 			}
 		}
 
-		public void Draw(int player, float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null) {
-			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
-			character.Draw(strCurrentAnimation, x, y, scaleX, scaleY, opacity, color, gradientMap: PaletteManager.GetEffectivePalette(player)?.LuaMap);
+		public void Draw(float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null) {
+			CCharacter character = CCharacter.GetCharacter(iPlayer);
+			character.Draw(strCurrentAnimation, x, y, scaleX, scaleY, opacity, color, gradientMap: PaletteManager.GetEffectivePalette(iPlayer)?.LuaMap);
 		}
 	}
 }

--- a/OpenTaiko/src/Character/CCharacterController.cs
+++ b/OpenTaiko/src/Character/CCharacterController.cs
@@ -23,9 +23,9 @@ namespace OpenTaiko {
 
 		public void PlayAction(int player, string animationType) {
 			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
-			if (!character.AvailableAnimation(player, animationType)) return;
+			if (!character.AvailableAnimation(animationType)) return;
 			strActionAnimation = animationType;
-			character.ResetAnimationCounter(player, animationType);
+			character.ResetAnimationCounter(animationType);
 
 			bPlayingAction[player] = true;
 		}
@@ -37,15 +37,15 @@ namespace OpenTaiko {
 
 		public void ResetCounter(int player) {
 			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
-			character.ResetAnimationCounter(player, strCurrentAnimation);
+			character.ResetAnimationCounter(strCurrentAnimation);
 		}
 
 		public void Update(int player) {
 			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
-			character.SetAnimationDuration(player, strCurrentAnimation, dbDuration);
+			character.SetAnimationDuration(strCurrentAnimation, dbDuration);
 
 			bool looping = !bPlayingAction[player] && bLooping;
-			bool animationEnded = character.Update(player, strCurrentAnimation, looping);
+			bool animationEnded = character.Update(strCurrentAnimation, looping);
 			if (bPlayingAction[player] && animationEnded) {
 				StopAction(player);
 				ResetCounter(player);
@@ -55,7 +55,7 @@ namespace OpenTaiko {
 
 		public void Draw(int player, float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null) {
 			CCharacter character = CCharacter.GetCharacter(nBasePlayerIndex);
-			character.Draw(player, strCurrentAnimation, x, y, scaleX, scaleY, opacity, color, gradientMap: PaletteManager.GetEffectivePalette(player)?.LuaMap);
+			character.Draw(strCurrentAnimation, x, y, scaleX, scaleY, opacity, color, gradientMap: PaletteManager.GetEffectivePalette(player)?.LuaMap);
 		}
 	}
 }

--- a/OpenTaiko/src/Character/Lua/CCharacterLua.cs
+++ b/OpenTaiko/src/Character/Lua/CCharacterLua.cs
@@ -19,57 +19,8 @@ class CCharacterLua : CCharacter {
 		Script.Dispose();
 	}
 
-	public override void LoadAnimation(string animationType) {
-		if (animationType == ANIM_NONE) return;
-		Dictionary<string, int> animationCounts = animationLoadCounts;
-		if (!animationCounts.ContainsKey(animationType)) animationCounts.Add(animationType, 0);
-
-		animationCounts[animationType]++;
-
-		if (animationCounts[animationType] == 1) {
-			ImplLoadAnimation(animationType);
-			bool available = AvailableAnimation(animationType, false);
-			if (!available) {
-				animationCounts[animationType]--;
-
-				string alternative = GetAlternativeAnimation(animationType);
-				LoadAnimation(alternative);
-			}
-		}
-
-	}
-
-	public override void DisposeAnimation(string animationType) {
-		if (animationType == ANIM_NONE) return;
-
-		bool available = AvailableAnimation(animationType, false);
-		if (!available) {
-			string alternative = GetAlternativeAnimation(animationType);
-			DisposeAnimation(alternative);
-			return;
-		}
-
-		Dictionary<string, int> animationCounts = animationLoadCounts;
-		if (!animationCounts.ContainsKey(animationType)) animationCounts.Add(animationType, 1);
-
-		animationCounts[animationType]--;
-
-		if (animationCounts[animationType] == 0) {
-			ImplDisposeAnimation(animationType);
-			animationCounts.Remove(animationType);
-		}
-	}
-
-	public override bool AvailableAnimation(string animationType, bool useAlternative = true) {
-		if (animationType == ANIM_NONE) return false;
-		for (int i = 0; i < 5; i++) {
-			bool available = Script.AvailableAnimation(animationType);
-			if (available) return true;
-			if (!useAlternative) return false;
-
-			animationType = GetAlternativeAnimation(animationType);
-		}
-		return false;
+	protected override bool AvailableResolvedAnimation(string animationType) {
+		return Script.AvailableAnimation(animationType);
 	}
 
 	public override void SetAnimationDuration(string animationType, double duration) {
@@ -78,31 +29,6 @@ class CCharacterLua : CCharacter {
 
 	public override void ResetAnimationCounter(string animationType) {
 		Script.ResetAnimationCounter(this.GetAnimation(animationType));
-	}
-
-	//voice-------------
-	public override void LoadVoice(string voice) {
-		Dictionary<string, int> voiceCounts = voiceLoadCounts;
-		if (!voiceCounts.ContainsKey(voice)) voiceCounts.Add(voice, 0);
-
-		if (voiceCounts[voice] == 0) {
-			ImplLoadVoice(voice);
-		}
-
-		voiceCounts[voice]++;
-	}
-
-	public override void DisposeVoice(string voice) {
-		Dictionary<string, int> voiceCounts = voiceLoadCounts;
-		if (!voiceCounts.ContainsKey(voice)) voiceCounts.Add(voice, 0);
-
-		if (voiceCounts[voice] <= 0) return;
-		voiceCounts[voice]--;
-
-		if (voiceCounts[voice] == 0) {
-			ImplDisposeVoice(voice);
-			voiceCounts.Remove(voice);
-		}
 	}
 
 	public override bool Update(string animationType, bool looping = true) {
@@ -135,11 +61,11 @@ class CCharacterLua : CCharacter {
 	}
 
 
-	protected override void ImplLoadAnimation(string animationType) {
+	protected override void LoadResolvedAnimation(string animationType) {
 		Script.LoadAnimation(animationType);
 	}
 
-	protected override void ImplDisposeAnimation(string animationType) {
+	protected override void DisposeResolvedAnimation(string animationType) {
 		Script.DisposeAnimation(animationType);
 	}
 
@@ -147,11 +73,11 @@ class CCharacterLua : CCharacter {
 		Script.PlayVoice(voice);
 	}
 
-	protected override void ImplLoadVoice(string voice) {
+	protected override void LoadResolvedVoice(string voice) {
 		Script.LoadVoice(voice);
 	}
 
-	protected override void ImplDisposeVoice(string voice) {
+	protected override void DisposeResolvedVoice(string voice) {
 		Script.DisposeVoice(voice);
 	}
 

--- a/OpenTaiko/src/Character/Lua/CCharacterLua.cs
+++ b/OpenTaiko/src/Character/Lua/CCharacterLua.cs
@@ -4,85 +4,66 @@ using Silk.NET.Maths;
 namespace OpenTaiko;
 
 class CCharacterLua : CCharacter {
-	private CLuaCharacterScript[] Script = new CLuaCharacterScript[5];
-
-	private Dictionary<string, int>[] animationLoadCounts = new Dictionary<string, int>[5] {
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>()
-	};
-
-	private Dictionary<string, int>[] voiceLoadCounts = new Dictionary<string, int>[5] {
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>(),
-		new Dictionary<string, int>()
-	};
-
-	public CLuaCharacterScript GetScript(int player) => Script[player];
+	public CLuaCharacterScript Script { get; private set; }
 
 	public CCharacterLua(string path, int i) : base(path, i) {
-		for (int player = 0; player < 5; player++) {
-			Script[player] = new CLuaCharacterScript(path, null, null, true);
+		Script = new CLuaCharacterScript(path, null, null, true);
 		}
+
+	public CCharacterLua(Info info) : base(info) {
+		Script = new CLuaCharacterScript(info._path, null, null, true);
 	}
 
 	public override void Dispose() {
 		base.Dispose();
-		for (int player = 0; player < 5; player++) {
-			Script[player].Dispose();
-			voiceLoadCounts[player].Clear();
-		}
+		Script.Dispose();
 	}
 
-	public override void LoadAnimation(int player, string animationType) {
+	public override void LoadAnimation(string animationType) {
 		if (animationType == ANIM_NONE) return;
-		Dictionary<string, int> animationCounts = animationLoadCounts[player];
+		Dictionary<string, int> animationCounts = animationLoadCounts;
 		if (!animationCounts.ContainsKey(animationType)) animationCounts.Add(animationType, 0);
 
 		animationCounts[animationType]++;
 
 		if (animationCounts[animationType] == 1) {
-			ImplLoadAnimation(player, animationType);
-			bool available = AvailableAnimation(player, animationType, false);
+			ImplLoadAnimation(animationType);
+			bool available = AvailableAnimation(animationType, false);
 			if (!available) {
 				animationCounts[animationType]--;
 
 				string alternative = GetAlternativeAnimation(animationType);
-				LoadAnimation(player, alternative);
+				LoadAnimation(alternative);
 			}
 		}
 
 	}
 
-	public override void DisposeAnimation(int player, string animationType) {
+	public override void DisposeAnimation(string animationType) {
 		if (animationType == ANIM_NONE) return;
 
-		bool available = AvailableAnimation(player, animationType, false);
+		bool available = AvailableAnimation(animationType, false);
 		if (!available) {
 			string alternative = GetAlternativeAnimation(animationType);
-			DisposeAnimation(player, alternative);
+			DisposeAnimation(alternative);
 			return;
 		}
 
-		Dictionary<string, int> animationCounts = animationLoadCounts[player];
+		Dictionary<string, int> animationCounts = animationLoadCounts;
 		if (!animationCounts.ContainsKey(animationType)) animationCounts.Add(animationType, 1);
 
 		animationCounts[animationType]--;
 
 		if (animationCounts[animationType] == 0) {
-			ImplDisposeAnimation(player, animationType);
+			ImplDisposeAnimation(animationType);
 			animationCounts.Remove(animationType);
 		}
 	}
 
-	public override bool AvailableAnimation(int player, string animationType, bool useAlternative = true) {
+	public override bool AvailableAnimation(string animationType, bool useAlternative = true) {
 		if (animationType == ANIM_NONE) return false;
 		for (int i = 0; i < 5; i++) {
-			bool available = Script[player].AvailableAnimation(animationType);
+			bool available = Script.AvailableAnimation(animationType);
 			if (available) return true;
 			if (!useAlternative) return false;
 
@@ -91,87 +72,87 @@ class CCharacterLua : CCharacter {
 		return false;
 	}
 
-	public override void SetAnimationDuration(int player, string animationType, double duration) {
-		Script[player].SetAnimationDuration(GetAnimation(player, this, animationType), duration);
+	public override void SetAnimationDuration(string animationType, double duration) {
+		Script.SetAnimationDuration(this.GetAnimation(animationType), duration);
 	}
 
-	public override void ResetAnimationCounter(int player, string animationType) {
-		Script[player].ResetAnimationCounter(GetAnimation(player, this, animationType));
+	public override void ResetAnimationCounter(string animationType) {
+		Script.ResetAnimationCounter(this.GetAnimation(animationType));
 	}
 
 	//voice-------------
-	public override void LoadVoice(int player, string voice) {
-		Dictionary<string, int> voiceCounts = voiceLoadCounts[player];
+	public override void LoadVoice(string voice) {
+		Dictionary<string, int> voiceCounts = voiceLoadCounts;
 		if (!voiceCounts.ContainsKey(voice)) voiceCounts.Add(voice, 0);
 
 		if (voiceCounts[voice] == 0) {
-			ImplLoadVoice(player, voice);
+			ImplLoadVoice(voice);
 		}
 
 		voiceCounts[voice]++;
 	}
 
-	public override void DisposeVoice(int player, string voice) {
-		Dictionary<string, int> voiceCounts = voiceLoadCounts[player];
+	public override void DisposeVoice(string voice) {
+		Dictionary<string, int> voiceCounts = voiceLoadCounts;
 		if (!voiceCounts.ContainsKey(voice)) voiceCounts.Add(voice, 0);
 
 		if (voiceCounts[voice] <= 0) return;
 		voiceCounts[voice]--;
 
 		if (voiceCounts[voice] == 0) {
-			ImplDisposeVoice(player, voice);
+			ImplDisposeVoice(voice);
 			voiceCounts.Remove(voice);
 		}
 	}
 
-	public override bool Update(int player, string animationType, bool looping = true) {
-		return Script[player].Update(OpenTaiko.FPS.DeltaTime, GetAnimation(player, this, animationType), looping);
+	public override bool Update(string animationType, bool looping = true) {
+		return Script.Update(OpenTaiko.FPS.DeltaTime, this.GetAnimation(animationType), looping);
 	}
 
-	public override void Draw(int player, string animationType, float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
-		string resolvedAnimation = GetAnimation(player, this, animationType);
+	public override void Draw(string animationType, float x, float y, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
+		string resolvedAnimation = this.GetAnimation(animationType);
 		string? contextType = (resolvedAnimation != animationType) ? animationType : null;
-		Script[player].Draw(resolvedAnimation, x, y, scaleX, scaleY, opacity, new LuaColor(color ?? Color4.White), contextType, rotation, blendMode, wrapMode, gradientMap);
+		Script.Draw(resolvedAnimation, x, y, scaleX, scaleY, opacity, new LuaColor(color ?? Color4.White), contextType, rotation, blendMode, wrapMode, gradientMap);
 	}
 
-	public override void DrawAtAnchor(int player, string animationType, float x, float y, string anchor, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float? clipW = null, float? clipH = null, float clipX = 0f, float clipY = 0f, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
-		string resolvedAnimation = GetAnimation(player, this, animationType);
+	public override void DrawAtAnchor(string animationType, float x, float y, string anchor, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255, Color4? color = null, float? clipW = null, float? clipH = null, float clipX = 0f, float clipY = 0f, float rotation = 0f, string? blendMode = null, string? wrapMode = null, LuaGradientMap? gradientMap = null) {
+		string resolvedAnimation = this.GetAnimation(animationType);
 		string? contextType = (resolvedAnimation != animationType) ? animationType : null;
-		Script[player].DrawAtAnchor(resolvedAnimation, x, y, anchor, scaleX, scaleY, opacity, new LuaColor(color ?? Color4.White), contextType, clipW, clipH, clipX, clipY, rotation, blendMode, wrapMode, gradientMap);
+		Script.DrawAtAnchor(resolvedAnimation, x, y, anchor, scaleX, scaleY, opacity, new LuaColor(color ?? Color4.White), contextType, clipW, clipH, clipX, clipY, rotation, blendMode, wrapMode, gradientMap);
 	}
 
-	public override LuaVector2 GetDrawSize(int player, string animationType) {
-		string resolvedAnimation = GetAnimation(player, this, animationType);
-		return Script[player].GetDrawSize(resolvedAnimation);
+	public override LuaVector2 GetDrawSize(string animationType) {
+		string resolvedAnimation = this.GetAnimation(animationType);
+		return Script.GetDrawSize(resolvedAnimation);
 	}
 
-	public override (float x, float y) GetHeyaRenderOffset(int player) {
-		return Script[player].GetHeyaRenderOffset();
+	public override (float x, float y) GetHeyaRenderOffset() {
+		return Script.GetHeyaRenderOffset();
 	}
 
 	public override (float x, float y)? GetAIBattlePosition(int player, float charaScale = 1.0f) {
-		return Script[player].GetAIBattlePosition(player, charaScale);
+		return Script.GetAIBattlePosition(player, charaScale);
 	}
 
 
-	private void ImplLoadAnimation(int player, string animationType) {
-		Script[player].LoadAnimation(animationType);
+	protected override void ImplLoadAnimation(string animationType) {
+		Script.LoadAnimation(animationType);
 	}
 
-	private void ImplDisposeAnimation(int player, string animationType) {
-		Script[player].DisposeAnimation(animationType);
+	protected override void ImplDisposeAnimation(string animationType) {
+		Script.DisposeAnimation(animationType);
 	}
 
-	public override void PlayVoice(int player, string voice) {
-		Script[player].PlayVoice(voice);
+	public override void PlayVoice(string voice) {
+		Script.PlayVoice(voice);
 	}
 
-	private void ImplLoadVoice(int player, string voice) {
-		Script[player].LoadVoice(voice);
+	protected override void ImplLoadVoice(string voice) {
+		Script.LoadVoice(voice);
 	}
 
-	private void ImplDisposeVoice(int player, string voice) {
-		Script[player].DisposeVoice(voice);
+	protected override void ImplDisposeVoice(string voice) {
+		Script.DisposeVoice(voice);
 	}
 
 	//------------------

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -20,7 +20,7 @@ internal class OpenTaiko : Game {
 	public static readonly string AppDisplayThreePartVersion = GetAppDisplayThreePartVersion();
 	public static readonly string AppNumericThreePartVersion = GetAppNumericThreePartVersion();
 
-	public static readonly int MAX_PLAYERS = 5;
+	public const int MAX_PLAYERS = 5;
 
 	private static string GetAppDisplayThreePartVersion() {
 		return $"v{GetAppNumericThreePartVersion()}";

--- a/OpenTaiko/src/Helpers/HGaugeMethods.cs
+++ b/OpenTaiko/src/Helpers/HGaugeMethods.cs
@@ -118,7 +118,7 @@ class HGaugeMethods {
 
 		return gt;
 	}
-	public static EGaugeType tGetGaugeTypeEnum(CCharacter? chara)
+	public static EGaugeType tGetGaugeTypeEnum(CCharacter.Info? chara)
 		=> (chara == null) ? EGaugeType.NORMAL : tGetGaugeTypeEnum(chara.effect.tGetGaugeType());
 	public static EGaugeType? tGetGaugeTypeEnum(CTja? tja) => tja?.forceGauge;
 	public static EGaugeType tGetGaugeTypeEnum(int player)

--- a/OpenTaiko/src/Lua/CLuaScript.cs
+++ b/OpenTaiko/src/Lua/CLuaScript.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Text;
 using System.Text.Json.Nodes;
 using FDK;
+using Newtonsoft.Json;
 using NLua;
 
 namespace OpenTaiko;
@@ -128,7 +129,8 @@ class CLuaScript : IDisposable {
 			LuaScript?.State?.GarbageCollector(KeraLua.LuaGC.Step, 0);
 			return ret;
 		} catch (Exception exception) {
-			Crash(exception);
+			var argsAsReprStrings = args.Select(v => JsonConvert.ToString(v));
+			Crash(exception, $"RunLuaCode - {luaFunction.Name}({string.Join(", ", argsAsReprStrings)})");
 		}
 		return null;
 	}
@@ -240,7 +242,7 @@ end
 			co.SetHook(_yieldHook, KeraLua.LuaHookMask.Count, Math.Max(1, YieldCheckInstructions));
 			_hookCo = co;
 		} catch (Exception exception) {
-			Crash(exception);
+			Crash(exception, $"tBeginYieldable({luaFunction.Name})");
 			tEndYieldable();
 		}
 	}
@@ -270,7 +272,7 @@ end
 			tEndYieldable();
 			return false;
 		} catch (Exception exception) {
-			Crash(exception);
+			Crash(exception, $"tStepYieldable({progress})");
 			tEndYieldable();
 			return false;
 		}
@@ -480,7 +482,7 @@ end
 
 			listScripts.Add(this);
 		} catch (Exception e) {
-			Crash(e);
+			Crash(e, $"initializing {nameof(CLuaScript)}");
 		}
 	}
 
@@ -523,11 +525,11 @@ end
 		listScripts.Remove(this);
 	}
 
-	protected void Crash(Exception exception) {
+	protected void Crash(Exception exception, string? at = null) {
 		bCrashed = true;
 		// iOS: surface Lua errors to the device console (os_log), which is easier to read than the on-screen overlay.
 
-		LogNotification.PopError($"{this.GetType().Name} Error: {exception.ToString()}");
+		LogNotification.PopError($"{this.GetType().Name} Error{(string.IsNullOrWhiteSpace(at) ? "" : $" at {at}")}: {exception.ToString()}");
 		Trace.TraceError($"Full script path: {this.strScriptPath}");
 		Trace.TraceError(exception.StackTrace);
 	}

--- a/OpenTaiko/src/Lua/Classes/LuaCharacter.cs
+++ b/OpenTaiko/src/Lua/Classes/LuaCharacter.cs
@@ -27,15 +27,11 @@ namespace OpenTaiko {
 			? CCharacter.GetCharacter(_player)
 			: _ownedCharacter;
 
-		// Slot used for all CCharacter calls in name-bound mode
-		// NOTE: I'd like CCharacter.Draw to not have a player number ideally, will think about how to design this
-		private int Slot => _player >= 0 ? _player : 0;
-
 		public bool IsValid => Character != null;
 
-		public string FolderName => Character?.dirName ?? "";
-		public string FullPath => Character?._path ?? "";
-		public string DisplayName => Character?.metadata?.tGetName() ?? FolderName;
+		public string FolderName => Character?.info.dirName ?? "";
+		public string FullPath => Character?.info._path ?? "";
+		public string DisplayName => Character?.info.metadata?.tGetName() ?? FolderName;
 
 		// ── Character-scope visual state ─────────────────────────────────────────
 		// All values are applied just before each draw call; frame textures are
@@ -115,16 +111,16 @@ namespace OpenTaiko {
 			: _paletteEntry?.LuaMap;
 
 		public void Draw(float x, float y, string animation, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255) {
-			Character?.Draw(Slot, animation, x, y, _scaleX * scaleX, _scaleY * scaleY, BlendOpacity(opacity), StoredColor(), _rotation, _blendMode, _wrapMode, DrawGradient);
+			Character?.Draw(animation, x, y, _scaleX * scaleX, _scaleY * scaleY, BlendOpacity(opacity), StoredColor(), _rotation, _blendMode, _wrapMode, DrawGradient);
 		}
 
 		public void DrawAtAnchor(float x, float y, string animation, string anchor = "bottom", float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255) {
-			Character?.DrawAtAnchor(Slot, animation, x, y, anchor, _scaleX * scaleX, _scaleY * scaleY, BlendOpacity(opacity), StoredColor(), null, null, 0f, 0f, _rotation, _blendMode, _wrapMode, DrawGradient);
+			Character?.DrawAtAnchor(animation, x, y, anchor, _scaleX * scaleX, _scaleY * scaleY, BlendOpacity(opacity), StoredColor(), null, null, 0f, 0f, _rotation, _blendMode, _wrapMode, DrawGradient);
 		}
 
 		/// <summary>Draws the character using the top-left corner of a layout rect as the origin.</summary>
 		public void DrawRect(float rect_x, float rect_y, float rect_w, float rect_h, string animation, float scaleX = 1.0f, float scaleY = 1.0f, int opacity = 255) {
-			Character?.Draw(Slot, animation, rect_x, rect_y, _scaleX * scaleX, _scaleY * scaleY, BlendOpacity(opacity), StoredColor(), _rotation, _blendMode, _wrapMode, DrawGradient);
+			Character?.Draw(animation, rect_x, rect_y, _scaleX * scaleX, _scaleY * scaleY, BlendOpacity(opacity), StoredColor(), _rotation, _blendMode, _wrapMode, DrawGradient);
 		}
 
 		/// <summary>
@@ -133,40 +129,40 @@ namespace OpenTaiko {
 		/// The caller is responsible for computing the exact draw position.
 		/// </summary>
 		public void DrawRectAtAnchor(float x, float y, float clip_w, float clip_h, string animation, int opacity = 255, float clipX = 0f, float clipY = 0f) {
-			Character?.DrawAtAnchor(Slot, animation, x, y, "topleft", _scaleX, _scaleY, BlendOpacity(opacity), StoredColor(), clip_w, clip_h, clipX, clipY, _rotation, _blendMode, _wrapMode, DrawGradient);
+			Character?.DrawAtAnchor(animation, x, y, "topleft", _scaleX, _scaleY, BlendOpacity(opacity), StoredColor(), clip_w, clip_h, clipX, clipY, _rotation, _blendMode, _wrapMode, DrawGradient);
 		}
 
 		public bool Update(string animation, bool looping = true) {
-			return Character?.Update(Slot, animation, looping) ?? false;
+			return Character?.Update(animation, looping) ?? false;
 		}
 
 		public void LoadAnimation(string animation) {
-			Character?.LoadAnimation(Slot, animation);
+			Character?.LoadAnimation(animation);
 		}
 
 		public void DisposeAnimation(string animation) {
-			Character?.DisposeAnimation(Slot, animation);
+			Character?.DisposeAnimation(animation);
 		}
 
 		public bool AvailableAnimation(string animation) {
-			return Character?.AvailableAnimation(Slot, animation) ?? false;
+			return Character?.AvailableAnimation(animation) ?? false;
 		}
 
 		public void SetAnimationDuration(string animation, double duration) {
-			Character?.SetAnimationDuration(Slot, animation, duration);
+			Character?.SetAnimationDuration(animation, duration);
 		}
 
 		public void SetAnimationCyclesFromBPM(string animation, double bpm) {
-			Character?.SetAnimationCyclesFromBPM(Slot, animation, bpm);
+			Character?.SetAnimationCyclesFromBPM(animation, bpm);
 		}
 
 		public void ResetAnimationCounter(string animation) {
-			Character?.ResetAnimationCounter(Slot, animation);
+			Character?.ResetAnimationCounter(animation);
 		}
 
 		/// <summary>Returns the drawn dimensions of the current animation frame scaled to the theme resolution. Returns (X=0, Y=0) if unavailable.</summary>
 		public LuaVector2 GetAnimationSize(string animation) {
-			return Character?.GetDrawSize(Slot, animation) ?? new LuaVector2(0, 0);
+			return Character?.GetDrawSize(animation) ?? new LuaVector2(0, 0);
 		}
 
 		#endregion
@@ -174,15 +170,15 @@ namespace OpenTaiko {
 		#region [Voice]
 
 		public void LoadVoice(string voice) {
-			Character?.LoadVoice(Slot, voice);
+			Character?.LoadVoice(voice);
 		}
 
 		public void DisposeVoice(string voice) {
-			Character?.DisposeVoice(Slot, voice);
+			Character?.DisposeVoice(voice);
 		}
 
 		public void PlayVoice(string voice) {
-			Character?.PlayVoice(Slot, voice);
+			Character?.PlayVoice(voice);
 		}
 
 		#endregion

--- a/OpenTaiko/src/Lua/Scripts/Accessors/LuaCharacterDatabase.cs
+++ b/OpenTaiko/src/Lua/Scripts/Accessors/LuaCharacterDatabase.cs
@@ -16,7 +16,7 @@ namespace OpenTaiko {
 
 		internal LuaCharacterDatabase(TextureLoader.CCharacterLuaSet[] characters) {
 			_entries = characters
-				.Select(s => s[0]) // use P1's instances for preview
+				.Select(s => s.Preview)
 				.Where(c => c != null)
 				.Select(c => new LuaCharacterEntry(c))
 				.ToArray();

--- a/OpenTaiko/src/Lua/Scripts/Accessors/LuaCharacterDatabase.cs
+++ b/OpenTaiko/src/Lua/Scripts/Accessors/LuaCharacterDatabase.cs
@@ -14,8 +14,9 @@ namespace OpenTaiko {
 		// Construction
 		// ────────────────────────────────────────────────────────────────────
 
-		internal LuaCharacterDatabase(CCharacterLua[] characters) {
+		internal LuaCharacterDatabase(TextureLoader.CCharacterLuaSet[] characters) {
 			_entries = characters
+				.Select(s => s[0]) // use P1's instances for preview
 				.Where(c => c != null)
 				.Select(c => new LuaCharacterEntry(c))
 				.ToArray();
@@ -77,12 +78,12 @@ namespace OpenTaiko {
 		public LuaUnlockCondition UnlockCondition { get; }
 
 		internal LuaCharacterEntry(CCharacterLua character) {
-			FolderName = character.dirName;
-			DisplayName = character.metadata.tGetName();
-			Rarity = character.metadata.Rarity;
+			FolderName = character.info.dirName;
+			DisplayName = character.info.metadata.tGetName();
+			Rarity = character.info.metadata.Rarity;
 			// Non-owning: wraps the already-loaded CCharacterLua — no extra Lua scripts created.
 			Character = new LuaCharacter(character);
-			UnlockCondition = new LuaUnlockCondition(character.unlock);
+			UnlockCondition = new LuaUnlockCondition(character.info.unlock);
 		}
 
 		private bool _disposed;

--- a/OpenTaiko/src/Lua/Scripts/CLuaActivityScript.cs
+++ b/OpenTaiko/src/Lua/Scripts/CLuaActivityScript.cs
@@ -82,7 +82,7 @@ namespace OpenTaiko {
 				LuaScript["DEACTIVATE"] = Deactivate;
 
 			} catch (Exception e) {
-				Crash(e);
+				Crash(e, $"initializing {nameof(CLuaActivityScript)}");
 			}
 
 		}

--- a/OpenTaiko/src/Lua/Scripts/CLuaCharacterScript.cs
+++ b/OpenTaiko/src/Lua/Scripts/CLuaCharacterScript.cs
@@ -127,7 +127,7 @@ namespace OpenTaiko {
 				lfDisposeVoice.Load(LuaScript);
 				lfPlayVoice.Load(LuaScript);
 			} catch (Exception e) {
-				Crash(e);
+				Crash(e, $"initializing {nameof(CLuaCharacterScript)}");
 			}
 		}
 	}

--- a/OpenTaiko/src/Lua/Scripts/CLuaROActivityScript.cs
+++ b/OpenTaiko/src/Lua/Scripts/CLuaROActivityScript.cs
@@ -16,7 +16,7 @@ namespace OpenTaiko {
 				LuaScript["ACTIVITY"] = null;
 				LuaScript["DATABASE"] = new LuaRODataStorageFunc(dir);
 			} catch (Exception e) {
-				Crash(e);
+				Crash(e, $"initializing {nameof(CLuaROActivityScript)}");
 			}
 		}
 

--- a/OpenTaiko/src/Lua/Scripts/CLuaStageScript.cs
+++ b/OpenTaiko/src/Lua/Scripts/CLuaStageScript.cs
@@ -128,7 +128,7 @@ namespace OpenTaiko {
 				LuaScript.State.Register("Exit", _exitCFunction);
 
 			} catch (Exception e) {
-				Crash(e);
+				Crash(e, $"initializing {nameof(CLuaStageScript)}");
 			}
 
 		}

--- a/OpenTaiko/src/Lua/Scripts/CLuaTransitionScript.cs
+++ b/OpenTaiko/src/Lua/Scripts/CLuaTransitionScript.cs
@@ -38,7 +38,7 @@ namespace OpenTaiko {
 				FadeOutSeconds = ReadSeconds("FADE_OUT_SECONDS");
 				FadeInSeconds = ReadSeconds("FADE_IN_SECONDS");
 			} catch (Exception e) {
-				Crash(e);
+				Crash(e, $"initializing {nameof(CLuaTransitionScript)}");
 			}
 		}
 

--- a/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
@@ -1235,6 +1235,7 @@ Result_Mountain = new CTexture[4]*/;
 		public readonly CCharacterLua[] instances; // [iPlayer]
 		public CCharacter.Info info => this;
 		public CCharacterLua this[int p] => instances[p];
+		public CCharacterLua Preview => instances[0]; // use P1's instance for preview
 
 		public CCharacterLuaSet(string path, int i) : base(path, i) {
 			instances = Enumerable.Range(0, OpenTaiko.MAX_PLAYERS)

--- a/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
@@ -833,11 +833,12 @@ class TextureLoader {
 
 		if (old >= 0 && !primary) {
 			OpenTaiko.SaveFileInstances[player].data.mountedCharacter = null;
-			Characters[old][player].CharaUnloadFor(player);
+			playerResourceRefCounts[player] = Characters[old][player].CharaUnload();
 		}
 
 		if ((newC >= 0 && OpenTaiko.SaveFileInstances[player].data.Character != newC) || primary) {
-			Characters[newC][player].CharaLoadFor(player);
+			Characters[newC][player].CharaLoad(playerResourceRefCounts[player]);
+			playerResourceRefCounts[player] = null;
 			OpenTaiko.SaveFileInstances[player].data.mountedCharacter = ((CCharacterLua)Characters[newC][player]).Script;
 		}
 	}
@@ -851,9 +852,11 @@ class TextureLoader {
 	public void SwapCharacterAnimations(int oldIdx, int newIdx, int player) {
 		if (oldIdx == newIdx) return;
 		if (oldIdx >= 0)
-			Characters[oldIdx][player].CharaUnloadFor(player);
-		if (newIdx >= 0)
-			Characters[newIdx][player].CharaLoadFor(player);
+			playerResourceRefCounts[player] = Characters[oldIdx][player].CharaUnload();
+		if (newIdx >= 0) {
+			Characters[newIdx][player].CharaLoad(playerResourceRefCounts[player]);
+			playerResourceRefCounts[player] = null;
+		}
 	}
 
 	public void DisposeTexture() {
@@ -1249,6 +1252,7 @@ Result_Mountain = new CTexture[4]*/;
 	public LuaCharacter[] PlayerCharacters = new LuaCharacter[5];
 	public LuaCharacterDatabase? LuaCharacterDb;
 
+	private CCharacter.ResourceRefCounts?[] playerResourceRefCounts = new CCharacter.ResourceRefCounts?[OpenTaiko.MAX_PLAYERS];
 	#endregion
 
 	#region [12_OnlineLounge]

--- a/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
@@ -757,11 +757,11 @@ class TextureLoader {
 
 		string[] charaDirs = OpenTaiko.GetMergedDirectories(OpenTaiko.strEXEFolder + GLOBAL + CHARACTERS);
 
-		Characters = new CCharacterLua[charaDirs.Length];
+		Characters = new CCharacterLuaSet[charaDirs.Length];
 
 		string[] charaDirNames = new string[charaDirs.Length];
 		for (int i = 0; i < charaDirs.Length; i++) {
-			Characters[i] = new CCharacterLua(charaDirs[i], i);
+			Characters[i] = new(charaDirs[i], i);
 			charaDirNames[i] = Characters[i].dirName;
 		}
 
@@ -832,18 +832,13 @@ class TextureLoader {
 			return;
 
 		if (old >= 0 && !primary) {
-			int i = old;
-
-			CCharacter.CharaUnload(player, Characters[i]);
 			OpenTaiko.SaveFileInstances[player].data.mountedCharacter = null;
+			Characters[old][player].CharaUnloadFor(player);
 		}
 
-		if ((newC >= 0 &&
-			 OpenTaiko.SaveFileInstances[player].data.Character != newC || primary)) {
-			int i = newC;
-
-			CCharacter.CharaLoad(player, Characters[i]);
-			OpenTaiko.SaveFileInstances[player].data.mountedCharacter = ((CCharacterLua)Characters[i]).GetScript(player);
+		if ((newC >= 0 && OpenTaiko.SaveFileInstances[player].data.Character != newC) || primary) {
+			Characters[newC][player].CharaLoadFor(player);
+			OpenTaiko.SaveFileInstances[player].data.mountedCharacter = ((CCharacterLua)Characters[newC][player]).Script;
 		}
 	}
 
@@ -856,9 +851,9 @@ class TextureLoader {
 	public void SwapCharacterAnimations(int oldIdx, int newIdx, int player) {
 		if (oldIdx == newIdx) return;
 		if (oldIdx >= 0)
-			CCharacter.CharaUnload(player, Characters[oldIdx]);
+			Characters[oldIdx][player].CharaUnloadFor(player);
 		if (newIdx >= 0)
-			CCharacter.CharaLoad(player, Characters[newIdx]);
+			Characters[newIdx][player].CharaLoadFor(player);
 	}
 
 	public void DisposeTexture() {
@@ -868,7 +863,7 @@ class TextureLoader {
 			listTexture.ElementAtOrDefault(i)?.Dispose();
 		listTexture.Clear();
 
-		foreach (CCharacter character in Characters) {
+		foreach (var character in Characters) {
 			character.Dispose();
 		}
 
@@ -1232,7 +1227,25 @@ Result_Mountain = new CTexture[4]*/;
 		Characters_Result_Clear_2P,
 		Characters_Result_Failed_2P;
 	*/
-	public CCharacterLua[] Characters = [];
+
+	public class CCharacterLuaSet : CCharacter.Info, IDisposable {
+		public readonly CCharacterLua[] instances; // [iPlayer]
+		public CCharacter.Info info => this;
+		public CCharacterLua this[int p] => instances[p];
+
+		public CCharacterLuaSet(string path, int i) : base(path, i) {
+			instances = Enumerable.Range(0, OpenTaiko.MAX_PLAYERS)
+				.Select(i => new CCharacterLua(this))
+				.ToArray();
+		}
+
+		public void Dispose() {
+			foreach (var instance in instances)
+				instance.Dispose();
+		}
+	}
+
+	public CCharacterLuaSet[] Characters = [];
 	public LuaCharacter[] PlayerCharacters = new LuaCharacter[5];
 	public LuaCharacterDatabase? LuaCharacterDb;
 

--- a/OpenTaiko/src/Stages/07.Game/CActPlayComboSound.cs
+++ b/OpenTaiko/src/Stages/07.Game/CActPlayComboSound.cs
@@ -59,7 +59,7 @@ internal class CActPlayComboSound : CActivity {
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			#region [Combo voices]
 
-			string charaPath = CCharacter.GetCharacter(i)._path;
+			string charaPath = CCharacter.GetCharacter(i).info._path;
 
 			var currentDir = OpenTaiko.ResolveAssetPath(Path.Combine(charaPath, "Sounds", "Combo") + Path.DirectorySeparatorChar);
 			if (Directory.Exists(currentDir)) {

--- a/OpenTaiko/src/Stages/07.Game/CFloorManagement.cs
+++ b/OpenTaiko/src/Stages/07.Game/CFloorManagement.cs
@@ -35,7 +35,7 @@ internal class CFloorManagement {
 			InvincibilityFrames = new CCounter(0, InvincibilityDurationSpeedDependent + 1000, 1, OpenTaiko.Timer);
 			CurrentNumberOfLives--;
 			//TJAPlayer3.Skin.soundTowerMiss.t再生する();
-			CCharacter.GetCharacter(0).PlayVoice(0, CCharacter.VOICE_TOWER_MISS);
+			CCharacter.GetCharacter(0).PlayVoice(CCharacter.VOICE_TOWER_MISS);
 		}
 	}
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBackground.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplBackground.cs
@@ -506,12 +506,12 @@ internal class CActImplBackground : CActivity {
 				animation = ctIsTired ? CCharacter.ANIM_GAME_TOWER_STANDING_TIRED : CCharacter.ANIM_GAME_TOWER_STANDING;
 			}
 
-			character.SetAnimationCyclesFromBPM(0, animation, OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]);
+			character.SetAnimationCyclesFromBPM(animation, OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[0]);
 
 			if (!OpenTaiko.stageGameScreen.bPAUSE) {
-				character.Update(0, animation);
+				character.Update(animation);
 			}
-			character.Draw(0, animation, x, y);
+			character.Draw(animation, x, y);
 
 			if (isClimbing) {
 				// Tired Climb

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CActImplCharacter.cs
@@ -21,9 +21,8 @@ internal class CActImplCharacter : CActivity {
 			ctKusuIn = new();
 
 			// Currently used character
-			int p = i;
 
-			this.iCurrentCharacter[i] = Math.Max(0, Math.Min(OpenTaiko.SaveFileInstances[p].data.Character, OpenTaiko.Tx.Characters.Length - 1));
+			this.iCurrentCharacter[i] = Math.Max(0, Math.Min(OpenTaiko.SaveFileInstances[i].data.Character, OpenTaiko.Tx.Characters.Length - 1));
 			CharacterControllers[i] = new CCharacterController(i);
 
 			CCharacter.AddEssentialAnimation(i, CCharacter.ANIM_GAME_NORMAL);
@@ -141,7 +140,7 @@ internal class CActImplCharacter : CActivity {
 
 			if (!OpenTaiko.stageGameScreen.bPAUSE) {
 				CharacterControllers[i].dbDuration = 60000 / Math.Abs(CTja.TjaBeatSpeedToGameBeatSpeed(OpenTaiko.stageGameScreen.actPlayInfo.dbBPM[i]));
-				CharacterControllers[i].Update(i);
+				CharacterControllers[i].Update();
 			}
 			//CCharacter.GetCharacter(i).Update(i, animation);
 
@@ -440,7 +439,7 @@ internal class CActImplCharacter : CActivity {
 				}
 
 				//CCharacter.GetCharacter(i).Draw(i, animation, chara_x, chara_y, charaScale, charaScale, 255, Color4.White, flipX);
-				CharacterControllers[i].Draw(i, chara_x, chara_y, _mirrorP2 ? -charaScale : charaScale, charaScale, 255, Color4.White);
+				CharacterControllers[i].Draw(chara_x, chara_y, _mirrorP2 ? -charaScale : charaScale, charaScale, 255, Color4.White);
 			}
 
 
@@ -489,7 +488,7 @@ internal class CActImplCharacter : CActivity {
 			}
 
 			//CCharacter.GetCharacter(i).Draw(i, CCharacter.ANIM_GAME_BALLOON_BREAKING, chara_x, chara_y, charaScale, charaScale, 255, Color4.White, false);
-			CharacterControllers[i].Draw(i, chara_x, chara_y, charaScale, charaScale, 255, Color4.White);
+			CharacterControllers[i].Draw(chara_x, chara_y, charaScale, charaScale, 255, Color4.White);
 			if (OpenTaiko.ConfigIni.nPlayerCount <= 2 && !IsInKusudama)
 				OpenTaiko.stageGameScreen.PuchiChara.OnProgressDraw(
 					OpenTaiko.stageGameScreen.GetJPOSCROLLX(i) + OpenTaiko.Skin.Game_PuchiChara_BalloonX[i],
@@ -518,8 +517,8 @@ internal class CActImplCharacter : CActivity {
 					kusuX *= -1;
 				}
 
-				CharacterControllers[i].Draw(i, chara_x + kusuX, chara_y + kusuY,
-				(i % 2 == 1) ? -charaScale : charaScale, charaScale, 255, Color4.White);
+				CharacterControllers[i].Draw(chara_x + kusuX, chara_y + kusuY, (i % 2 == 1) ? -charaScale : charaScale,
+				charaScale, 255, Color4.White);
 				OpenTaiko.stageGameScreen.PuchiChara.OnProgressDraw(
 					OpenTaiko.Skin.Game_PuchiChara_KusudamaX[i] + (int)kusuX,
 					OpenTaiko.Skin.Game_PuchiChara_KusudamaY[i] + (int)kusuY, false, 255, true, player: i);
@@ -822,7 +821,7 @@ internal class CActImplCharacter : CActivity {
 		} else if (priority < ActionKeepingPriority(CharacterControllers[player].strActionAnimation)) {
 			return; // insufficient action keeping priority
 		}
-		CharacterControllers[player].PlayAction(player, animationType);
+		CharacterControllers[player].PlayAction(animationType);
 	}
 
 	private bool visibleKusuChara(int iPlayer)
@@ -834,7 +833,7 @@ internal class CActImplCharacter : CActivity {
 		ctKusuSuccess = null;
 		for (int i = 0; i < OpenTaiko.ConfigIni.nPlayerCount; i++) {
 			CCharacter character = CCharacter.GetCharacter(i);
-			CharacterControllers[i].StopAction(i); // KusuIn replaces the action
+			CharacterControllers[i].StopAction(); // KusuIn replaces the action
 			CharacterControllers[i].strLoopAnimation = CCharacter.ANIM_GAME_KUSUDAMA_IDLE;
 			CharacterControllers[i].bLooping = true;
 		}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStagePlayDrumsScreen.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStagePlayDrumsScreen.cs
@@ -346,7 +346,7 @@ internal partial class CStagePlayDrumsScreen : CStagePlayScreenCommon {
 		var becomeStageFailed = (this.stageAbortType[iPlayer] == EStageAbort.None);
 		base.SetStageFailed(iPlayer, failType);
 		if (becomeStageFailed) {
-			this.actChara.CharacterControllers[iPlayer].PlayAction(iPlayer, CCharacter.ANIM_GAME_CLEAR_OUT);
+			this.actChara.CharacterControllers[iPlayer].PlayAction(CCharacter.ANIM_GAME_CLEAR_OUT);
 			this.actGauge.dbCurrentGaugeValue[iPlayer] = 0; // for indicate life failure in AI mode
 			this.UpdateGauge(null, EKeyConfigPart.Taiko, iPlayer, ENoteJudge.Auto); // update gauge
 			OpenTaiko.stageGameScreen.FloorManagement.CurrentNumberOfLives = 0; // prevent clear
@@ -698,7 +698,7 @@ internal partial class CStagePlayDrumsScreen : CStagePlayScreenCommon {
 			anim = CCharacter.ANIM_GAME_CLEARED;
 		else
 			anim = CCharacter.ANIM_GAME_FAILED;
-		this.actChara.CharacterControllers[i].PlayAction(i, anim);
+		this.actChara.CharacterControllers[i].PlayAction(anim);
 		this.actEnd.Start(i, endOfPlay: true);
 	}
 

--- a/OpenTaiko/src/Stages/08.Result/CActResultParameterPanel.cs
+++ b/OpenTaiko/src/Stages/08.Result/CActResultParameterPanel.cs
@@ -246,7 +246,7 @@ internal class CActResultParameterPanel : CActivity {
 			CCharacter character = CCharacter.GetCharacter(i);
 			CCharacterController characterController = new CCharacterController(i);
 			characterController.strLoopAnimation = CCharacter.ANIM_RESULT_NORMAL;
-			characterController.ResetCounter(i);
+			characterController.ResetCounter();
 
 			this.characterController[i] = characterController;
 		}
@@ -810,8 +810,8 @@ internal class CActResultParameterPanel : CActivity {
 					CResultCharacter.tMenuDisplayCharacter(p, chara_x, chara_y, CResultCharacter.ECharacterResult.NORMAL, pos);
 				*/
 
-				characterController[p].Update(p);
-				characterController[p].Draw(p, chara_x, chara_y, (pos % 2 == 1) ? -1.0f : 1.0f, 1.0f, 255, Color4.White);
+				characterController[p].Update();
+				characterController[p].Draw(chara_x, chara_y, (pos % 2 == 1) ? -1.0f : 1.0f, 1.0f, 255, Color4.White);
 
 				#endregion
 
@@ -1215,14 +1215,14 @@ internal class CActResultParameterPanel : CActivity {
 			character.PlayVoice(CCharacter.VOICE_RESULT_CLEARSUCCESS);
 
 			characterController[player].strLoopAnimation = CCharacter.ANIM_RESULT_CLEAR;
-			characterController[player].ResetCounter(player);
+			characterController[player].ResetCounter();
 		} else {
 			CCharacter character = CCharacter.GetCharacter(player);
 			character.PlayVoice(CCharacter.VOICE_RESULT_CLEARFAILED);
 
 			characterController[player].strLoopAnimation = CCharacter.ANIM_RESULT_FAILED;
-			characterController[player].ResetCounter(player);
-			characterController[player].PlayAction(player, CCharacter.ANIM_RESULT_FAILED_IN);
+			characterController[player].ResetCounter();
+			characterController[player].PlayAction(CCharacter.ANIM_RESULT_FAILED_IN);
 		}
 	}
 

--- a/OpenTaiko/src/Stages/08.Result/CActResultParameterPanel.cs
+++ b/OpenTaiko/src/Stages/08.Result/CActResultParameterPanel.cs
@@ -1212,13 +1212,13 @@ internal class CActResultParameterPanel : CActivity {
 	private void CheckClear(int player) {
 		if (OpenTaiko.stageResults.nClear[player] >= 1) {
 			CCharacter character = CCharacter.GetCharacter(player);
-			character.PlayVoice(player, CCharacter.VOICE_RESULT_CLEARSUCCESS);
+			character.PlayVoice(CCharacter.VOICE_RESULT_CLEARSUCCESS);
 
 			characterController[player].strLoopAnimation = CCharacter.ANIM_RESULT_CLEAR;
 			characterController[player].ResetCounter(player);
 		} else {
 			CCharacter character = CCharacter.GetCharacter(player);
-			character.PlayVoice(player, CCharacter.VOICE_RESULT_CLEARFAILED);
+			character.PlayVoice(CCharacter.VOICE_RESULT_CLEARFAILED);
 
 			characterController[player].strLoopAnimation = CCharacter.ANIM_RESULT_FAILED;
 			characterController[player].ResetCounter(player);

--- a/OpenTaiko/src/Stages/11.Heya/CHeyaDisplayAssetInformations.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CHeyaDisplayAssetInformations.cs
@@ -20,7 +20,7 @@ class CHeyaDisplayAssetInformations {
 		}
 	}
 
-	public static void DisplayCharacterInfo(CCachedFontRenderer pf, CCharacter character) {
+	public static void DisplayCharacterInfo(CCachedFontRenderer pf, CCharacter.Info character) {
 		string description = "";
 		description += $"{CLangManager.LangInstance.GetString("HEYA_DESCRIPTION_NAME").SafeFormat(character.metadata.tGetName())}\n";
 		description += $"{CLangManager.LangInstance.GetString("HEYA_DESCRIPTION_RARITY").SafeFormat(

--- a/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
@@ -233,11 +233,11 @@ class CStageHeya : CStage {
 		if (iCurrentMenu == CurrentMenu.Puchi) OpenTaiko.Tx.Puchichara[iPuchiCharaCurrent].render?.t2DDraw(0, 0);
 		if (iCurrentMenu == CurrentMenu.Chara) {
 			string renderAnimation = CCharacter.ANIM_RENDER;
-			var chara = OpenTaiko.Tx.Characters[iCharacterCurrent];
-			var (offsetX, offsetY) = chara.GetHeyaRenderOffset(0);
-			chara.SetAnimationDuration(0, renderAnimation, CCharacter.DEFAULT_DURATION);
-			chara.Update(0, renderAnimation);
-			chara.Draw(0, renderAnimation, offsetX, offsetY);
+			var chara = OpenTaiko.Tx.Characters[iCharacterCurrent][0]; // use P1's instance for preview
+			var (offsetX, offsetY) = chara.GetHeyaRenderOffset();
+			chara.SetAnimationDuration(renderAnimation, CCharacter.DEFAULT_DURATION);
+			chara.Update(renderAnimation);
+			chara.Draw(renderAnimation, offsetX, offsetY);
 		}
 
 		#endregion
@@ -315,8 +315,8 @@ class CStageHeya : CStage {
 
 				var scroll = DrawBox_Slot(i + (OpenTaiko.Skin.Heya_Center_Menu_Box_Count / 2));
 
-				OpenTaiko.Tx.Characters[pos].Draw(0, CCharacter.ANIM_PREVIEW, scroll.Item1 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[0],
-					scroll.Item2 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[1], 1.0f, 1.0f, 255, color);
+				OpenTaiko.Tx.Characters[pos][0].Draw(CCharacter.ANIM_PREVIEW, scroll.Item1 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[0], scroll.Item2 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[1],
+					1.0f, 1.0f, 255, color); // use P1's instance for preview
 
 				#region [Database related values]
 
@@ -599,7 +599,7 @@ class CStageHeya : CStage {
 					OpenTaiko.SaveFileInstances[iPlayer].tUpdateCharacterName(OpenTaiko.Tx.Characters[iCharacterCurrent].dirName);
 
 					// Welcome voice using Sanka
-					character.PlayVoice(iPlayer, CCharacter.VOICE_TITLE_SANKA);
+					character.PlayVoice(CCharacter.VOICE_TITLE_SANKA);
 
 					OpenTaiko.SaveFileInstances[iPlayer].tApplyHeyaChanges();
 

--- a/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
@@ -503,8 +503,8 @@ class CStageHeya : CStage {
 			//TJAPlayer3.Tx.SongSelect_Chara_Normal[ctChara_Normal.n現在の値].Opacity = ctChara_In.n現在の値 * 2;
 			//TJAPlayer3.Tx.SongSelect_Chara_Normal[ctChara_Normal.n現在の値].t2D描画(-200 + CharaX, 336 - CharaY);
 
-			characterController.Update(0);
-			characterController.Draw(0, chara_x, chara_y, 1.0f, 1.0f, 255, Color4.White);
+			characterController.Update();
+			characterController.Draw(chara_x, chara_y, 1.0f, 1.0f, 255, Color4.White);
 
 			#region [PuchiChara]
 

--- a/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
@@ -233,7 +233,7 @@ class CStageHeya : CStage {
 		if (iCurrentMenu == CurrentMenu.Puchi) OpenTaiko.Tx.Puchichara[iPuchiCharaCurrent].render?.t2DDraw(0, 0);
 		if (iCurrentMenu == CurrentMenu.Chara) {
 			string renderAnimation = CCharacter.ANIM_RENDER;
-			var chara = OpenTaiko.Tx.Characters[iCharacterCurrent][0]; // use P1's instance for preview
+			var chara = OpenTaiko.Tx.Characters[iCharacterCurrent].Preview;
 			var (offsetX, offsetY) = chara.GetHeyaRenderOffset();
 			chara.SetAnimationDuration(renderAnimation, CCharacter.DEFAULT_DURATION);
 			chara.Update(renderAnimation);
@@ -315,8 +315,8 @@ class CStageHeya : CStage {
 
 				var scroll = DrawBox_Slot(i + (OpenTaiko.Skin.Heya_Center_Menu_Box_Count / 2));
 
-				OpenTaiko.Tx.Characters[pos][0].Draw(CCharacter.ANIM_PREVIEW, scroll.Item1 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[0], scroll.Item2 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[1],
-					1.0f, 1.0f, 255, color); // use P1's instance for preview
+				OpenTaiko.Tx.Characters[pos].Preview.Draw(CCharacter.ANIM_PREVIEW, scroll.Item1 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[0], scroll.Item2 + OpenTaiko.Skin.Heya_Center_Menu_Box_Item_Offset[1],
+					1.0f, 1.0f, 255, color);
 
 				#region [Database related values]
 


### PR DESCRIPTION
* fix `CharaScript.lua`: `Game_Chara_Beat_GoGoMax` was overridden by `Game_Chara_Beat_GoGo` and `Game_Chara_Motion_GoGoStart_Max` was loaded twice
* refactor `CharaScript.lua`: tabulate animation configs and config loading
* fix Disposed voices/animations still remained in `CharaScript.lua` tables
* feat: load chara configs missing in 0.6.0: `Game_Chara_`[`Motion`/`Beat`]`_Tower_Running`(`_Tired`), `Game_Chara_Motion_Tower_Fail`
* refactor out player slot and per-player states in `CCharacter`
* refactor out player slot parameters in `CCharacterController`
* add info about called C#/Lua function and arguments to Lua crash log
* rework character switching to not rely on player slot within `CCharacter`