### PR TITLE
fix song not found in 0.6.0.108 and related issues, and shrandonm's fixes backported from 0.6.1

### DIFF
--- a/FDK/src/01.Framework/Rendering/Angle/AngleContext.cs
+++ b/FDK/src/01.Framework/Rendering/Angle/AngleContext.cs
@@ -101,10 +101,16 @@ public class AngleContext : IGLContext {
 		Egl.Initialize(Display, out int major, out int minor);
 		Egl.BindAPI(RenderApi.ES);
 
+		// 8-bit color channels MUST be requested explicitly: with no size constraints, eglChooseConfig sorts
+		// smaller buffers first, and on the D3D11 backend a 16-bit (RGB565) config wins — visible banding on
+		// gradients. Requesting nonzero R/G/B flips the sort to prefer the deepest matching config (8888).
 		IntPtr[] configs = new IntPtr[1];
 		int[] configAttributes = new int[]
 		{
 			Egl.RENDERABLE_TYPE, Egl.OPENGL_ES2_BIT,
+			Egl.RED_SIZE, 8,
+			Egl.GREEN_SIZE, 8,
+			Egl.BLUE_SIZE, 8,
 			Egl.BUFFER_SIZE, 0,
 			Egl.NONE
 		};

--- a/FDK/src/03.Sound/CSoundDeviceBASS.cs
+++ b/FDK/src/03.Sound/CSoundDeviceBASS.cs
@@ -79,7 +79,7 @@ public class CSoundDeviceBASS : ISoundDevice {
 
 		int freq = 44100;
 
-		if (!Bass.Init(-1, freq, DeviceInitFlags.Default))
+		if (!Bass.Init(-1, freq, DeviceInitFlags.Latency))
 			throw new Exception(string.Format("BASS の初期化に失敗しました。(BASS_Init)[{0}]", Bass.LastError.ToString()));
 
 		if (!Bass.Configure(Configuration.UpdatePeriod, updatePeriod)) {
@@ -90,6 +90,7 @@ public class CSoundDeviceBASS : ISoundDevice {
 		}
 
 		Bass.Configure(Configuration.PlaybackBufferLength, bufferSize);
+		Bass.Configure(Configuration.DeviceBufferLength, bufferSize);
 		Bass.Configure(Configuration.LogarithmicVolumeCurve, true);
 
 		this.STREAMPROC = new StreamProcedure(StreamProc);

--- a/FDK/src/03.Sound/SoundManager.cs
+++ b/FDK/src/03.Sound/SoundManager.cs
@@ -301,7 +301,7 @@ public class SoundManager   // : CSound
 		//-----------------
 		switch (SoundDeviceType) {
 			case ESoundDeviceType.Bass:
-				SoundDevice = new CSoundDeviceBASS(SoundDelayBASS, SoundUpdatePeriodBASS);
+				SoundDevice = new CSoundDeviceBASS(updatePeriod: SoundUpdatePeriodBASS, bufferSize: SoundDelayBASS);
 				break;
 
 			case ESoundDeviceType.ExclusiveWASAPI:

--- a/OpenTaiko/src/Common/OpenTaiko.cs
+++ b/OpenTaiko/src/Common/OpenTaiko.cs
@@ -568,9 +568,9 @@ internal class OpenTaiko : Game {
 					case CStage.EStage.SongLoading:
 						if (EnumSongs != null) {
 							#region [ (特定条件時) 曲検索スレッドの起動_開始 ]
-							if (rCurrentStage.eStageID == CStage.EStage.StartUp &&
-								rCurrentStage.ePhaseID == CStage.EPhase.Startup_Complete &&
-								!EnumSongs.IsSongListEnumStarted) {
+							if ((rCurrentStage.eStageID != CStage.EStage.StartUp || rCurrentStage.ePhaseID == CStage.EPhase.Startup_Complete)
+								&& !EnumSongs.IsSongListEnumStarted
+								) {
 								actEnumSongs.Activate();
 								if (!ConfigIni.PreAssetsLoading) {
 									actEnumSongs.CreateManagedResource();

--- a/OpenTaiko/src/Components/CSongReplay.cs
+++ b/OpenTaiko/src/Components/CSongReplay.cs
@@ -59,8 +59,10 @@ class CSongReplay {
 		storedPlayer = player;
 	}
 
+	public void tStartRegisterInput() => allInputs = new();
+
 	public void tRegisterInput(double timestamp, byte keypress) {
-		allInputs.Add(Tuple.Create(timestamp, keypress));
+		allInputs?.Add(Tuple.Create(timestamp, keypress));
 	}
 
 	#region [Dan methods]
@@ -336,7 +338,7 @@ class CSongReplay {
 	private int storedPlayer;
 	private int danAccumulatedScore = 0;
 
-	private List<Tuple<double, byte>> allInputs = new List<Tuple<double, byte>>();
+	private List<Tuple<double, byte>>? allInputs = null;
 
 	#endregion
 

--- a/OpenTaiko/src/Stages/01.StartUp/CStage起動.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/CStage起動.cs
@@ -92,7 +92,7 @@ internal class CStage起動 : CStage {
 				this.list進行文字列.Add("");
 
 				es = new CEnumSongs();
-				es.StartEnumFromCache();                                        // 曲リスト取得(別スレッドで実行される)
+				es.StartLoadSystemSound();
 				base.IsFirstDraw = false;
 				return 0;
 			}
@@ -210,11 +210,13 @@ internal class CStage起動 : CStage {
 					ePhaseID = EPhase.Startup_Complete;
 				}
 			} else {
-				if (es != null && es.IsSongListEnumCompletelyDone)                          // 曲リスト作成が終わったら
+				if (es != null && es.IsSongListEnumCompletelyDone)                          // System sound loaded
 				{
-					OpenTaiko.Songs管理 = (es != null) ? es.Songs管理 : null;      // 最後に、曲リストを拾い上げる
+					es.Abort(); // reset for further enumerating
 					ePhaseID = EPhase.Startup_Complete;
+				}
 
+				if (ePhaseID == EPhase.Startup_Complete) {
 					if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)) {
 						OpenTaiko.Skin.soundDecideSFX.tPlay();
 						return 1;

--- a/OpenTaiko/src/Stages/01.StartUp/CStage起動.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/CStage起動.cs
@@ -203,7 +203,11 @@ internal class CStage起動 : CStage {
 					langSelectIndex = Math.Min(langSelectIndex + 1, CLangManager.Languages.Length - 1);
 				} else if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.UpArrow) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.LeftArrow)) {
 					langSelectIndex = Math.Max(langSelectIndex - 1, 0);
-				} else if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)) {
+				} else if (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.Decide)
+					|| OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed)
+					|| OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed)
+					|| OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)
+					) {
 					OpenTaiko.Skin.soundDecideSFX.tPlay();
 					OpenTaiko.ConfigIni.sLang = CLangManager.intToLang(langSelectIndex);
 					CLangManager.langAttach(OpenTaiko.ConfigIni.sLang);
@@ -217,7 +221,11 @@ internal class CStage起動 : CStage {
 				}
 
 				if (ePhaseID == EPhase.Startup_Complete) {
-					if (OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)) {
+					if (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.Decide)
+						|| OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed)
+						|| OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed)
+						|| OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)
+						) {
 						OpenTaiko.Skin.soundDecideSFX.tPlay();
 						return 1;
 					}

