### PR TITLE
update install-dotnet-sdk.sh and fix spanish localization grammar

### DIFF
--- a/OpenTaiko/Lang/es/lang.json
+++ b/OpenTaiko/Lang/es/lang.json
@@ -30,7 +30,7 @@
 		"SETTINGS_GAME": "Opciones de la Jugabilidad",
 		"SETTINGS_GAME_DESC": "Ajustes para tocar los tambores.",
 		"SETTINGS_EXIT": "Salir",
-		"SETTINGS_EXIT_DESC": "Guarda los ajustes y sale del menú de\nCONFIGURACIÓN.",
+		"SETTINGS_EXIT_DESC": "Guarda los ajustes y sal del menú de\nCONFIGURACIÓN.",
 
 		"SETTINGS_MENU_RETURN": "<< Volver al menú",
 		"SETTINGS_MENU_RETURN_DESC": "Vuelve al menú de la izquierda.",
@@ -54,7 +54,7 @@
 		"SETTINGS_SYSTEM_RELOADSONG_STATUS": " La lista de canciones se está cargando.\n         Por favor, espere...",
 
 		"SETTINGS_SYSTEM_IMPORTSCOREINI": "Importar Archivos de Score.ini",
-		"SETTINGS_SYSTEM_IMPORTSCOREINI_DESC": "Importa archivos de Score.ini a la base de datos.\n\n<c.#f0ad4e>ADVERTENCIA\nLos siguientes no serán transferidos:\n- Estados de Completados\n- Modificadores de jugabilidad\n- # de golpes (Bien, Vale, Mal, Redobles, etcétera)\n- Puntos del examen Dan",
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_DESC": "Importa archivos de Score.ini a la base de datos.\n\n<c.#f0ad4e>ADVERTENCIA\nLos siguientes no serán transferidos:\n- Marcas de Completado\n- Modificadores de jugabilidad\n- # de golpes (Bien, Vale, Mal, Redobles, etcétera)\n- Puntos del examen Dan",
 		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS1": "Búsqueda de partituras...",
 		// {0}: Total # of score.ini files to be processed
 		// {1}: # of score.ini files successfully imported
@@ -69,7 +69,7 @@
 		// {3}: # of players whose scores failed to import due to an error
 		// {4}: ID of the current player being processed.
 		// {5}: Name of the current player being processed.
-		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS3": "Actualizando las puntuaciones de {0} jugadores...\n<c.#0bb000>{1} de {2} actualizados/c> (<c.#b00000>{3} falló</c>)\n\n{4}: {5}",
+		"SETTINGS_SYSTEM_IMPORTSCOREINI_STATUS3": "Actualizando las puntuaciones de {0} jugadores...\n<c.#0bb000>{1} de {2} actualizados</c> (<c.#b00000>{3} falló</c>)\n\n{4}: {5}",
 
 		"SETTINGS_SYSTEM_HIDEDANTOWER": "Ocultar Dans/Torres",
 		"SETTINGS_SYSTEM_HIDEDANTOWER_DESC": "Oculta partituras de Dans y Torres en el menú de\nModo Taiko.\nNota: Recarga las canciones para aplicar los cambios.",
@@ -78,11 +78,11 @@
 		"SETTINGS_SYSTEM_FULLSCREEN": "Modo de Pantalla Completa",
 		"SETTINGS_SYSTEM_FULLSCREEN_DESC": "Alterna entre modo de ventana y pantalla completa.",
 		"SETTINGS_SYSTEM_VSYNC": "Modo de VSync",
-		"SETTINGS_SYSTEM_VSYNC_DESC": "Alterna si VSync es utilizado.\nActivarlo limitará los FPS a 60, suavizará el\ndesplazamiento de notas pero aumentará el \nretraso de entrada.\nDesactivarlo no limitará los FPS, disminuirá el\nretraso de entrada pero hará que el desplazamiento\nde nota parezca más inestable.",
+		"SETTINGS_SYSTEM_VSYNC_DESC": "Alterna si VSync es utilizado.\nActivarlo limitará los FPS a 60, suavizará el\ndesplazamiento de notas pero aumentará el \nretraso de entrada.\nDesactivarlo no limitará los FPS, disminuirá el\nretraso de entrada pero hará que el desplazamiento\nde las notas parezca más inestable.",
 		"SETTINGS_SYSTEM_GRAPHICSAPI": "API Gráfica",
 		"SETTINGS_SYSTEM_GRAPHICSAPI_DESC": "Método de Renderizado:\nElige entre OpenGL, DirectX 11, Vulkan, o Metal.\nOpenGL es lento, pero compatible y estable.\nDirectX11 es rápido y estable, pero solo funciona\nen Windows.\nVulkan funciona más rápido en Linux.\nMetal solo funciona en MacOS.\n\nEsto tendrá efecto después de reiniciar el juego.",
 		"SETTINGS_SYSTEM_TEXTUREASYNC": "Carga de Texturas Asíncronas",
-		"SETTINGS_SYSTEM_TEXTUREASYNC_DESC": "Tipo de Carga de Textura:\nDesaparece la congelación al inicio.\nDesactiva esta opción si algunas texturas se vuelven\nnegras.\nEste cambio tendrá efecto después de reiniciar\nOpenTaiko.",
+		"SETTINGS_SYSTEM_TEXTUREASYNC_DESC": "Tipo de Carga de Textura:\nEvita que se congele al iniciar.\nDesactiva esta opción si algunas texturas se vuelven\nnegras.\nEste cambio tendrá efecto después de reiniciar\nOpenTaiko.",
 
 		"SETTINGS_SYSTEM_BGMOVIE": "Alternar Reproducción de Video",
 		"SETTINGS_SYSTEM_BGMOVIE_DESC": "Alterna si se utilizan videos de fondo.\nSi está habilitado y falta el video en una carpeta,\nel fondo aparecerá oscurecido.",
