### PR TITLE
Fix the missing audio due to missing SoundMaster volume initialization during startup

### DIFF
--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -1650,6 +1650,7 @@ internal class OpenTaiko : Game {
 				0,
 				OpenTaiko.ConfigIni.nASIODevice,
 				OpenTaiko.ConfigIni.bUseOSTimer);
+			SoundManager.nMasterVolume = OpenTaiko.ConfigIni.nMasterVolume;
 			// iOS: the desktop branch below also creates these; without SongGainController the first note NREs (CTja.tチップの再生).
 			SongGainController = new SongGainController();
 			ConfigIniToSongGainControllerBinder.Bind(ConfigIni, SongGainController);


### PR DESCRIPTION
This issue was only exposed after 60a22765.