--- a/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
+++ b/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
@@ -86,12 +86,9 @@ internal class CEnumSongs                           // #27060 2011.2.7 yyagi 曲
 
 	}
 
-	/// <summary>
-	/// 曲リストのキャッシュ(songlist.db)取得スレッドの開始
-	/// </summary>
-	public void StartEnumFromCache() {
-		this.thDTXFileEnumerate = new Thread(new ThreadStart(this.t曲リストの構築1));
-		this.thDTXFileEnumerate.Name = "曲リストの構築";
+	public void StartLoadSystemSound() {
+		this.thDTXFileEnumerate = new Thread(new ThreadStart(this.LoadSystemSound));
+		this.thDTXFileEnumerate.Name = "LoadSystemSound";
 		this.thDTXFileEnumerate.IsBackground = true;
 		this.thDTXFileEnumerate.Start();
 	}
@@ -204,10 +201,7 @@ internal class CEnumSongs                           // #27060 2011.2.7 yyagi 曲
 
 
 
-	/// <summary>
-	/// songlist.dbからの曲リスト構築
-	/// </summary>
-	public void t曲リストの構築1() {
+	public void LoadSystemSound() {
 		// ！注意！
 		// 本メソッドは別スレッドで動作するが、プラグイン側でカレントディレクトリを変更しても大丈夫なように、
 		// すべてのファイルアクセスは「絶対パス」で行うこと。(2010.9.16)

--- a/OpenTaiko/src/Stages/02.Title/CStageTitle.cs
+++ b/OpenTaiko/src/Stages/02.Title/CStageTitle.cs
@@ -261,7 +261,10 @@ internal class CStageTitle : CStage {
 
 
 				if (OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.Decide)
-					|| OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)) {
+					|| OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.RRed)
+					|| OpenTaiko.Pad.bPressed(EInstrumentPad.Drums, EPad.LRed)
+					|| OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Return)
+					) {
 					if (bプレイヤーエントリー && this.ctSaveLoaded.IsEnded) {
 						if (n現在の選択行プレイヤーエントリー == 0 || n現在の選択行プレイヤーエントリー == 2) {
 							if (!bプレイヤーエントリー決定) {

--- a/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
+++ b/OpenTaiko/src/Stages/05.SongSelect/CStageSongSelect.cs
@@ -829,8 +829,8 @@ internal class CStageSongSelect : CStage {
 					}
 				} else if (!this.actSortSongs.bIsActivePopupMenu && !this.actQuickConfig.bIsActivePopupMenu && !this.actDifficultySelectionScreen.bIsDifficltSelect && !actNewHeya.IsOpend) {
 					#region [ ESC ]
-					if ((OpenTaiko.Pad.bPressedDGB(EPad.Cancel) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape)) && (OpenTaiko.SongMount.rCurrentlySelectedSong != null))// && (  ) ) )
-						if (OpenTaiko.SongMount.rCurrentlySelectedSong.rParentNode == null) {   // [ESC]
+					if ((OpenTaiko.Pad.bPressedDGB(EPad.Cancel) || OpenTaiko.InputManager.Keyboard.KeyPressed((int)SlimDXKeys.Key.Escape)))
+						if (OpenTaiko.SongMount.rCurrentlySelectedSong?.rParentNode == null) {  // [ESC]
 							this.actPresound.tStopSound();
 							CSongSelectSongManager.enable();
 

--- a/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/OpenTaiko/src/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -212,6 +212,11 @@ internal class CStage演奏ドラム画面 : CStage演奏画面共通 {
 		int iPrevTopChipMax = this.nCurrentTopChip.Max();
 		base.t数値の初期化(b演奏記録, b演奏状態);
 
+		if (b演奏記録) {
+			for (int i = 0; i < OpenTaiko.MAX_PLAYERS; ++i)
+				OpenTaiko.ReplayInstances[i]?.tStartRegisterInput();
+		}
+
 		if (b演奏状態) {
 			this.actGame.t叩ききりまショー_初期化();
 

--- a/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
+++ b/OpenTaiko/src/Stages/11.Heya/CStageHeya.cs
@@ -101,7 +101,7 @@ class CStageHeya : CStage {
 		idx = 1;
 		if (OpenTaiko.SaveFileInstances[iPlayer].data.UnlockedNameplateIds != null) {
 			foreach (var _ref in OpenTaiko.SaveFileInstances[iPlayer].data.UnlockedNameplateIds) {
-				var item = OpenTaiko.Databases.DBNameplateUnlockables.data?[_ref];
+				var item = OpenTaiko.Databases.DBNameplateUnlockables.data?.GetValueOrDefault(_ref);
 				if (item != null) {
 					this.ttkTitles[idx] = new TitleTextureKey(item.nameplateInfo.cld.GetString(""), this.pfHeyaFont, Color.Black, Color.Transparent, 1000);
 					this.titlesKeys[idx] = _ref;


### PR DESCRIPTION
* [Fix] Song list enumeration not started at launch every next time since 0.6.0.108, because StartUp stage had always been mistreating system sound done loading as song list done enumerating long before exposed as a bug in 0.6.0.108
* [Fix] Lessen song list enumeration start condition to not rely on transition edge
* [Feat] Can now hit don on the main menu to enter the game by shrandonm (adapted)
* [Fix] Could not exit from song select screen if no songs are available
* [Fix] Unknown nameplate ID crashed 0.6.0 Heya screen
* [Fix] Stop replay from containing old inputs before retrying [0.6.1 backport]
* [Fix] mac BASS audio driver configuration by shrandonm (adapted)
* [Fix] dx11 color issue [0.6.1 backport]