@@ -110,7 +110,7 @@
 		"SETTINGS_SYSTEM_DISPLAYPUCHI": "Mostrar Puchichara",
 		"SETTINGS_SYSTEM_DISPLAYPUCHI_DESC": "Muestra imágenes del Puchichara.",
 		"SETTINGS_SYSTEM_SIMPLEMODE": "Modo Simple",
-		"SETTINGS_SYSTEM_SIMPLEMODE_DESC": "Simplifica el renderizado ocultando la mayoría de\nlosdestellos y efectos visuales durante el juego.",
+		"SETTINGS_SYSTEM_SIMPLEMODE_DESC": "Simplifica el renderizado ocultando la mayoría de\nlos destellos y efectos visuales durante el juego.",
 
 		"SETTINGS_SYSTEM_SKIN": "Skin Actual",
 		"SETTINGS_SYSTEM_SKIN_DESC": "Elige una skin desde la carpeta de sistema.",
@@ -121,7 +121,7 @@
 		"SETTINGS_SYSTEM_USESONGVOL": "Aplicar Metadatos de SONGVOL",
 		"SETTINGS_SYSTEM_USESONGVOL_DESC": "Esto es una configuración parcialmente redundante\nque alterna si se utilizan metadatos de SONGVOL.\nValores entre 0 y 100 reducirán el volumen de la\ncanción, pero valores superiores a 100 no hacen\nnada.",
 		"SETTINGS_SYSTEM_SEVOL": "Volumen de Efectos de Sonidos",
-		"SETTINGS_SYSTEM_SEVOL_DESC": "Ajusta volumen de sonidos relacionados con el tambor.\nPara jugar sin instrumento, configúralo en 0.\nDebes reiniciar el juego después de salir de la config.\npara guardar esta opción.",
+		"SETTINGS_SYSTEM_SEVOL_DESC": "Ajusta el volumen de sonidos relacionados\ncon el tambor.\nPara jugar sin instrumento, configúralo en 0.\nDebes reiniciar el juego después de salir de la config.\npara guardar esta opción.",
 		"SETTINGS_SYSTEM_VOICEVOL": "Volumen de Voz",
 		"SETTINGS_SYSTEM_VOICEVOL_DESC": "Ajusta volumen de sonidos relacionados con la voz de\nun personaje.\nDebes reiniciar el juego después de salir de la config.\npara guardar esta opción.",
 		"SETTINGS_SYSTEM_SONGVOL": "Volumen de Reproducción de Canción",
@@ -134,32 +134,32 @@
 		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER": "Búfer de Reproducción de Canción",
 		"SETTINGS_SYSTEM_SONGPLAYBACKBUFFER_DESC": "El tiempo necesario antes de la reproducción de la\ncanción durante el juego.\nDisminuir el valor puede hacer que las canciones se\nreproduzcan demasiado pronto.",
 		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER": "Búfer de Vista Previa de Canción",
-		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER_DESC": "El tiempo necesario antes de que se reproduzca\nla vista previa de una canción.\nDisminuir este valor puede hacer que las \nvistas previas comiencen mientras aún te desplazas.\nPuedes especificar de 0 ms a 10000 ms.",
+		"SETTINGS_SYSTEM_SONGPREVIEWBUFFER_DESC": "El tiempo necesario antes de que se reproduzca la\nvista previa de una canción.\nDisminuir este valor puede hacer que las vistas \nprevias comiencen mientras aún te desplazas.\nPuedes especificar de 0 ms a 10000 ms.",
 
 		"SETTINGS_SYSTEM_AUDIOPLAYBACK": "Modo de Reproducción de Canción",
-		"SETTINGS_SYSTEM_AUDIOPLAYBACK_DESC": "ASIO:\n- Solo funciona en dispositivos de sonido\ncompatibles con la reproducción ASIO.\n- Tiene el menor retraso de entrada.\nWasapi:\n- Solo compatible con Windows.\n- Tiene el segundo menor retraso de entrada.\nBASS:\n- Compatible con todas las plataformas.\nNota: Sal de CONFIGURACIÓN para realizar los\n           ajustes.",
+		"SETTINGS_SYSTEM_AUDIOPLAYBACK_DESC": "ASIO:\n- Solo funciona en dispositivos de sonido\ncompatibles con la reproducción ASIO.\n- Tiene el menor retraso de entrada.\nWasapi:\n- Solo compatible con Windows.\n- Tiene el segundo menor retraso de entrada.\nBASS:\n- Compatible con todas las plataformas.\nNota: Sal de la CONFIGURACIÓN para aplicar los\n           cambios.",
 		"SETTINGS_SYSTEM_ASIOPLAYBACK": "Dispositivo de Reproducción de ASIO",
-		"SETTINGS_SYSTEM_ASIOPLAYBACK_DESC": "Elige un dispositivo válido para habilitar el modo de\nreproducción de ASIO.\n\nNota: Sal de CONFIGURACIÓN para realizar los\n           ajustes.",
+		"SETTINGS_SYSTEM_ASIOPLAYBACK_DESC": "Elige un dispositivo válido para habilitar el modo de\nreproducción de ASIO.\n\nNota: Sal de la CONFIGURACIÓN para aplicar los\n           cambios.",
 		"SETTINGS_SYSTEM_WASAPIBUFFER": "Tamaño de Búfer de WASAPI",
