### PR TITLE
Fix Windows MIDI crash, SDL input thread crash, Kusudama not downgrading, pin version in standalone install script, restore readme screen...

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -201,6 +201,13 @@ jobs:
           7z u ../../../../../OpenTaiko.Linux.x64.zip "publish/Libs/linux-x64/*" "publish/FFmpeg/linux-x64/*" "publish/Songs/L2 Custom Charts/*" "publish/Songs/L3 Downloaded Songs/*" "publish/Songs/S1 Dan-i Dojo/box.def" "publish/Songs/S2 Taiko Towers/box.def" "publish/Songs/X1 Favorite/*" "publish/Songs/X2 Recent/*" "publish/Songs/X3 Search By Difficulty/*" "publish/Songs/X4 Search By Text/*"
           cd ..\..\..\..\..\
 
+      - name: Pin Version for Install Script (Linux x64)
+        run: |
+          $version = $env:versionLast
+          Write-Host "Pin version in linux_installer_standalone.bash to $version"
+          (Get-Content -Raw special/linux_installer_standalone.bash) -replace 'version="\$version"', "version=`"$version`"" |
+              Set-Content special/linux_installer_standalone.bash
+
       - name: Check if tag exists
         uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag

--- a/FDK/FDK.csproj
+++ b/FDK/FDK.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="managed-midi" Version="1.10.1" />
+    <PackageReference Include="ppy.managed-midi" Version="1.10.2" />
     <PackageReference Include="ReadJEnc" Version="1.3.1.2" />
     <PackageReference Include="Silk.NET.OpenGLES.Extensions.ImGui" Version="2.21.0" />
     <PackageReference Include="Silk.NET.Windowing" Version="2.21.0" />

--- a/FDK/src/01.Framework/Core/Game.cs
+++ b/FDK/src/01.Framework/Core/Game.cs
@@ -96,6 +96,7 @@ public abstract class Game : IDisposable {
 
 	public static List<Action> AsyncActions { get; private set; } = new();
 
+	public SemaphoreSlim thInputLock = new(1, 1);
 	public Thread thInput { get; private set; }
 	private CancellationTokenSource thInputCancel;
 
@@ -409,7 +410,20 @@ public abstract class Game : IDisposable {
 	/// Runs the game.
 	/// </summary>
 	public void Run() {
-		Window_.Run();
+		// adapted from Window_.Run();
+		Window_.Initialize();
+		Window_.Run(delegate {
+			this.EventsNoWait();
+			if (!Window_.IsClosing) {
+				Window_.DoUpdate();
+			}
+
+			if (!Window_.IsClosing) {
+				Window_.DoRender();
+			}
+		});
+		this.EventsNoWait();
+		Window_.Reset();
 	}
 
 	protected virtual void Configuration() {
@@ -437,7 +451,26 @@ public abstract class Game : IDisposable {
 
 	}
 
-	protected virtual void Events() {
+	protected void EventsNoWait() {
+		if (this.thInputLock.Wait(0)) {
+			try {
+				this.OnEvents();
+			} finally {
+				this.thInputLock.Release();
+			}
+		}
+	}
+
+	protected void Events() {
+		this.thInputLock.Wait();
+		try {
+			this.OnEvents();
+		} finally {
+			this.thInputLock.Release();
+		}
+	}
+
+	protected virtual void OnEvents() {
 		Window_.DoEvents();
 	}
 
@@ -537,7 +570,6 @@ public abstract class Game : IDisposable {
 		OnExiting();
 
 		this.thInputCancel.Cancel();
-		this.thInputCancel.Dispose();
 		Context.Dispose();
 	}
 

--- a/FDK/src/01.Framework/Rendering/Angle/AngleContext.cs
+++ b/FDK/src/01.Framework/Rendering/Angle/AngleContext.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using OpenTK.Graphics.Egl; //OpenTKさん ありがとう!
 using Silk.NET.Core.Contexts;
 using Silk.NET.GLFW;
@@ -10,6 +11,13 @@ public class AngleContext : IGLContext {
 	private nint Display;
 	private nint Context;
 	private nint Surface;
+	private nint _wlEglWindow;   // Wayland only: the wl_egl_window wrapping the wl_surface (see below)
+
+	// On Wayland, EGL (ANGLE, Mesa) takes a wl_egl_window as its EGLNativeWindowType — the bare
+	// wl_surface is rejected (EGL_BAD_NATIVE_WINDOW). libwayland-egl creates/sizes/destroys it.
+	[DllImport("libwayland-egl.so.1")] private static extern nint wl_egl_window_create(nint surface, int width, int height);
+	[DllImport("libwayland-egl.so.1")] private static extern void wl_egl_window_resize(nint eglWindow, int width, int height, int dx, int dy);
+	[DllImport("libwayland-egl.so.1")] private static extern void wl_egl_window_destroy(nint eglWindow);
 
 	public AngleContext(AnglePlatformType anglePlatformType, IWindow window, string flag_override = "") {
 		nint windowHandle;
@@ -36,8 +44,22 @@ public class AngleContext : IGLContext {
 			Console.WriteLine("Handle set to Cocoa");
 		} else if ((window.Native.Kind.HasFlag(NativeWindowFlags.Wayland) && !flag_has_override) || flag_override == "wayland") {
 			selectedflag = NativeWindowFlags.Wayland;
-			windowHandle = window.Native.Wayland.Value.Surface;
 			display = window.Native.Wayland.Value.Display;
+			nint wlSurface = window.Native.Wayland.Value.Surface;
+			// Wrap the wl_surface in a wl_egl_window; eglCreateWindowSurface needs THIS, not the raw
+			// surface. Size it to the window (matching the viewport math, which is driven by Size, not
+			// the framebuffer), keep it in sync on resize, and free it on dispose.
+			int w = Math.Max(1, window.Size.X), h = Math.Max(1, window.Size.Y);
+			try { _wlEglWindow = wl_egl_window_create(wlSurface, w, h); } catch (DllNotFoundException) { _wlEglWindow = 0; }
+			if (_wlEglWindow != 0) {
+				windowHandle = _wlEglWindow;
+				window.Resize += sz => { if (_wlEglWindow != 0 && sz.X > 0 && sz.Y > 0) wl_egl_window_resize(_wlEglWindow, sz.X, sz.Y, 0, 0); };
+			} else {
+				// libwayland-egl missing: fall back to the raw surface (likely won't render, but no
+				// worse than before) and tell the user how to recover.
+				windowHandle = wlSurface;
+				Trace.TraceWarning("libwayland-egl.so.1 not found — Wayland rendering may fail. Install it (e.g. libwayland-egl1), or run under XWayland / force X11 (-w glfw or SDL_VIDEODRIVER=x11).");
+			}
 			Console.WriteLine("Handle set to Wayland");
 		} else {
 			if (flag_has_override) throw new Exception("Override flag provided is invalid, please check for spelling errors or remove your argument.");
@@ -154,5 +176,6 @@ public class AngleContext : IGLContext {
 		Egl.DestroyContext(Display, Context);
 		Egl.DestroySurface(Display, Surface);
 		Egl.Terminate(Display);
+		if (_wlEglWindow != 0) { try { wl_egl_window_destroy(_wlEglWindow); } catch { } _wlEglWindow = 0; }
 	}
 }

--- a/OpenTaiko/System/Open-World Memories/Graphics/5_Game/9_End/AllPerfect/Script.lua
+++ b/OpenTaiko/System/Open-World Memories/Graphics/5_Game/9_End/AllPerfect/Script.lua
@@ -28,6 +28,7 @@ function playEndAnime(player)
 end
 
 function init()
+    imageHeight = 324
     if playerCount <= 2 then
         y = { 204, 468, 0, 0, 0 }
     elseif playerCount == 5 then

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -561,15 +561,15 @@ internal class OpenTaiko : Game {
 				actEnumSongs?.Draw();                            // "Enumerating Songs..." icon
 
 				switch (rCurrentStage.eStageID) {
+					case CStage.EStage.StartUp:
 					case CStage.EStage.Title:
 					case CStage.EStage.Config:
 					case CStage.EStage.SongSelect:
 					case CStage.EStage.SongLoading:
 						if (EnumSongs != null) {
 							#region [ (特定条件時) 曲検索スレッドの起動_開始 ]
-							if (rCurrentStage.eStageID == CStage.EStage.Title &&
-								rPreviousStage.eStageID == CStage.EStage.StartUp &&
-								this.nDrawLoopReturnValue == (int)EReturnValue.Continuation &&
+							if (rCurrentStage.eStageID == CStage.EStage.StartUp &&
+								rCurrentStage.ePhaseID == CStage.EPhase.Startup_Complete &&
 								!EnumSongs.IsSongListEnumStarted) {
 								actEnumSongs.Activate();
 								if (!ConfigIni.PreAssetsLoading) {

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -505,13 +505,12 @@ internal class OpenTaiko : Game {
 		this.tExitProcess();
 		base.OnExiting();
 	}
-	protected override void Events() {
-		base.Events();
+	protected override void OnEvents() {
+		base.OnEvents();
 		FPSInput?.Update();
 	}
 	protected override void Update() {
 		InputManager?.Polling();
-		FPSInput?.Update(); // events polled before Update() is called
 	}
 	protected override void Draw() {
 #if !DEBUG

--- a/OpenTaiko/src/Stages/01.StartUp/CStage起動.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/CStage起動.cs
@@ -153,7 +153,7 @@ internal class CStage起動 : CStage {
 
 							this.list進行文字列.Add("LOADING TEXTURES...OK");
 							this.str現在進行中 = "Setup done.";
-							this.ePhaseID = EPhase.Startup_Complete;
+							this.ePhaseID = EPhase.Startup_7_SetUpNewConfig;
 							OpenTaiko.Skin.bgm起動画面.tStop();
 						}
 						if (OpenTaiko.ConfigIni.ASyncTextureLoad) {
@@ -168,7 +168,7 @@ internal class CStage起動 : CStage {
 			//-----------------
 			#endregion
 
-			if (ePhaseID != EPhase.Startup_Complete) {
+			if (ePhaseID is not (EPhase.Startup_7_SetUpNewConfig or EPhase.Startup_Complete)) {
 				#region [ this.list進行文字列＋this.現在進行中 の表示 ]
 				//-----------------
 				int x = (int)(320 * OpenTaiko.Skin.Resolution[0] / 1280.0);
@@ -180,7 +180,7 @@ internal class CStage起動 : CStage {
 				}
 				//-----------------
 				#endregion
-			} else if (OpenTaiko.ConfigIsNew && !bLanguageSelected) // Prompt language selection if Config.ini is newly generated
+			} else if (OpenTaiko.ConfigIsNew && ePhaseID is EPhase.Startup_7_SetUpNewConfig) // Prompt language selection if Config.ini is newly generated
 			{
 				HBlackBackdrop.Draw();
 
@@ -207,15 +207,21 @@ internal class CStage起動 : CStage {
 					OpenTaiko.Skin.soundDecideSFX.tPlay();
 					OpenTaiko.ConfigIni.sLang = CLangManager.intToLang(langSelectIndex);
 					CLangManager.langAttach(OpenTaiko.ConfigIni.sLang);
-					bLanguageSelected = true;
+					ePhaseID = EPhase.Startup_Complete;
 				}
 			} else {
 				if (es != null && es.IsSongListEnumCompletelyDone)                          // 曲リスト作成が終わったら
 				{
 					OpenTaiko.Songs管理 = (es != null) ? es.Songs管理 : null;      // 最後に、曲リストを拾い上げる
+					ePhaseID = EPhase.Startup_Complete;
 
-					return 1;
+					if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)) {
+						OpenTaiko.Skin.soundDecideSFX.tPlay();
+						return 1;
+					}
 				}
+
+				OpenTaiko.Tx.Readme.t2D描画(0, 0);
 			}
 
 		}

--- a/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/TextureLoader.cs
@@ -136,7 +136,7 @@ class TextureLoader {
 		Scanning_Loudness = TxC(@$"Scanning_Loudness.png");
 		Overlay = TxC(@$"Overlay.png");
 		Network_Connection = TxC(@$"Network_Connection.png");
-		// Readme = TxC(@$"Readme.png");
+		Readme = TxC(@$"Readme.png");
 		NamePlateBase = TxC(@$"NamePlate.png");
 		NamePlate_Extension = TxC(@$"NamePlate_Extension.png");
 

--- a/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
+++ b/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
@@ -255,13 +255,13 @@ internal class CEnumSongs                           // #27060 2011.2.7 yyagi 曲
 			#endregion
 
 		} finally {
-			OpenTaiko.stageStartup.ePhaseID = CStage.EPhase.Startup_6_LoadTextures;
 			TimeSpan span = (TimeSpan)(DateTime.Now - now);
 			Trace.TraceInformation("起動所要時間: {0}", span.ToString());
 			lock (this)                         // #28700 2012.6.12 yyagi; state change must be in finally{} for exiting as of compact mode.
 			{
 				state = DTXEnumState.CompletelyDone;
 			}
+			OpenTaiko.stageStartup.ePhaseID = CStage.EPhase.Startup_6_LoadTextures;
 		}
 	}
 

--- a/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStage演奏画面共通.cs
@@ -62,7 +62,7 @@ internal abstract class CStage演奏画面共通 : CStage {
 		}
 		this.ReduceMultiplayerNotes(
 			chip => NotesManager.IsKusudama(chip),
-			chip => chip.nChannelNo = NotesManager.ToChannelNo(NotesManager.ENoteType.BalloonEx),
+			chip => chip.nChannelNo = NotesManager.ToChannelNo(NotesManager.ENoteType.Balloon),
 			OpenTaiko.ConfigIni.nPlayerCount);
 		this.ReduceMultiplayerNotes(chip => chip.IsPartnerNote, chip => chip.IsPartnerNote = false, 2);
 
@@ -290,8 +290,14 @@ internal abstract class CStage演奏画面共通 : CStage {
 							break; // would not match further
 						double msError = Math.Max(Math.Abs(now.db発声時刻ms - min.db発声時刻ms), Math.Abs(now.end.db発声時刻ms - min.end.db発声時刻ms));
 						if (ReferenceEquals(now, min) || msError < msErrorMin) {
+							// downgrade unmatched notes
+							for (int id = idxNotes[i, b]; id < ic; ++id) {
+								var note = targetNotes[i, b][id];
+								reduceF(note);
+								note.multiLink = null;
+							}
 							msErrorMin = msError;
-							idxNotes[i, b] = ic + 1; // exclude from future match, leave previous matches unmatched
+							idxNotes[i, b] = ic + 1; // exclude from future match
 							matchedNotes[i, b] = now;
 						}
 					}

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1159,7 +1159,9 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 
 		if ((pChip.bVisible && !pChip.bHideBarLine) && (OpenTaiko.Tx.Bar != null)) {
 			var width = OpenTaiko.Tx.Bar.szTextureSize.Width;
-			if (x >= -width / 2 && x <= GameWindowSize.Width + width / 2) {
+			var height = OpenTaiko.Skin.Game_Notes_Size[1];
+			var maxRadius = width + height; // upper limit of Math.Hypot(width, height) and a close approximant because width is small
+			if (x >= -maxRadius / 2 && x <= GameWindowSize.Width + maxRadius / 2) {
 				double theta = (pChip.dbSCROLL_Y == 0.0) ? 0 : -Math.Atan2(pChip.nVerticalChipDistance, pChip.nHorizontalChipDistance);
 				CTexture tex = (pChip.bBranch) ? OpenTaiko.Tx.Bar_Branch : OpenTaiko.Tx.Bar;
 				tex.fZ軸中心回転 = (float)theta;

--- a/OpenTaiko/src/Stages/CStage.cs
+++ b/OpenTaiko/src/Stages/CStage.cs
@@ -50,6 +50,7 @@ public class CStage : CActivity {
 		Startup_4_LoadSongsNotSeenInScoreCacheAndApplyThem,
 		Startup_5_PostProcessSonglist,
 		Startup_6_LoadTextures,
+		Startup_7_SetUpNewConfig,
 		Startup_Complete,
 		Title_FadeIn,
 		SongSelect_FadeInFromResults,

--- a/special/linux_installer_standalone.bash
+++ b/special/linux_installer_standalone.bash
@@ -29,33 +29,38 @@ desktop_folder="$HOME/.local/share/applications"
 archive_filename="OpenTaiko.Linux.x64.zip"
 installation_folder="$current_dir/OpenTaiko"
 git_repo="0auBSQ/OpenTaiko"
+version="$version"  # replaced with the real release tag in GitHub Action
 
 # Create cache directory
 mkdir -p "$cache_dir"
 
-# Get latest release tag via GitHub API
-echo "Fetching latest release tag for $git_repo..."
-latest_tag=$(curl -s "https://api.github.com/repos/$git_repo/releases/latest" | jq -r '.tag_name')
+# Select version
+if [ -n "$version" ]; then
+    echo "Selected version: $version"
+else
+    # Get latest release tag via GitHub API
+    echo "Fetching latest release tag for $git_repo..."
+    version=$(curl -s "https://api.github.com/repos/$git_repo/releases/latest" | jq -r '.tag_name')
 
-if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
-    echo "Failed to fetch the latest version tag."
-    exit 1
+    if [ -z "$version" ] || [ "$version" = "null" ]; then
+        echo "Failed to fetch the latest version tag."
+        exit 1
+    fi
+    echo "Latest version: $version"
 fi
-
-echo "Latest version: $latest_tag"
 
 # Create and move to installation_folder
 mkdir -p "$installation_folder"
 cd "$installation_folder" || exit 1
 
 # Check if we already have this version cached
-cached_file="$cache_dir/$latest_tag-$archive_filename"
+cached_file="$cache_dir/$version-$archive_filename"
 if [ -f "$cached_file" ]; then
     echo "Using cached version: $cached_file"
     cp "$cached_file" "$archive_filename"
 else
     # Download using curl with redirect support
-    download_url="https://github.com/$git_repo/releases/download/$latest_tag/$archive_filename"
+    download_url="https://github.com/$git_repo/releases/download/$version/$archive_filename"
     echo "Downloading from: $download_url"
     curl -L -o "$archive_filename" "$download_url" || { echo "Download failed."; exit 1; }
     


### PR DESCRIPTION
This fixes some issues in 0auBSQ/OpenTaiko#918. This might fix 0auBSQ/OpenTaiko#822, 0auBSQ/OpenTaiko#922.

* [Fix] MIDI input crashed, fixed by updating managed-midi to 1.10.2 (osu!'s fork), which includes the fix for wrong WinMM MIDI header structure
* [Fix] Input thread concurrency crashed SDL event handling, fixed using modified window loop with mutex access to `DoEvents()`
* [Fix] Kusudama never downgraded to regular Balloon since 0.6.0.106
* [Fix] Rotated barline suddenly disappeared near left or right screen edges
* [Fix] built-in dev skin: Playing All-Perfect animation in 5P mode truncated out its SENote lane part forever
* [Feat] Restore the readme screen requiring <kbd>Enter</kbd> removed in 0.6.0.106 and allow song list enumeration at the screen
* [Chore] Pin release version in `linux_installer_standalone.bash` for release assets in auto build
* [Fix] speculative wayland fix [0.6.1 backport]

## Test Auto Build

https://github.com/IepIweidieng/OpenTaiko/actions/runs/29630885671
https://github.com/IepIweidieng/OpenTaiko/releases/tag/0.6.0.601

### To Fix

- [x] fix pinning release version in `linux_installer_standalone.bash` failed
