### PR TITLE
Reduce the size of the cloned repo by ~3.4GB without loss of songs

### DIFF
--- a/special/linux_installer_standalone.bash
+++ b/special/linux_installer_standalone.bash
@@ -80,7 +80,7 @@ cd "publish" || exit 1
 cached_soundtrack="$cache_dir/OpenTaiko-Soundtrack"
 if [ -d "$cached_soundtrack" ]; then
     echo "Updating cached soundtrack repository..."
-    cd "$cached_soundtrack" && git pull && cd - || exit 1
+    cd "$cached_soundtrack" && git fetch --depth 1 origin HEAD && git reset --hard FETCH_HEAD && cd - || exit 1
 else
     echo "Cloning soundtrack repository to cache..."
     git clone --depth 1 https://github.com/OpenTaiko/OpenTaiko-Soundtrack "$cached_soundtrack"
@@ -148,7 +148,7 @@ if pgrep -x "OpenTaiko" > /dev/null; then
 fi
 
 echo "Updating OpenTaiko repositories..."
-cd "$cache_dir/OpenTaiko-Soundtrack" && git pull
+cd "$cache_dir/OpenTaiko-Soundtrack" && git fetch --depth 1 origin HEAD && git reset --hard FETCH_HEAD
 cp -rf "$cache_dir/OpenTaiko-Soundtrack/"* "$installation_folder/publish/Songs/"
 cd "$cache_dir/OpenTaiko-Skins" && git pull
 cp -rf "$cache_dir/OpenTaiko-Skins/"* "$installation_folder/publish/"

--- a/special/linux_installer_standalone.bash
+++ b/special/linux_installer_standalone.bash
@@ -63,7 +63,7 @@ else
     download_url="https://github.com/$git_repo/releases/download/$version/$archive_filename"
     echo "Downloading from: $download_url"
     curl -L -o "$archive_filename" "$download_url" || { echo "Download failed."; exit 1; }
-    
+
     # Cache the download
     echo "Caching download for future use..."
     cp "$archive_filename" "$cached_file"
@@ -83,7 +83,7 @@ if [ -d "$cached_soundtrack" ]; then
     cd "$cached_soundtrack" && git pull && cd - || exit 1
 else
     echo "Cloning soundtrack repository to cache..."
-    git clone https://github.com/OpenTaiko/OpenTaiko-Soundtrack "$cached_soundtrack"
+    git clone --depth 1 https://github.com/OpenTaiko/OpenTaiko-Soundtrack "$cached_soundtrack"
 fi
 
 # Merge soundtrack into publish/Songs


### PR DESCRIPTION
Cloning the soundtrack repo without `--depth 1` will clone ~3.4GB of repo history into the `.git` directory of `cache/OpenTaiko-Soundtrack`. This is data which can be safely excluded, reducing download time and space usage.

See the disk usage difference below.
```
[main][~/Applications]$ du -sh cache/OpenTaiko-Soundtrack 
8.0G	cache/OpenTaiko-Soundtrack                                                                                                      /0.1s
[29ms][main][~/Applications]$ du -sh cache/OpenTaiko-Soundtrack --exclude cache/OpenTaiko-Soundtrack/.git
4.6G	cache/OpenTaiko-Soundtrack
```