-		"SETTINGS_SYSTEM_WASAPIBUFFER_DESC": "Cambia el búfer de sonido para el modo de\nreproducción de sonido de Wasapi.\nDeja el número más bajo posible evitando problemas\ncomo congelamiento de la canción y el tiempo\nincorrecto. Déjalo en 0 para usar un valor estimado,\no encuentra el valor correcto para ti a base de\nprueba y error.\nNota: Sal de CONFIGURACIÓN para realizar los\n           ajustes.",
+		"SETTINGS_SYSTEM_WASAPIBUFFER_DESC": "Cambia el búfer de sonido para el modo de\nreproducción de sonido de Wasapi.\nDeja el número más bajo posible evitando problemas\ncomo congelamiento de la canción y el tiempo\nincorrecto. Déjalo en 0 para usar un valor estimado,\no encuentra el valor correcto para ti a base de\nprueba y error.\nNota: Sal de la CONFIGURACIÓN para aplicar los\n           cambios.",
 		"SETTINGS_SYSTEM_BASSBUFFER": "Tamaño de Búfer de Bass",
-		"SETTINGS_SYSTEM_BASSBUFFER_DESC": "Tamaño del búfer cuando se usan Bass:\nTamaño puede estar entre 0 ~ 99999ms.\nUn valor de 0 hará que el sistema operativo decida\nautomáticamente el tamaño.\nMenos el valor, menos retraso de audio hay, pero\ntambién puede causar audio anormal o crepitante.\n※ NOTA: Sal de CONFIGURACIÓN para realizar los\n                 ajustes.",
+		"SETTINGS_SYSTEM_BASSBUFFER_DESC": "Tamaño del búfer cuando se usan Bass:\nTamaño puede estar entre 0 ~ 99999ms.\nUn valor de 0 hará que el sistema operativo decida\nautomáticamente el tamaño.\nMenos el valor, menos retraso de audio hay, pero\ntambién puede causar audio anormal o crepitante.\n※ NOTA: Sal de la CONFIGURACIÓN para aplicar los\n                 cambios.",
 		"SETTINGS_SYSTEM_OSTIMER": "Usar Temporizador del Sistema",
-		"SETTINGS_SYSTEM_OSTIMER_DESC": "Activar esto hará notas se desplacen más\nsuavemente, pero podría hacer que la partitura se\ndesincronice con la canción.\nDesactivar esto evitará que la partitura se\ndesincronice con la canción, pero puede\nhacer que las notas fluctúen al desplazarse.",
+		"SETTINGS_SYSTEM_OSTIMER_DESC": "Activar esto hará notas se desplacen más\nsuavemente, pero podría hacer que la partitura se\ndesincronice con la canción.\nDesactivar esto evitará que la partitura se\ndesincronice con la canción, pero puede\nhacer que las notas tiemblen al desplazarse.",
 
 		// Settings - System - Misc.
 		"SETTINGS_SYSTEM_LOG": "Crear Archivo de Registro",
 		"SETTINGS_SYSTEM_LOG_DESC": "Alterna si un archivo TJAPlayer3.log se genera\ncuando se cierra el juego.\nEsto rastrea el rendimiento del juego e identifica\nerrores.",
 		"SETTINGS_SYSTEM_RANDOMSUBFOLDER": "Usar Subcarpetas en la Selección Aleatoria",
-		"SETTINGS_SYSTEM_RANDOMSUBFOLDER_DESC": "Alterna si se usan subcarpetas durante la selección\nde aleatoria de las canciones.",
+		"SETTINGS_SYSTEM_RANDOMSUBFOLDER_DESC": "Alterna si se usan subcarpetas durante la selección\naleatoria de las canciones.",
 		"SETTINGS_SYSTEM_DEBUGMODE": "Modo de Depuración",
-		"SETTINGS_SYSTEM_DEBUGMODE_DESC": "Alterna si modo de depuración está habilitado.\nEsto hará que aparezca información adicional en la\nparte inferior derecha.\nEsto mostrará la calibración de latencia para juego\nsin sonido.",
+		"SETTINGS_SYSTEM_DEBUGMODE_DESC": "Alterna si el modo depuración está habilitado.\nEsto hará que aparezca información adicional en la\nparte inferior derecha.\nEsto mostrará la calibración de latencia para jugar\nsin sonido.",
 		"SETTINGS_SYSTEM_AUTOSCREENSHOT": "Capturas de Pantalla Automáticas",
-		"SETTINGS_SYSTEM_AUTOSCREENSHOT_DESC": "Alterna si las capturas de pantalla de los resultados\nse toman automáticamente. Esto solo ocurrirá\ncuando se logre puntos más alta, lo que puede no\ncorrelacionarse con el mejor juego de esa canción.",
-		"SETTINGS_SYSTEM_DISCORDRPC": "Presencia Rica en Discord",
+		"SETTINGS_SYSTEM_AUTOSCREENSHOT_DESC": "Alterna si las capturas de pantalla de los resultados\nse toman automáticamente. Esto solo ocurrirá\ncuando se logre una puntuacion más alta, lo que\npuede no correlacionarse con la mejor jugada de\nesa canción.",
+		"SETTINGS_SYSTEM_DISCORDRPC": "Rich Presence en Discord",
 		"SETTINGS_SYSTEM_DISCORDRPC_DESC": "Alterna si la información de la canción se comparte\ncon Discord.",
 		"SETTINGS_SYSTEM_BUFFEREDINPUT": "Modo de Entrada con Búfer",
-		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "Cuando esto está activado, la resolución de entrada\npuede exceder los FPS y no se descartará ninguna\nentrada.\nCuando está desactivado, la resolución de entrada\nestá limitada por FPS y las entradas pueden\ndescartarse.",
+		"SETTINGS_SYSTEM_BUFFEREDINPUT_DESC": "Cuando esto está activado, la resolución de entrada\npuede exceder los FPS y no se descartará ninguna\nentrada.\nCuando está desactivado, la resolución de entrada\nestá limitada por los FPS y las entradas podrían\ndescartarse.",
 
 		// Settings - Gameplay
 		"SETTINGS_GAME_GLOBALOFFSET": "Offset Global",
