### PR TITLE
[0.6.1] Fix song enumeration warning crash, video decoding optimization, remove unintended dancer, time correction accurary and precision ...

### DIFF
--- a/FDK/src/03.Sound/CSoundTimer.cs
+++ b/FDK/src/03.Sound/CSoundTimer.cs
@@ -79,11 +79,11 @@ public class CSoundTimer : CTimerBase {
 	const int msSnapTimersInternal = 1000;
 
 	private void SnapTimers() {
-		this.msDInputTimerOffset = this.ctDInputTimer.SystemTimeMs;
-		this.msSoundTimerOffset = this.SystemTimeMs;
+		this.msDInputTimerOffset = this.ctDInputTimer.SystemTimeMsReal;
+		this.msSoundTimerOffset = this.SystemTimeMsReal;
 	}
 	public long msGetPreciseNowSoundTimerTime()
-		=> this.msDInputTimeToSoundTimerTime(this.ctDInputTimer.SystemTimeMs);
+		=> this.msDInputTimeToSoundTimerTime(this.ctDInputTimer.SystemTimeMsReal);
 	private long msDInputTimeToSoundTimerTime(long msDInputTime) {
 		return msDInputTime - this.msDInputTimerOffset + this.msSoundTimerOffset;    // Timer違いによる時差を補正する
 	}

--- a/FDK/src/04.Graphics/CDecodedFrame.cs
+++ b/FDK/src/04.Graphics/CDecodedFrame.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Runtime.InteropServices;
 using FFmpeg.AutoGen;
 
 namespace FDK;
@@ -8,7 +7,6 @@ public class CDecodedFrame : IDisposable {
 	public CDecodedFrame(Size texsize) {
 		this.Using = false;
 		this.TexSize = texsize;
-		this.TexPointer = Marshal.AllocHGlobal(texsize.Width * TexSize.Height * 4);
 	}
 
 	public bool Using {
@@ -28,19 +26,34 @@ public class CDecodedFrame : IDisposable {
 		private set;
 	}
 
-	public unsafe CDecodedFrame UpdateFrame(double time, AVFrame* frame) {
-		this.Time = time;
-		Buffer.MemoryCopy(frame->data[0], (void*)this.TexPointer, frame->linesize[0] * frame->height, frame->linesize[0] * frame->height);
+	private unsafe AVFrame* _frame = ffmpeg.av_frame_alloc();
+	internal unsafe AVFrame* GetEmptyFrame() {
+		this.RemoveFrame();
 		this.Using = true;
-		return this;
+		return _frame;
 	}
 
-	public void RemoveFrame() {
+	public unsafe void UpdateFrame(double time) {
+		this.Time = time;
+		this.TexPointer = (IntPtr)this._frame->data[0];
+		this.Using = true;
+	}
+
+	public unsafe void RemoveFrame() {
+		ffmpeg.av_frame_unref(this._frame);
+		this.TexPointer = 0;
 		this.Using = false;
 	}
 
-	public void Dispose() {
+	public unsafe void Dispose() {
+		if (this._frame != null) {
+			fixed (AVFrame** pThisFrame = &this._frame) {
+				ffmpeg.av_frame_unref(*pThisFrame);
+				ffmpeg.av_frame_free(pThisFrame);
+			}
+			this._frame = null;
+		}
+		this.TexPointer = 0;
 		this.Using = false;
-		Marshal.FreeHGlobal(this.TexPointer);
 	}
 }

--- a/FDK/src/04.Graphics/CFrameConverter.cs
+++ b/FDK/src/04.Graphics/CFrameConverter.cs
@@ -27,25 +27,21 @@ public unsafe class CFrameConverter : IDisposable {
 		ffmpeg.av_image_fill_arrays(ref _dstData, ref _dstLinesize, (byte*)_convertedFrameBufferPtr, CVPxfmt, FrameSize.Width, FrameSize.Height, 1);
 	}
 
-	public AVFrame* Convert(AVFrame* framep) {
-		if (this.IsConvert) {
-			ffmpeg.sws_scale(convert_context, framep->data, framep->linesize, 0, framep->height, _dstData, _dstLinesize);
+	public void Convert(AVFrame* framep) {
+		if (!this.IsConvert)
+			return;
 
-			AVFrame* tmp = ffmpeg.av_frame_alloc();
-			tmp = ffmpeg.av_frame_alloc();
-			tmp->best_effort_timestamp = framep->best_effort_timestamp;
-			tmp->width = FrameSize.Width;
-			tmp->height = FrameSize.Height;
-			tmp->data = new byte_ptrArray8();
-			tmp->data.UpdateFrom(_dstData);
-			tmp->linesize = new int_array8();
-			tmp->linesize.UpdateFrom(_dstLinesize);
+		var timestamp = framep->best_effort_timestamp;
+		ffmpeg.sws_scale(convert_context, framep->data, framep->linesize, 0, framep->height, _dstData, _dstLinesize);
+		ffmpeg.av_frame_unref(framep);
 
-			ffmpeg.av_frame_unref(framep);
-			return tmp;
-		} else {
-			return framep;
-		}
+		framep->best_effort_timestamp = timestamp;
+		framep->width = FrameSize.Width;
+		framep->height = FrameSize.Height;
+		framep->data = new byte_ptrArray8();
+		framep->data.UpdateFrom(_dstData);
+		framep->linesize = new int_array8();
+		framep->linesize.UpdateFrom(_dstLinesize);
 	}
 
 	public void Dispose() {

--- a/FDK/src/04.Graphics/CVideoDecoder.cs
+++ b/FDK/src/04.Graphics/CVideoDecoder.cs
@@ -63,10 +63,9 @@ public unsafe class CVideoDecoder : IDisposable {
 
 			frameconv = new CFrameConverter(FrameSize, codec_context->pix_fmt);
 
-			decodedframes = new ConcurrentQueue<CDecodedFrame>();
-
 			for (int i = 0; i < framelist.Length; i++)
 				framelist[i] = new CDecodedFrame(new Size(codec_context->width, codec_context->height));
+			framelistHead = framelistTail = 0;
 
 			CTimer = new CTimer(CTimer.TimerType.GameTimeAtDraw);
 		}
@@ -98,8 +97,7 @@ public unsafe class CVideoDecoder : IDisposable {
 
 		if (disposing) {
 			bDrawing = false;
-			cts?.Cancel();
-			decodeStopped.Wait();
+			this.StopEnqueuingFrames();
 			frameconv?.Dispose();
 		}
 
@@ -119,9 +117,11 @@ public unsafe class CVideoDecoder : IDisposable {
 		if (disposing) {
 			if (lastTexture != null)
 				lastTexture.Dispose();
-			if (decodedframes != null)
-				while (decodedframes.TryDequeue(out CDecodedFrame frame))
-					frame.Dispose();
+			foreach (var frame in framelist) {
+				frame.Dispose();
+				this.canEnqueueFrame.Set();
+			}
+			framelistHead = framelistTail = 0;
 		}
 	}
 
@@ -168,138 +168,167 @@ public unsafe class CVideoDecoder : IDisposable {
 
 	public void Seek(long timestampms) {
 		this.bStreamEnded = false;
-		cts?.Cancel();
-		decodeStopped.Wait();
+		this.StopEnqueuingFrames();
 		if (ffmpeg.av_seek_frame(format_context, video_stream->index, timestampms, ffmpeg.AVSEEK_FLAG_BACKWARD) < 0)
 			Trace.TraceError("av_seek_frame failed\n");
 		ffmpeg.avcodec_flush_buffers(codec_context);
 		CTimer.NowTimeMs = timestampms;
-		cts?.Dispose();
-		while (decodedframes.TryDequeue(out CDecodedFrame frame))
+		foreach (var frame in framelist) {
 			frame.RemoveFrame();
-		this.EnqueueFrames();
-		if (lastTexture != null)
-			lastTexture.Dispose();
+			this.canEnqueueFrame.Set();
+		}
+		framelistHead = framelistTail = 0;
+		this.EnsureEnqueuingFrames();
+		lastTexture?.Dispose();
 		lastTexture = new CTexture(FrameSize.Width, FrameSize.Height);
 	}
 
 	public void GetNowFrame(ref CTexture Texture) {
-		if (this.bPlaying && decodedframes.Count != 0) {
+		if (this.bPlaying && framelist[framelistHead].Using) {
 			CTimer.Update();
-			if (decodedframes.TryPeek(out CDecodedFrame frame)) {
-				while (frame.Time <= (CTimer.NowTimeMs * _dbPlaySpeed)) {
-					if (decodedframes.TryDequeue(out CDecodedFrame cdecodedframe)) {
-
-						if (decodedframes.Count != 0)
-							if (decodedframes.TryPeek(out frame))
-								if (frame.Time <= (CTimer.NowTimeMs * _dbPlaySpeed)) {
-									cdecodedframe.RemoveFrame();
-									continue;
-								}
-
-						lastTexture.UpdateTexture(cdecodedframe.TexPointer, cdecodedframe.TexSize.Width, cdecodedframe.TexSize.Height, Silk.NET.OpenGLES.PixelFormat.Rgba);
-
-						cdecodedframe.RemoveFrame();
-					}
-					break;
-				}
+			(int idx, CDecodedFrame frame)? nowFrame = null;
+			for ((int idx, CDecodedFrame frame)? next;
+				(next = this.FirstUsedFrame()) != null && next.Value.frame.TexPointer != 0 && next.Value.frame.Time <= this.msPlayPosition;
+				) {
+				if (nowFrame != null)
+					this.RemoveFrameAt(nowFrame.Value.idx);
+				this.PopFrameAt(next.Value.idx);
+				nowFrame = next;
 			}
-
-			if (DS == DecodingState.Stopped)
-				this.EnqueueFrames();
+			if (nowFrame != null) {
+				var frame = nowFrame.Value.frame;
+				lastTexture ??= new CTexture(FrameSize.Width, FrameSize.Height);
+				lastTexture.UpdateTexture(frame.TexPointer, frame.TexSize.Width, frame.TexSize.Height, Silk.NET.OpenGLES.PixelFormat.Rgba);
+				this.RemoveFrameAt(nowFrame.Value.idx);
+			}
+			this.EnsureEnqueuingFrames();
 		}
-
-		if (lastTexture == null)
-			lastTexture = new CTexture(FrameSize.Width, FrameSize.Height);
 
 		if (Texture == lastTexture)
 			return;
 
+		Texture?.Dispose();
 		Texture = lastTexture;
 
 	}
 
-	private void EnqueueFrames() {
-		if (DS != DecodingState.Running && !close) {
+	private void EnsureEnqueuingFrames() {
+		if (decodeStopped.IsSet && !close) {
+			this.StopEnqueuingFrames();
 			cts = new CancellationTokenSource();
 			decodeStopped.Reset();
-			// LongRunning → dedicated thread, not a thread-pool worker. EnqueueOneFrame is a loop that lives
-			// for the whole video (it Thread.Sleep(1)s while the frame queue is full); on the pool it would
+			// LongRunning → dedicated thread, not a thread-pool worker. EnqueueFrames is a loop that lives
+			// for the whole video (it canEnqueueFrame.Wait() while the frame queue is full); on the pool it would
 			// occupy a worker for minutes and make the pool inject/retire extra threads (the "[thread]
 			// exited with code 0" churn seen in-game) and risk starving other pooled work.
-			Task.Factory.StartNew(() => EnqueueOneFrame(), TaskCreationOptions.LongRunning);
+			Task.Factory.StartNew(() => EnqueueFrames(), TaskCreationOptions.LongRunning);
+		}
+	}
+	private void StopEnqueuingFrames() {
+		if (this.cts != null) {
+			this.cts.Cancel();
+			this.decodeStopped.Wait();
+			cts.Dispose();
+			cts = null;
 		}
 	}
 
-	private void EnqueueOneFrame() {
-		DS = DecodingState.Running;
-		AVFrame* frame = ffmpeg.av_frame_alloc();
+	private void EnqueueFrames() {
+		decodeStopped.Reset();
 		AVPacket* packet = ffmpeg.av_packet_alloc();
 		try {
 			while (true) {
-				if (cts.IsCancellationRequested || close)
+				if (cts!.IsCancellationRequested || close)
 					return;
 
-				//2020/10/27 Mr-Ojii 閾値フレームごとにパケット生成するのは無駄だと感じたので、ループに入ったら、パケット生成し、シークによるキャンセルまたは、EOFまで無限ループ
-				if (decodedframes.Count < framelist.Length - 1)//-1をして、余裕を持たせておく。
-				{
-					int error = ffmpeg.av_read_frame(format_context, packet);
-
-					if (error >= 0) {
-						if (packet->stream_index == video_stream->index) {
-							if (ffmpeg.avcodec_send_packet(codec_context, packet) >= 0) {
-								if (ffmpeg.avcodec_receive_frame(codec_context, frame) == 0) {
-									AVFrame* outframe = null;
-
-									outframe = frameconv.Convert(frame);
-
-									decodedframes.Enqueue(PickUnusedDcodedFrame().UpdateFrame((outframe->best_effort_timestamp - video_stream->start_time) * ((double)video_stream->time_base.num / (double)video_stream->time_base.den) * 1000, outframe));
-
-									ffmpeg.av_frame_unref(frame);
-									ffmpeg.av_frame_unref(outframe);
-									ffmpeg.av_frame_free(&outframe);
-								}
-							}
-						}
-
-						//2020/10/27 Mr-Ojii packetが解放されない周回があった問題を修正。
-						ffmpeg.av_packet_unref(packet);
-					} else if (error == ffmpeg.AVERROR_EOF) {
-						this.bStreamEnded = true;
-						return;
-					} else {
+				int error = ffmpeg.av_read_frame(format_context, packet);
+				if (error < 0) {
+					if (error != ffmpeg.AVERROR_EOF) {
 						// Treat any other read error as the end of the stream.
 						Trace.TraceError($"av_read_frame failed ({error}); stopping decode.");
-						this.bStreamEnded = true;
-						return;
 					}
-				} else {
-					//ポーズ中に無限ループに入り、CPU使用率が異常に高くなってしまうため、1ms待つ。
-					//ネットを調べると、await Task.Delay()を使えというお話が出てくるが、unsafeなので、使えない
-					Thread.Sleep(1);
+					this.bStreamEnded = true;
+					return;
+				}
+				try {
+					if (packet->stream_index != video_stream->index || ffmpeg.avcodec_send_packet(codec_context, packet) < 0)
+						continue;
+
+					(int idx, CDecodedFrame frame)? pickedDecodeFrame;
+					while ((pickedDecodeFrame = this.PickUnusedDecodedFrame()) == null) {
+						canEnqueueFrame.Reset();
+						canEnqueueFrame.Wait(cts.Token);
+						if (cts!.IsCancellationRequested || close)
+							return;
+					}
+					var decodeFrame = pickedDecodeFrame.Value;
+					var frame = decodeFrame.frame.GetEmptyFrame();
+					if (ffmpeg.avcodec_receive_frame(codec_context, frame) != 0) {
+						this.UnpickDecodedFrameAt(decodeFrame.idx);
+						continue;
+					}
+					frameconv.Convert(frame);
+
+					double msVideoTime = (frame->best_effort_timestamp - video_stream->start_time) * (video_stream->time_base.num / (double)video_stream->time_base.den) * 1000;
+					if (msVideoTime < this.msPlayPosition) { // evict non-empty outdated frames
+						for ((int idx, CDecodedFrame frame)? f; (f = this.FirstUsedFrame()) != null && f.Value.idx != decodeFrame.idx;)
+							this.RemoveFrameAt(f.Value.idx);
+					}
+					decodeFrame.frame.UpdateFrame(msVideoTime);
+				} finally {
+					//2020/10/27 Mr-Ojii packetが解放されない周回があった問題を修正。
+					ffmpeg.av_packet_unref(packet);
 				}
 			}
+		} catch (OperationCanceledException) {
+			// canceled requested
 		} catch (Exception e) {
 			Trace.TraceError(e.ToString());
 		} finally {
 			ffmpeg.av_packet_free(&packet);
-			ffmpeg.av_frame_unref(frame);
-			ffmpeg.av_free(frame);
-			DS = DecodingState.Stopped;
 			decodeStopped.Set();
 		}
 	}
 
-	public CDecodedFrame PickUnusedDcodedFrame() {
-		for (int i = 0; i < framelist.Length; i++) {
-			if (framelist[i].Using == false) {
-				return framelist[i];
-			}
+	public (int idx, CDecodedFrame frame)? PickUnusedDecodedFrame() {
+		var idx = framelistTail;
+		if (framelist[idx].Using)
+			return null;
+		Interlocked.CompareExchange(ref framelistTail, (idx + 1) % framelist.Length, idx);
+		return (idx, framelist[idx]);
+	}
+
+	public void UnpickDecodedFrameAt(int idx) {
+		framelist[idx].RemoveFrame();
+		int beforeTail = (framelistTail + (framelist.Length - 1)) % framelist.Length;
+		if (idx == beforeTail)
+			Interlocked.CompareExchange(ref framelistTail, beforeTail, idx);
+	}
+
+	private (int idx, CDecodedFrame frame)? FirstUsedFrame() {
+		for (int i = 0; i < framelist.Length; ++i) {
+			int idx = (framelistHead + i) % framelist.Length;
+			var frame = framelist[idx];
+			if (frame.Using)
+				return (idx, framelist[idx]);
+			if (idx == framelistTail)
+				break;
+			this.PopFrameAt(idx);
 		}
 		return null;
 	}
 
-	public double msPlayPosition => CTimer.NowTimeMs * _dbPlaySpeed;
+	private void RemoveFrameAt(int idx) {
+		framelist[idx].RemoveFrame();
+		this.PopFrameAt(idx);
+	}
+
+	private void PopFrameAt(int idx) {
+		Interlocked.CompareExchange(ref framelistHead, (idx + 1) % framelist.Length, idx);
+		this.canEnqueueFrame.Set();
+	}
+
+	public double msPlayPosition => CTimer.NowTimeMs_Double * _dbPlaySpeed;
 
 	public Size FrameSize {
 		get;
@@ -330,16 +359,13 @@ public unsafe class CVideoDecoder : IDisposable {
 	private AVFormatContext* format_context;
 	private AVStream* video_stream;
 	private AVCodecContext* codec_context;
-	private ConcurrentQueue<CDecodedFrame> decodedframes;
-	private CancellationTokenSource cts;
+	private CancellationTokenSource? cts;
 	private CDecodedFrame[] framelist = new CDecodedFrame[6];
-	private DecodingState DS = DecodingState.Stopped;
+	private int framelistHead = 0;
+	private int framelistTail = 0;
 	// Set while the decode thread is stopped; lets Dispose/Seek wait for it without polling.
 	private readonly ManualResetEventSlim decodeStopped = new ManualResetEventSlim(true);
-	private enum DecodingState {
-		Stopped,
-		Running
-	}
+	private readonly ManualResetEventSlim canEnqueueFrame = new ManualResetEventSlim(true);
 
 	//for play
 	public bool bPlaying { get; private set; } = false;
@@ -348,12 +374,16 @@ public unsafe class CVideoDecoder : IDisposable {
 	private bool bStreamEnded = false;
 	// End of playback (stream fully read and all frames shown), unlike msPlayPosition which can stall.
 	public bool IsFinishedPlaying {
-		get => bStreamEnded && decodedframes.IsEmpty;
+		get => bStreamEnded && !framelist[framelistHead].Using;
 		private set {
 			this.bStreamEnded = value;
 			if (value) {
-				while (decodedframes.TryDequeue(out CDecodedFrame frame))
+				this.StopEnqueuingFrames();
+				for (CDecodedFrame frame; (frame = framelist[framelistHead]).Using; framelistHead = (framelistHead + 1) % framelist.Length) {
 					frame.RemoveFrame();
+					this.canEnqueueFrame.Set();
+				}
+				framelistHead = framelistTail = 0;
 			}
 		}
 	}

--- a/OpenTaiko/System/Open-World Memories/Graphics/5_Game/5_Background/Presets.json
+++ b/OpenTaiko/System/Open-World Memories/Graphics/5_Game/5_Background/Presets.json
@@ -91,7 +91,7 @@
 		"AF2026": {
             "UP": [ "3" ],
             "DOWN": [ "A2_af2026" ],
-            "DANCER": [ "0" ],
+            "DANCER": [ ],
             "FOOTER": [ "0" ],
             "MOB": [ "A2_af2026" ],
             "RUNNER": [ "0" ]

--- a/OpenTaiko/src/Common/CConfigIni.cs
+++ b/OpenTaiko/src/Common/CConfigIni.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -213,11 +214,11 @@ internal class CConfigIni : INotifyPropertyChanged {
 	// Properties
 
 	public class CAIPerformances {
-		public int nGoodOdds;
-		public int nPerfectOdds;
-		public int nBadOdds;
-		public int nRollSpeed;
-		public int nMineHitOdds;
+		public readonly int nGoodOdds;
+		public readonly int nPerfectOdds;
+		public readonly int nBadOdds;
+		public readonly int nRollSpeed;
+		public readonly int nMineHitOdds;
 
 		public CAIPerformances(int po, int go, int bo, int rp, int mho = 0) {
 			nGoodOdds = go;
@@ -229,9 +230,9 @@ internal class CConfigIni : INotifyPropertyChanged {
 	}
 
 	public class CTimingZones {
-		public int nGoodZone;
-		public int nOkZone;
-		public int nBadZone;
+		public readonly int nGoodZone;
+		public readonly int nOkZone;
+		public readonly int nBadZone;
 
 		public CTimingZones(int gz, int oz, int bz) {
 			nGoodZone = gz;
@@ -398,7 +399,7 @@ internal class CConfigIni : INotifyPropertyChanged {
 	public int nTouchDrumVisual = 30; // Don radius as percentage of screen width (10-50)
 	public int nTouchDrumOpacity = 15; // touch drum overlay opacity percentage (0-100)
 
-	public CAIPerformances[] apAIPerformances = {
+	public readonly ImmutableArray<CAIPerformances> apAIPerformances = [
 		new CAIPerformances(500, 400, 100, 7, 200),
 		new CAIPerformances(650, 310, 40, 8, 150),
 		new CAIPerformances(750, 225, 25, 9, 100),
@@ -408,18 +409,18 @@ internal class CConfigIni : INotifyPropertyChanged {
 		new CAIPerformances(920, 75, 5, 16, 20),
 		new CAIPerformances(950, 49, 1, 22, 10),
 		new CAIPerformances(975, 25, 0, 26, 5),
-		new CAIPerformances(1000, 0, 0, 30, 0)
-	};
+		new CAIPerformances(1000, 0, 0, 30, 0),
+	];
 
-	public CTimingZones[] tzLevels = {
+	public readonly ImmutableArray<CTimingZones> tzLevels = [
 		new CTimingZones(75, 108, 125), // Lv0 (Easy-Normal + "Loose" mod)
 		new CTimingZones(58, 108, 125), // Lv1 (Easy-Normal + "Lenient" mod)
 		new CTimingZones(42, 108, 125), // Lv2 (Easy-Normal / Tower Ama-kuchi or Hard-Extreme + "Loose" mod)
 		new CTimingZones(42, 75, 108), // Lv3 (Hard-Extreme + "Lenient" timing mod or Easy-Normal + "Strict" mod)
 		new CTimingZones(25, 75, 108), // Lv4 (Hard-Extreme / Tower Ex Kara-kuchi / Dan or Easy-Normal + "Rigorous" mod)
 		new CTimingZones(25, 58, 108), // Lv5 (Hard-Extreme + "Strict" mod (Tatsu))
-		new CTimingZones(17, 42, 108) // Lv6 (Hard-Extreme + "Rigorous" mod)
-	};
+		new CTimingZones(17, 42, 108), // Lv6 (Hard-Extreme + "Rigorous" mod)
+	];
 
 	public bool bJudgeBigNotes;
 	public bool bForceNormalGauge;

--- a/OpenTaiko/src/Components/CVisualLogManager.cs
+++ b/OpenTaiko/src/Components/CVisualLogManager.cs
@@ -49,8 +49,8 @@ class CVisualLogManager {
 		LogCard? firstCard;
 		lock (this.cards) { // concurrent with only Display()
 			firstCard = this.firstCard;
-			if (firstCard?.IsExpired() ?? true) {
-				while (this.cards.TryDequeue(out firstCard) && firstCard.IsExpired())
+			if (firstCard == null || firstCard.IsExpired()) {
+				while (this.cards.TryDequeue(out firstCard) && (firstCard == null || firstCard.IsExpired()))
 					;
 			}
 			this.firstCard = firstCard;

--- a/OpenTaiko/src/Songs/CTja.cs
+++ b/OpenTaiko/src/Songs/CTja.cs
@@ -631,7 +631,7 @@ internal class CTja : CActivity {
 		if (wc.rSound[0] != null && wc.rSound[0].TotalPlayTime >= 5000) {
 			for (int i = 0; i < nPolyphonicSounds; i++) {
 				if ((wc.rSound[i] != null) && (wc.rSound[i].IsPlaying)) {
-					long nCurrentTime = SoundManager.PlayTimer.SystemTimeMs;
+					long nCurrentTime = SoundManager.PlayTimer.SystemTimeMsReal;
 					if (nCurrentTime > wc.nPlaybackStartTime[i]) {
 						long nAbsTimeFromStartPlaying = nCurrentTime - wc.nPlaybackStartTime[i];
 						// nInitialSeekMs: added by the Dan builder when the BGM chip is

--- a/OpenTaiko/src/Stages/01.StartUp/CStageStartup.cs
+++ b/OpenTaiko/src/Stages/01.StartUp/CStageStartup.cs
@@ -106,7 +106,7 @@ internal class CStageStartup : CStage {
 					OpenTaiko.NamePlate.RefreshSkin();
 					OpenTaiko.ModalManager.RefreshSkin();
 					es = new CEnumSongs();
-					es.StartEnumFromCache();   // 曲リスト取得(別スレッドで実行される)
+					es.StartLoadSystemSound();
 				}
 			}
 			#endregion
@@ -184,13 +184,10 @@ internal class CStageStartup : CStage {
 				}
 				//-----------------
 				#endregion
-			} else {
-				if (es != null && es.IsSongListEnumCompletelyDone)                          // 曲リスト作成が終わったら
-				{
-					OpenTaiko.SongManager = (es != null) ? es.SongManager : null;      // 最後に、曲リストを拾い上げる
-
-					return 1;
-				}
+			} else if (es != null && es.IsSongListEnumCompletelyDone) {                     // System sound loaded
+				es.Abort(); // reset for further enumerating
+				ePhaseID = EPhase.Startup_Complete;
+				return 1;
 			}
 
 		}

--- a/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
+++ b/OpenTaiko/src/Stages/02.Title/CEnumSongs.cs
@@ -91,12 +91,9 @@ internal partial class CEnumSongs                   // #27060 2011.2.7 yyagi 曲
 
 	}
 
-	/// <summary>
-	/// 曲リストのキャッシュ(songlist.db)取得スレッドの開始
-	/// </summary>
-	public void StartEnumFromCache() {
-		this.thDTXFileEnumerate = new Thread(new ThreadStart(this.EstablishSystemSounds));
-		this.thDTXFileEnumerate.Name = "曲リストの構築";
+	public void StartLoadSystemSound() {
+		this.thDTXFileEnumerate = new Thread(new ThreadStart(this.LoadSystemSound));
+		this.thDTXFileEnumerate.Name = "LoadSystemSound";
 		this.thDTXFileEnumerate.IsBackground = true;
 		this.thDTXFileEnumerate.Start();
 	}
@@ -209,10 +206,7 @@ internal partial class CEnumSongs                   // #27060 2011.2.7 yyagi 曲
 
 
 
-	/// <summary>
-	/// songlist.dbからの曲リスト構築
-	/// </summary>
-	public void EstablishSystemSounds() {
+	public void LoadSystemSound() {
 		// ！注意！
 		// 本メソッドは別スレッドで動作するが、プラグイン側でカレントディレクトリを変更しても大丈夫なように、
 		// すべてのファイルアクセスは「絶対パス」で行うこと。(2010.9.16)

--- a/OpenTaiko/src/Stages/07.Game/CStagePlayScreenCommon.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStagePlayScreenCommon.cs
@@ -2377,7 +2377,7 @@ internal abstract class CStagePlayScreenCommon : CStage {
 	private long msLastBgmDriftCheck = 0;
 	private int nBgmDriftStrikes = 0;
 	private const long msBgmDriftCheckInterval = 500;
-	private const long msBgmDriftThreshold = 100;
+	private readonly long msBgmDriftThreshold = OpenTaiko.ConfigIni.tzLevels.Last().nGoodZone;
 
 	protected void tCheckBgmDrift() {
 		if (this.bPAUSE || this.isRewinding || this.IsFailStopped()) {
@@ -2393,7 +2393,7 @@ internal abstract class CStagePlayScreenCommon : CStage {
 				return;
 			}
 		}
-		long now = SoundManager.PlayTimer.SystemTimeMs;
+		long now = SoundManager.PlayTimer.SystemTimeMsReal;
 		if (now - this.msLastBgmDriftCheck < msBgmDriftCheckInterval) return;
 		this.msLastBgmDriftCheck = now;
 

--- a/OpenTaiko/src/Stages/07.Game/CStagePlayScreenCommon.cs
+++ b/OpenTaiko/src/Stages/07.Game/CStagePlayScreenCommon.cs
@@ -1096,7 +1096,7 @@ internal abstract class CStagePlayScreenCommon : CStage {
 
 	protected long msAutoInputTime = 0;
 	protected long msAutoInputSkipKeyPollTime = 0;
-	protected void TrackMsAutoInputTime() => msAutoInputSkipKeyPollTime = msAutoInputTime = SoundManager.PlayTimer.NowTimeMs;
+	protected void TrackMsAutoInputTime() => msAutoInputSkipKeyPollTime = msAutoInputTime = SoundManager.PlayTimer.RealNowTimeMs;
 	protected bool WithinInputFrame(bool forceSkip = false) {
 		const int msWithinMax = 2;
 		long msGameTime = SoundManager.PlayTimer.RealNowTimeMs;


### PR DESCRIPTION
* [Fix] Dancer presented in scene preset AF2026
* [Fix] Null exception crash when displaying chart warnings during song enumeration
* [Perf] Optimize video decoding: remove copying of converted frame, remove extra allocation for converting frame, use the frame queue buffer directly
* [Fix] StartUp stage had always been mistreating system sound done loading as song list done enumerating
* [Fix] Inaccurate autohit lag/freeze detection caused insufficient hits
* ensure `CAIPerformances` and `CTimingZones` are immutable by the code
* [Enhance] Make music position correction more accurate and precise
* [Enhance] Make input timer correction more accurate and precise