@@ -173,44 +173,44 @@
 		"SETTINGS_GAME_CONTROLLERDEADZONE_DESC": "Ajusta la zona muerta del joystick para todos los\nmandos conectados. Puede ser de 10% a 90%.\n\nDespués de guardar, vuelva a conectar el mando\no reinicia el juego para aplicar los cambios.",
 
 		"SETTINGS_GAME_BADCOUNT": "Modo Kanpeki",
-		"SETTINGS_GAME_BADCOUNT_DESC": "Elige cuántos MALos se permiten antes de una\ncanción se pierde automáticamente.\nEstablezca esto en 0 para deshabilitar el modo.",
+		"SETTINGS_GAME_BADCOUNT_DESC": "Elige cuántos MALos se permiten antes de que una\ncanción sea fallada automáticamente.\nEstablece esto en 0 para deshabilitar el modo.",
 		"SETTINGS_GAME_NOTELOCK": "Modo de Bloqueo de Notas",
 		"SETTINGS_GAME_NOTELOCK_DESC": "Activa si golpear en espacios entre notas cuenta\ncomo un MAL.",
 		"SETTINGS_GAME_AILEVEL": "Nivel de IA",
-		"SETTINGS_GAME_AILEVEL_DESC": "Determina que tan precisa la IA es.\nSi 0, IA está desactivado.\nSi 1 o más, el J2 jugará como IA.\nDesactivado si AUTO de J2 está ON.",
+		"SETTINGS_GAME_AILEVEL_DESC": "Determina que tan precisa es la IA.\nSi es 0, la IA está desactivada.\nSi es 1 o más, el J2 jugará como IA.\nSe desactivará si el modo AUTO de J2 está activado.",
 		"SETTINGS_GAME_NORMALGAUGE": "Siempre Usar Medidor Normal",
 		"SETTINGS_GAME_NORMALGAUGE_DESC": "Fuerza el medidor normal en todo momento,\nindependientemente de los modificadores de un\npersonaje.",
 
-		"SETTINGS_GAME_AUTOP1": "Juego Auto de Jugador 1",
+		"SETTINGS_GAME_AUTOP1": "Juego AUTO de Jugador 1",
 		"SETTINGS_GAME_AUTOP1_DESC": "Activa si el jugador 1 juega automáticamente.",
-		"SETTINGS_GAME_AUTOP2": "Juego Auto de Jugador 2",
+		"SETTINGS_GAME_AUTOP2": "Juego AUTO de Jugador 2",
 		"SETTINGS_GAME_AUTOP2_DESC": "Activa si jugador 2 juega automáticamente.",
 		"SETTINGS_GAME_AUTOROLL": "Velocidad de Redoble",
-		"SETTINGS_GAME_AUTOROLL_DESC": "Cuando auto está activado, redobles serán\nautomáticamente golpear estas veces al segundo.\nNo tiene efecto en globos.\n0 desactiva redoble auto, y el valor máximo es un\ngolpe al fotograma.",
+		"SETTINGS_GAME_AUTOROLL_DESC": "Cuando AUTO está activado, los redobles se\ngolpearán automáticamente esta cantidad de veces\npor segundo.\nNo tiene efecto en globos.\n0 desactiva redoble auto, y el valor máximo es un\ngolpe por fotograma.",
 
 		"SETTINGS_GAME_NOINFO": "Modo Sin Información",
-		"SETTINGS_GAME_NOINFO_DESC": "Activa si la información de la canción se muestra.\nActivar esto se deshabilitará la información de la\ncanción.\nDesactivar esto se habilitará la información de la\ncanción.\n",
+		"SETTINGS_GAME_NOINFO_DESC": "Oculta la información de la canción que se muestra.\nAl activar esto se deshabilitará la información de la\ncanción.\nDesactivar esto habilitará la información de la\ncanción.\n",
 		"SETTINGS_GAME_COMBODISPLAY": "Visualización de Combo Mínimo",
 		"SETTINGS_GAME_COMBODISPLAY_DESC": "Elije el número inicial en el que se muestra el combo.\nSe puede especificar entre 1 y 99999.",
 		"SETTINGS_GAME_SCOREDISPLAY": "Alternar Visualización de Punto",
 		"SETTINGS_GAME_SCOREDISPLAY_DESC": "Muestra los juicios Bien/Vale/Mal actuales en la\nparte inferior izquierda.\n(Solo para un Jugador)",
-		"SETTINGS_GAME_BRANCHANIME": "Conjunto de Animación de Rama",
+		"SETTINGS_GAME_BRANCHANIME": "Conjunto de Animación de Ruta",
 		"SETTINGS_GAME_BRANCHANIME_DESC": "Cambia el conjunto de animación usado cuando una\npartitura se ramifica.\nTYPE-A: Gen-2\nTYPE-B: Gen-3\n",
 
 		"SETTINGS_GAME_DEFAULTDIFF": "Dificultad Predeterminada",
 		"SETTINGS_GAME_DEFAULTDIFF_DESC": "Elije la dificultad predeterminada que se elegirá en\nla selección de la canción.\nSi no se elige Extra, no será visible a menos que se\npresione la tecla de flecha derecha en la dificultad\nExtrema de una canción aplicable.",
 		"SETTINGS_GAME_EXEXTRAANIME": "Usar Transiciones Extremo/Extra",
-		"SETTINGS_GAME_EXEXTRAANIME_DESC": "Reproduzca una animación definida por el aspecto\nmientras cambia entre Extremo y Extra.",
+		"SETTINGS_GAME_EXEXTRAANIME_DESC": "Reproduce una animación de la skin al cambiar\nentre Extremo y Extra.",
 
 		// Settings - Gameplay - Training Mode
 		"SETTINGS_TRAINING_SKIPCOUNT": "Cantidad de Saltar Compases",
-		"SETTINGS_TRAINING_SKIPCOUNT_DESC": "El número de compás para saltar mientras presiona\nSaltar Compases hacia Atrás o Adelante en Modo\nEntrenamiento.",
+		"SETTINGS_TRAINING_SKIPCOUNT_DESC": "El número de compás(es) para saltar mientras\npresionas Saltar Compases hacia Atrás o Adelante\nen Modo Entrenamiento.",
 		"SETTINGS_TRAINING_JUMPINTERVAL": "Intervalo de Tiempo de Saltar Compases",
-		"SETTINGS_TRAINING_JUMPINTERVAL_DESC": "La cantidad de tiempo en milisegundos necesaria\npara tocar repetidamente las teclas Azules Izquierda\no Derecha saltar a un compás marcado en Modo\nEntrenamiento.",
+		"SETTINGS_TRAINING_JUMPINTERVAL_DESC": "La cantidad de tiempo en milisegundos necesaria\npara tocar repetidamente las teclas Azules Izquierda\no Derecha y saltar a un compás marcado en Modo\nEntrenamiento.",
 
 		// Settings - Gameplay - Unlockables
 		"SETTINGS_GAME_IGNORESONGUNLOCKABLES": "Ignorar Desbloqueables de Canciones",
-		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Hace que todas las canciones estén disponibles\nignorando SongUnlockables.db3.\nEsto no agrega entradas de desbloqueo a Saves.db3.\nLas notificaciones de desbloqueo seguirán\napareciendo en los resultados.\n\n<c.#f0ad4e>ADVERTENCIA\nTener esta opción ON invalida cualquier speedrun.</c>",
+		"SETTINGS_GAME_IGNORESONGUNLOCKABLES_DESC": "Hace que todas las canciones estén disponibles\nignorando SongUnlockables.db3.\nEsto no agrega entradas de desbloqueo a Saves.db3.\nLas notificaciones de desbloqueo seguirán\napareciendo en los resultados.\n\n<c.#f0ad4e>ADVERTENCIA\nTener esta opción activada invalida cualquier\nspeedrun.</c>",
 
 		// Settings - Broken/Unused/Might Deprecate/Might Update
 		// Translate these anyways, even if their future is uncertain.
@@ -220,10 +220,10 @@
 		"SETTINGS_SYSTEM_TIMESTRETCH_DESC": "No se está seguro de qué hace esta opción.\nUtiliza más potencia de CPU, y puede causar\nproblemas de sonido por debajo de 0,9 veces\nla velocidad de reproducción.",
 		"SETTINGS_SYSTEM_FASTRENDER": "Renderizado Rápido",
 		"SETTINGS_SYSTEM_FASTRENDER_DESC": "Alterna si las imágenes se procesan antes de cargar\nlas canciones.",
-		"SETTINGS_GAME_BRANCHGUIDE": "Guía de Rama",
-		"SETTINGS_GAME_BRANCHGUIDE_DESC": "Activa una guía numérica que se muestra para\nver cuál rama se va a escoger.\nNo se muestra en modo auto.",
+		"SETTINGS_GAME_BRANCHGUIDE": "Guía de Ruta",
+		"SETTINGS_GAME_BRANCHGUIDE_DESC": "Activa una guía numérica que se muestra para ver\ncuál ruta se va a escoger.\nNo se muestra en modo AUTO.",
 		"SETTINGS_GAME_BIGNOTEJUDGE": "Juicio de Nota Grande",
-		"SETTINGS_GAME_BIGNOTEJUDGE_DESC": "Alterna si las notas grandes recompensan ser\ngolpeadas con 2 teclas.\nSi está activado, usar 1 tecla provocará un retraso\nvisual antes de que desaparezcan.\nGolpes con 2 teclas otorgarán el doble de puntos.\nSi está desactivado, usar 1 tecla los golpeará como\nuna nota normal.\nAún se otorgarán puntos dobles.\nIntentar golpearlos con 2 teclas puede hacer que se\ngolpee la siguiente nota.",
+		"SETTINGS_GAME_BIGNOTEJUDGE_DESC": "Alterna si golpear las notas grandes con 2 teclas\nte da una recompensa (el doble de puntos).\nSi está activado, usar 1 tecla provocará un retraso\nvisual antes de que desaparezcan.\nGolpes con 2 teclas otorgarán el doble de puntos.\nSi está desactivado, usar 1 tecla los golpeará como\nuna nota normal.\nAún se otorgarán puntos dobles.\nIntentar golpearlos con 2 teclas puede hacer que se\ngolpee la siguiente nota.",
 		"SETTINGS_GAME_SURVIVAL": "Modo Supervivencia",
 		"SETTINGS_GAME_SURVIVAL_DESC": "Este modo está roto.\nImplementa un sistema medidor parecido a los\ncursos de StepMania, pero hay código faltante así\nque su funcionamiento es limitado.",
 		"SETTINGS_GAME_SCOREMODE": "Modo de Puntos",
@@ -248,14 +248,14 @@
 		"SETTINGS_KEYASSIGN_SYSTEM_QUICKHEYA_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para la personalización del\njugador.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
 		"SETTINGS_KEYASSIGN_SYSTEM_SONGSORT": "Cambiar Orden de Canciones",
 		"SETTINGS_KEYASSIGN_SYSTEM_SONGSORT_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para reordenar las canciones.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
-		"SETTINGS_KEYASSIGN_SYSTEM_AUTO1P": "Alternar Auto (J1)",
-		"SETTINGS_KEYASSIGN_SYSTEM_AUTO1P_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para alternar Auto de J1.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
-		"SETTINGS_KEYASSIGN_SYSTEM_AUTO2P": "Alternar Auto (J2)",
-		"SETTINGS_KEYASSIGN_SYSTEM_AUTO2P_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para alternar Auto de J2.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
+		"SETTINGS_KEYASSIGN_SYSTEM_AUTO1P": "Alternar AUTO (J1)",
+		"SETTINGS_KEYASSIGN_SYSTEM_AUTO1P_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para alternar AUTO de J1.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
+		"SETTINGS_KEYASSIGN_SYSTEM_AUTO2P": "Alternar AUTO (J2)",
+		"SETTINGS_KEYASSIGN_SYSTEM_AUTO2P_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para alternar AUTO de J2.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
 		"SETTINGS_KEYASSIGN_SYSTEM_TRAINING": "Alternar Modo Entrenamiento",
 		"SETTINGS_KEYASSIGN_SYSTEM_TRAINING_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para alternar el Modo\nEntrenamiento.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
 		"SETTINGS_KEYASSIGN_SYSTEM_BGMOVIEDISPLAY": "Visualización de Reproducción de Video de Ciclo",
-		"SETTINGS_KEYASSIGN_SYSTEM_BGMOVIEDISPLAY_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para los modos de visualización\nde reproducción de video de ciclo.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
+		"SETTINGS_KEYASSIGN_SYSTEM_BGMOVIEDISPLAY_DESC": "Asignación de tecla del sistema:\nAsigna cualquier tecla para los modos de\nvisualización de reproducción de video de ciclo.\n(Solo puedes usar el teclado. No puedes usar mandos\nde juego.)",
 
 		// Key Assignment - Gameplay
 		"SETTINGS_KEYASSIGN_GAME_DECIDE": "Confirmar",
@@ -325,26 +325,26 @@
 		// Key Assignment - Training
 		"SETTINGS_KEYASSIGN_TRAINING_PAUSE": "Pausa Entrenamiento",
 		"SETTINGS_KEYASSIGN_TRAINING_PAUSE_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para pausar.",
-		"SETTINGS_KEYASSIGN_TRAINING_AUTO": "Alternar Auto",
-		"SETTINGS_KEYASSIGN_TRAINING_AUTO_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para alternar auto.",
+		"SETTINGS_KEYASSIGN_TRAINING_AUTO": "Alternar AUTO",
+		"SETTINGS_KEYASSIGN_TRAINING_AUTO_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para alternar AUTO.",
 		"SETTINGS_KEYASSIGN_TRAINING_BOOKMARK": "Agregar/Quitar Marcador",
 		"SETTINGS_KEYASSIGN_TRAINING_BOOKMARK_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para agregar o quitar\nmarcadores.",
 		"SETTINGS_KEYASSIGN_TRAINING_INCREASESCROLL": "Aumentar Velocidad de Desplazamiento",
-		"SETTINGS_KEYASSIGN_TRAINING_INCREASESCROLL_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para aumentar velocidad de\ndesplazamiento.",
+		"SETTINGS_KEYASSIGN_TRAINING_INCREASESCROLL_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para aumentar la velocidad de\ndesplazamiento.",
 		"SETTINGS_KEYASSIGN_TRAINING_DECREASESCROLL": "Disminuir Velocidad de Desplazamiento",
-		"SETTINGS_KEYASSIGN_TRAINING_DECREASESCROLL_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para disminuir velocidad de\ndesplazamiento.",
+		"SETTINGS_KEYASSIGN_TRAINING_DECREASESCROLL_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para disminuir la velocidad de\ndesplazamiento.",
 		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED": "Aumentar Velocidad de Canción",
-		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para aumentar velocidad de\nla canción.",
+		"SETTINGS_KEYASSIGN_TRAINING_INCREASESPEED_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para aumentar la velocidad de\nla canción.",
 		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED": "Disminuir Velocidad de Canción",
-		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para disminuir velocidad de\nla canción.",
-		"SETTINGS_KEYASSIGN_TRAINING_BRANCHNORMAL": "Establecer Rama en Normal",
-		"SETTINGS_KEYASSIGN_TRAINING_BRANCHNORMAL_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para establecer la rama de\nuna partitura en normal.",
-		"SETTINGS_KEYASSIGN_TRAINING_BRANCHEXPERT": "Establecer Rama en Experto",
-		"SETTINGS_KEYASSIGN_TRAINING_BRANCHEXPERT_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para establecer la rama de\nuna partitura en experto.",
-		"SETTINGS_KEYASSIGN_TRAINING_BRANCHMASTER": "Establecer Rama en Maestro",
-		"SETTINGS_KEYASSIGN_TRAINING_BRANCHMASTER_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para establecer la rama de\nuna partitura en maestro.",
+		"SETTINGS_KEYASSIGN_TRAINING_DECREASESPEED_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para disminuir la velocidad de\nla canción.",
+		"SETTINGS_KEYASSIGN_TRAINING_BRANCHNORMAL": "Cambiar Ruta a Normal",
+		"SETTINGS_KEYASSIGN_TRAINING_BRANCHNORMAL_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para cambiar la ruta de\nuna partitura a Normal.",
+		"SETTINGS_KEYASSIGN_TRAINING_BRANCHEXPERT": "Cambiar Ruta a Experto",
+		"SETTINGS_KEYASSIGN_TRAINING_BRANCHEXPERT_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para cambiar la ruta de\nuna partitura a Experto.",
+		"SETTINGS_KEYASSIGN_TRAINING_BRANCHMASTER": "Cambiar Ruta a Maestro",
+		"SETTINGS_KEYASSIGN_TRAINING_BRANCHMASTER_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para cambiar la ruta de\nuna partitura a Maestro.",
 		"SETTINGS_KEYASSIGN_TRAINING_MOVEFORWARD": "Avanzar Compás",
-		"SETTINGS_KEYASSIGN_TRAINING_MOVEFORWARD_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para avanzar una compás.",
+		"SETTINGS_KEYASSIGN_TRAINING_MOVEFORWARD_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para avanzar un compás.",
 		"SETTINGS_KEYASSIGN_TRAINING_MOVEBACKWARD": "Retroceder Compás",
 		"SETTINGS_KEYASSIGN_TRAINING_MOVEBACKWARD_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para retroceder un compás.",
 		"SETTINGS_KEYASSIGN_TRAINING_SKIPFORWARD": "Saltar Compases hacia Adelante",
@@ -354,7 +354,7 @@
 		"SETTINGS_KEYASSIGN_TRAINING_JUMPTOFIRST": "Saltar a Primer Compás",
 		"SETTINGS_KEYASSIGN_TRAINING_JUMPTOFIRST_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para saltar al primer\ncompás.",
 		"SETTINGS_KEYASSIGN_TRAINING_JUMPTOLAST": "Saltar a Último Compás",
-		"SETTINGS_KEYASSIGN_TRAINING_JUMPTOLAST_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para saltar a la última\ncompás.",
+		"SETTINGS_KEYASSIGN_TRAINING_JUMPTOLAST_DESC": "Asignación de tecla de tambor:\nAsigna cualquier tecla para saltar al último\ncompás.",
 
 		// Title Screen
 		"TITLE_MODE_TAIKO": "Modo Taiko",
@@ -482,7 +482,7 @@
 		"HEYA_DESCRIPTION_EFFECTS_GAUGETYPE_EXTREME": "Extremo",
 		"HEYA_DESCRIPTION_EFFECTS_GAUGETYPE_NORMAL_DESC": "¡Termina la canción dentro de la zona de completado del medidor!",
 		"HEYA_DESCRIPTION_EFFECTS_GAUGETYPE_HARD_DESC": "¡El medidor empieza lleno y se agota bruscamente en cada falla!\n¡Ten cuidado, si el valor del medidor llega a 0, tu partida está automáticamente perdida!",
-		"HEYA_DESCRIPTION_EFFECTS_GAUGETYPE_EXTREME_DESC": "¡El medidor empieza lleno y se agota bruscamente en cada falla!\nUn poder extraño parece reducir el margen de error por la canción...",
+		"HEYA_DESCRIPTION_EFFECTS_GAUGETYPE_EXTREME_DESC": "¡El medidor empieza lleno y se agota bruscamente en cada falla!\nUn poder extraño parece reducir el margen de error durante la canción...",
 		// {0}: Percentage of mines
 		"HEYA_DESCRIPTION_EFFECTS_BOMBFACTOR": "Factor de Bomba: {0}% de notas se convierten a minas en Buscaminas",
 		// {0}: Percentage of fuse rolls
@@ -491,13 +491,13 @@
 		"HEYA_DESCRIPTION_EFFECTS_SHOWADLIB": "Notas de <c.#c4ffe2>ADLib</c> se vuelven visibles",
 		// {0}: # of auto-rolls per second
 		"HEYA_DESCRIPTION_EFFECTS_AUTOROLL": "<c.#ffff00>Redoble</c> automáticamente en {0} golpes/s",
-		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Divide</c> <c.#0088ff>Carriles</c>",
+		"HEYA_DESCRIPTION_EFFECTS_SPLITLANE": "<c.#ff4040>Separar</c> <c.#0088ff>Carriles</c>",
 		// {0}: Coin multiplier
 		"HEYA_DESCRIPTION_COIN_MULTIPLIER": "Multiplicador de Monedas: x{0}",
 
 		// Unlock requirements & messages (Any Menu)
 		"UNLOCK_CONDITION_INVALID": "[ERROR] Condición no valida",
-		"UNLOCK_CONDITION_SHOP": "Artículo está solamente disponible en la Tienda.", // cs
+		"UNLOCK_CONDITION_SHOP": "Este artículo está disponible solamente en la Tienda.", // cs
 		// {0}: Price of item
 		"UNLOCK_CONDITION_COST": "Precio: {0}", // ch, cs, cm
 		"UNLOCK_COIN_BOUGHT": "¡Artículo comprado!",
@@ -560,21 +560,21 @@
 		"UNLOCK_CONDITION_TRIGGER_0": "Desactiva",
 		"UNLOCK_CONDITION_TRIGGER_1": "Activa",
 
-		"UNLOCK_CONDITION_TYPE_l": "es menos que",
+		"UNLOCK_CONDITION_TYPE_l": "es menor que",
 		"UNLOCK_CONDITION_TYPE_le": "es menor o igual a",
 		"UNLOCK_CONDITION_TYPE_e": "es igual a",
-		"UNLOCK_CONDITION_TYPE_me": "es más o igual a",
-		"UNLOCK_CONDITION_TYPE_m": "es más que",
+		"UNLOCK_CONDITION_TYPE_me": "es mayor o igual a",
+		"UNLOCK_CONDITION_TYPE_m": "es mayor que",
 		"UNLOCK_CONDITION_TYPE_d": "no es igual a",
 
 		"UNLOCK_CONDITION_REQUIRE_PLAY": "Juega",
 		"UNLOCK_CONDITION_REQUIRE_PLAY_MORE": "Juega",
-		"UNLOCK_CONDITION_REQUIRE_ASSIST": "Obtén un Completado Asistido en",
-		"UNLOCK_CONDITION_REQUIRE_ASSIST_MORE": "Obtén al menos un Completado Asistido en",
-		"UNLOCK_CONDITION_REQUIRE_CLEAR": "Obtén un Completado en",
-		"UNLOCK_CONDITION_REQUIRE_CLEAR_MORE": "Obtén al menos un Completado en",
-		"UNLOCK_CONDITION_REQUIRE_FC": "Obtén un Combo Completo en",
-		"UNLOCK_CONDITION_REQUIRE_FC_MORE": "Obtén al menos un Combo Completo en",
+		"UNLOCK_CONDITION_REQUIRE_ASSIST": "Supera con asistencia",
+		"UNLOCK_CONDITION_REQUIRE_ASSIST_MORE": "Supera con asistencia al menos",
+		"UNLOCK_CONDITION_REQUIRE_CLEAR": "Supera",
+		"UNLOCK_CONDITION_REQUIRE_CLEAR_MORE": "Supera al menos",
+		"UNLOCK_CONDITION_REQUIRE_FC": "Obtén un Full Combo en",
+		"UNLOCK_CONDITION_REQUIRE_FC_MORE": "Obtén al menos un Full Combo en",
 		"UNLOCK_CONDITION_REQUIRE_PERFECT": "Obtén un Perfecto en",
 		"UNLOCK_CONDITION_REQUIRE_PERFECT_MORE": "Obtén un Perfecto en",
 
@@ -602,9 +602,9 @@
 		"MOD_SPEED": "Vel. de Desplazamiento",
 
 		"MOD_HIDE": "Notas Invisibles",
-		"MOD_STEALTH": "Cauteloso",
+		"MOD_STEALTH": "Sigilo",
 
-		"MOD_FLIP": "Notas Opuestas",
+		"MOD_FLIP": "Notas invertidas",
 
 		"MOD_RANDOM": "Aleatorio",
 		"MOD_RANDOM_SHUFFLE": "Mezclado",
@@ -612,12 +612,12 @@
 
 		"MOD_TIMING": "Timing",
 		"MOD_TIMING1": "Relajado",
-		"MOD_TIMING2": "Leve",
+		"MOD_TIMING2": "Permisivo",
 		"MOD_TIMING3": "Normal",
 		"MOD_TIMING4": "Estricto",
-		"MOD_TIMING5": "Rigoroso",
+		"MOD_TIMING5": "Riguroso",
 
-		"MOD_JUSTICE": "Modo Estricto",
+		"MOD_JUSTICE": "Modo Justo",
 		"MOD_SAFE": "Seguro",
 		"MOD_JUST": "Exacto",
 
@@ -640,7 +640,7 @@
 		"MOD_FUN_MINESWEEPER": "Buscaminas"
 	},
 	// In the case that a key is missing, this message will display, with the name of the missing/unknown key.
-	"InvalidKey": "La llave no se ha encontrado: {0}",
+	"InvalidKey": "La clave no se ha encontrado: {0}",
 	// If a skin does not include a font for a specific language, the game will fallback to this language's fonts. This ensures that all text for all languages can be clearly read.
 	// Font name can be a file, or the name of an already installed font (i.e. "Arial"). If using a font name instead of a file name, please ensure that the user already has this font installed on their computer.
 	"FontName": "../font.ttf",

--- a/install-dotnet-sdk.sh
+++ b/install-dotnet-sdk.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 source /etc/os-release
 
 if [[ "$ID" == "ubuntu" || "$ID_LIKE" == *"ubuntu"* ]]; then
@@ -24,4 +24,6 @@ elif [[ "$ID" == "fedora" || "$ID_LIKE" == *"fedora"* || "$ID_LIKE" == *"rhel"* 
     sudo dnf install -y dotnet-sdk-8.0
 elif [[ "$ID" == "arch" || "$ID_LIKE" == *"arch"* ]]; then
     sudo pacman -S --noconfirm dotnet-sdk
+else
+  echo "Your OS is not supported by the script: ${ID}"
 fi

--- a/install-dotnet-sdk.sh
+++ b/install-dotnet-sdk.sh
@@ -1,12 +1,27 @@
+#!/bin/bash
 
-os=$(cat /etc/os-release | grep -w 'ID')
+source /etc/os-release
 
-if [[ "$os" == "ID=ubuntu" ]]; then
-
-    wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-    sudo dpkg -i packages-microsoft-prod.deb
-    rm packages-microsoft-prod.deb
-    sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
-else
-    echo "System not supported"
+if [[ "$ID" == "ubuntu" || "$ID_LIKE" == *"ubuntu"* ]]; then
+    sudo apt-get update
+    if ! sudo apt-get install -y dotnet-sdk-8.0; then
+        echo "The package was not found by your package manager, setting up alternate repository."
+        
+        MAJOR_VERSION=$(echo "$VERSION_ID" | cut -d. -f1)
+        
+        if [[ "$MAJOR_VERSION" -ge 26 ]]; then
+            echo "Adding dotnet backports PPA..."
+            sudo add-apt-repository ppa:dotnet/backports -y
+        else
+            echo "Adding microsoft repository..."
+            wget "https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb" -O packages-microsoft-prod.deb
+            sudo dpkg -i packages-microsoft-prod.deb
+            rm packages-microsoft-prod.deb
+        fi
+        sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
+    fi
+elif [[ "$ID" == "fedora" || "$ID_LIKE" == *"fedora"* || "$ID_LIKE" == *"rhel"* ]]; then
+    sudo dnf install -y dotnet-sdk-8.0
+elif [[ "$ID" == "arch" || "$ID_LIKE" == *"arch"* ]]; then
+    sudo pacman -S --noconfirm dotnet-sdk
 fi

--- a/install-dotnet-sdk.sh
+++ b/install-dotnet-sdk.sh
@@ -1,4 +1,12 @@
-wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-rm packages-microsoft-prod.deb
-sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
+
+os=$(cat /etc/os-release | grep -w 'ID')
+
+if [[ "$os" == "ID=ubuntu" ]]; then
+
+    wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    rm packages-microsoft-prod.deb
+    sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
+else
+    echo "System not supported"
+fi


### PR DESCRIPTION
the `install-dotnet-sdk.sh` script now has system checks based on the `/etc/os-release` file to handle the installation on various distros and handle the repository management for ubuntu since some versions require adding the dotnet backports PPA.

fixed grammar and some terminology in the spanish translation file where previous translations were too literal from their english counterparts